### PR TITLE
WebContainer logs and console output in UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@webcontainer/api": "^1.6.1",
+        "ansi-to-react": "^6.2.6",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "effect": "^3.19.15",
@@ -4929,6 +4930,12 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/anser": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-2.3.5.tgz",
+      "integrity": "sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==",
+      "license": "MIT"
+    },
     "node_modules/ansi-escapes": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
@@ -4969,6 +4976,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansi-to-react": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/ansi-to-react/-/ansi-to-react-6.2.6.tgz",
+      "integrity": "sha512-Eqi0iaMK5OZ3jsVFxWvU2B74UZBnGuHlkflKMX6wTOeH+luy9KE2O0gUkc2PxhIP1R4IO0xohv62UMFInQOSeg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "anser": "^2.3.2",
+        "escape-carriage": "^1.3.1",
+        "linkify-it": "^3.0.3"
+      },
+      "peerDependencies": {
+        "react": "^16.3.2 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.3.2 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/argparse": {
@@ -6345,6 +6367,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-carriage": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/escape-carriage/-/escape-carriage-1.3.1.tgz",
+      "integrity": "sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -8626,6 +8654,15 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
     },
     "node_modules/lint-staged": {
       "version": "16.2.7",
@@ -11207,6 +11244,12 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@webcontainer/api": "^1.6.1",
+    "ansi-to-react": "^6.2.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "effect": "^3.19.15",

--- a/src/components/editor/WebContainerLogsPanel.tsx
+++ b/src/components/editor/WebContainerLogsPanel.tsx
@@ -1,8 +1,9 @@
 import AnsiModule from "ansi-to-react";
 import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
-import { useRef, useEffect } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import type { ComponentType } from "react";
 
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { useWebContainerLogsStore } from "@/stores/webContainerLogsStore";
 
@@ -21,106 +22,216 @@ export function WebContainerLogsPanel({
   expanded = true,
   onToggle,
 }: WebContainerLogsPanelProps) {
-  const { logs, clear } = useWebContainerLogsStore();
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const { logs, clearLogs, clearErrors } = useWebContainerLogsStore();
+  const [activeTab, setActiveTab] = useState<"logs" | "errors">("logs");
+  const logsScrollRef = useRef<HTMLDivElement>(null);
+  const errorsScrollRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (scrollRef.current && expanded) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-    }
+  const logEntries = logs.filter((e) => e.label !== "error");
+  const errorEntries = logs.filter((e) => e.label === "error");
+  const hasLogs = logEntries.length > 0;
+  const hasErrors = errorEntries.length > 0;
+
+  const handleClear = () => {
+    if (activeTab === "logs") clearLogs();
+    else clearErrors();
+  };
+
+  const canClear = activeTab === "logs" ? hasLogs : hasErrors;
+
+  const scrollToBottom = (el: HTMLDivElement | null) => {
+    if (el) el.scrollTop = el.scrollHeight;
+  };
+
+  useLayoutEffect(() => {
+    if (!expanded) return;
+    scrollToBottom(logsScrollRef.current);
+    scrollToBottom(errorsScrollRef.current);
   }, [logs, expanded]);
+
+  useLayoutEffect(() => {
+    if (!expanded) return;
+    const ref = activeTab === "logs" ? logsScrollRef : errorsScrollRef;
+    scrollToBottom(ref.current);
+  }, [activeTab, expanded]);
 
   return (
     <div
       className={cn(
-        "flex shrink-0 flex-col border-t border-border bg-muted/30",
-        !expanded && "min-h-0",
+        "flex min-h-0 flex-1 flex-col border-t border-border bg-muted/30",
+        expanded && "h-full overflow-hidden",
+        !expanded && "min-h-0 flex-none",
       )}
     >
-      <div
-        className={cn(
-          "flex shrink-0 items-center justify-between border-b border-border",
-          "bg-muted/50 px-3 py-1.5",
-        )}
-      >
-        <button
-          type="button"
-          onClick={onToggle}
-          className={cn(
-            "flex cursor-pointer items-center gap-1.5 text-xs font-medium",
-            `
-              text-muted-foreground transition-colors
-              hover:text-foreground
-            `,
-          )}
+      {expanded ? (
+        <Tabs
+          value={activeTab}
+          onValueChange={(v) => setActiveTab(v as "logs" | "errors")}
+          className="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
         >
-          Console
-          {expanded ? (
-            <ChevronDownIcon className="size-3.5" aria-hidden />
-          ) : (
-            <ChevronUpIcon className="size-3.5" aria-hidden />
-          )}
-        </button>
-        {expanded && logs.length > 0 && (
-          <button
-            type="button"
-            onClick={clear}
+          <div
             className={cn(
-              "text-xs text-muted-foreground underline-offset-2",
-              "hover:text-foreground hover:underline",
+              `
+                flex shrink-0 items-center justify-between gap-2 border-b
+                border-border
+              `,
+              "bg-muted/50 px-3 py-1.5",
             )}
           >
-            Clear
-          </button>
-        )}
-      </div>
-      {expanded && (
-        <div
-          ref={scrollRef}
-          className={cn(
-            "h-48 min-h-0 overflow-x-auto overflow-y-auto p-2",
-            "font-mono text-xs",
-          )}
-        >
-          {logs.length === 0 ? (
-            <p className="text-muted-foreground">No logs yet.</p>
-          ) : (
-            <div className="flex flex-col gap-0.5">
-              {logs.map((entry, i) =>
-                entry.label === "output" || entry.label === "error" ? (
-                  <div
-                    key={`${entry.timestamp ?? i}-${i}`}
-                    className={cn(
-                      "px-2 py-0.5 break-all",
-                      entry.label === "output" && "bg-muted/30",
-                      entry.label === "error" && "bg-destructive/15",
-                    )}
-                  >
-                    <Ansi>{entry.message}</Ansi>
-                  </div>
-                ) : (
-                  <div
-                    key={`${entry.timestamp ?? i}-${i}`}
-                    className="flex gap-2 break-all"
-                  >
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              <button
+                type="button"
+                onClick={onToggle}
+                className={cn(
+                  `
+                    flex shrink-0 cursor-pointer items-center gap-1.5 text-xs
+                    font-medium
+                  `,
+                  `
+                    text-muted-foreground transition-colors
+                    hover:text-foreground
+                  `,
+                )}
+              >
+                Console
+                <ChevronDownIcon className="size-3.5" aria-hidden />
+              </button>
+              <TabsList variant="line" className="h-7 gap-1">
+                <TabsTrigger value="logs" className="px-2 text-xs">
+                  Logs
+                </TabsTrigger>
+                <TabsTrigger value="errors" className="px-2 text-xs">
+                  Errors
+                  {hasErrors && (
                     <span
-                      className={cn(
-                        "shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium",
-                        entry.label === "boot" && "bg-primary/20 text-primary",
-                        entry.label === "npm" &&
-                          "bg-amber-500/20 text-amber-700",
-                      )}
+                      className={`
+                        ml-1 rounded bg-destructive/20 px-1 text-[10px]
+                      `}
                     >
-                      {entry.label}
+                      {errorEntries.length}
                     </span>
-                    <span className="text-muted-foreground">
-                      {entry.message}
-                    </span>
-                  </div>
-                ),
+                  )}
+                </TabsTrigger>
+              </TabsList>
+            </div>
+            {canClear && (
+              <button
+                type="button"
+                onClick={handleClear}
+                className={cn(
+                  "shrink-0 text-xs text-muted-foreground underline-offset-2",
+                  "hover:text-foreground hover:underline",
+                )}
+              >
+                Clear
+              </button>
+            )}
+          </div>
+          <TabsContent
+            value="logs"
+            className={`
+              mt-0 flex h-0 min-h-0 flex-1 flex-col overflow-hidden outline-none
+            `}
+          >
+            <div
+              ref={logsScrollRef}
+              className={cn(
+                "min-h-0 flex-1 overflow-x-auto overflow-y-auto p-2 pb-10",
+                "font-mono text-xs",
+              )}
+            >
+              {logEntries.length === 0 ? (
+                <p className="text-muted-foreground">No logs yet.</p>
+              ) : (
+                <div className="flex flex-col gap-0.5">
+                  {logEntries.map((entry, i) =>
+                    entry.label === "output" ? (
+                      <div
+                        key={`${entry.timestamp ?? i}-${i}`}
+                        className="bg-muted/30 px-2 py-0.5 break-all"
+                      >
+                        <Ansi>{entry.message}</Ansi>
+                      </div>
+                    ) : (
+                      <div
+                        key={`${entry.timestamp ?? i}-${i}`}
+                        className="flex gap-2 break-all"
+                      >
+                        <span
+                          className={cn(
+                            `
+                              shrink-0 rounded px-1.5 py-0.5 text-[10px]
+                              font-medium
+                            `,
+                            entry.label === "boot" &&
+                              "bg-primary/20 text-primary",
+                            entry.label === "npm" &&
+                              "bg-amber-500/20 text-amber-700",
+                          )}
+                        >
+                          {entry.label}
+                        </span>
+                        <span className="text-muted-foreground">
+                          {entry.message}
+                        </span>
+                      </div>
+                    ),
+                  )}
+                </div>
               )}
             </div>
+          </TabsContent>
+          <TabsContent
+            value="errors"
+            className={`
+              mt-0 flex h-0 min-h-0 flex-1 flex-col overflow-hidden outline-none
+            `}
+          >
+            <div
+              ref={errorsScrollRef}
+              className={cn(
+                "min-h-0 flex-1 overflow-x-auto overflow-y-auto p-2 pb-10",
+                "font-mono text-xs",
+              )}
+            >
+              {errorEntries.length === 0 ? (
+                <p className="text-muted-foreground">No errors.</p>
+              ) : (
+                <div className="flex flex-col gap-0.5">
+                  {errorEntries.map((entry, i) => (
+                    <div
+                      key={`${entry.timestamp ?? i}-${i}`}
+                      className="bg-destructive/15 px-2 py-0.5 break-all"
+                    >
+                      <Ansi>{entry.message}</Ansi>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </TabsContent>
+        </Tabs>
+      ) : (
+        <div
+          className={cn(
+            "flex shrink-0 items-center justify-between border-b border-border",
+            "bg-muted/50 px-3 py-1.5",
           )}
+        >
+          <button
+            type="button"
+            onClick={onToggle}
+            className={cn(
+              "flex cursor-pointer items-center gap-1.5 text-xs font-medium",
+              `
+                text-muted-foreground transition-colors
+                hover:text-foreground
+              `,
+            )}
+          >
+            Console
+            <ChevronUpIcon className="size-3.5" aria-hidden />
+          </button>
         </div>
       )}
     </div>

--- a/src/components/editor/WebContainerLogsPanel.tsx
+++ b/src/components/editor/WebContainerLogsPanel.tsx
@@ -150,7 +150,7 @@ export function WebContainerLogsPanel({
             <div
               ref={logsScrollRef}
               className={cn(
-                "min-h-0 flex-1 overflow-x-auto overflow-y-auto p-2 pb-10",
+                "min-h-0 flex-1 overflow-x-auto overflow-y-auto p-2",
                 "font-mono text-xs",
               )}
             >
@@ -206,7 +206,7 @@ export function WebContainerLogsPanel({
               <div
                 ref={errorsScrollRef}
                 className={cn(
-                  "min-h-0 flex-1 overflow-x-auto overflow-y-auto p-2 pb-10",
+                  "min-h-0 flex-1 overflow-x-auto overflow-y-auto p-2",
                   "font-mono text-xs",
                 )}
               >

--- a/src/components/editor/WebContainerLogsPanel.tsx
+++ b/src/components/editor/WebContainerLogsPanel.tsx
@@ -1,8 +1,16 @@
+import AnsiModule from "ansi-to-react";
 import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import { useRef, useEffect } from "react";
+import type { ComponentType } from "react";
 
 import { cn } from "@/lib/utils";
 import { useWebContainerLogsStore } from "@/stores/webContainerLogsStore";
+
+// ansi-to-react is CJS; Vite/ESM may give us { default: Component } instead of
+// the component. React expects a function/class, not an object — extract default.
+const Ansi =
+  (AnsiModule as { default?: ComponentType<{ children?: string }> }).default ??
+  AnsiModule;
 
 interface WebContainerLogsPanelProps {
   expanded?: boolean;
@@ -46,7 +54,7 @@ export function WebContainerLogsPanel({
             `,
           )}
         >
-          WebContainer
+          Console
           {expanded ? (
             <ChevronDownIcon className="size-3.5" aria-hidden />
           ) : (
@@ -78,23 +86,39 @@ export function WebContainerLogsPanel({
             <p className="text-muted-foreground">No logs yet.</p>
           ) : (
             <div className="flex flex-col gap-0.5">
-              {logs.map((entry, i) => (
-                <div
-                  key={`${entry.timestamp ?? i}-${i}`}
-                  className="flex gap-2 break-all"
-                >
-                  <span
+              {logs.map((entry, i) =>
+                entry.label === "output" || entry.label === "error" ? (
+                  <div
+                    key={`${entry.timestamp ?? i}-${i}`}
                     className={cn(
-                      "shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium",
-                      entry.label === "boot" && "bg-primary/20 text-primary",
-                      entry.label === "npm" && "bg-amber-500/20 text-amber-700",
+                      "px-2 py-0.5 break-all",
+                      entry.label === "output" && "bg-muted/30",
+                      entry.label === "error" && "bg-destructive/15",
                     )}
                   >
-                    {entry.label}
-                  </span>
-                  <span className="text-muted-foreground">{entry.message}</span>
-                </div>
-              ))}
+                    <Ansi>{entry.message}</Ansi>
+                  </div>
+                ) : (
+                  <div
+                    key={`${entry.timestamp ?? i}-${i}`}
+                    className="flex gap-2 break-all"
+                  >
+                    <span
+                      className={cn(
+                        "shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium",
+                        entry.label === "boot" && "bg-primary/20 text-primary",
+                        entry.label === "npm" &&
+                          "bg-amber-500/20 text-amber-700",
+                      )}
+                    >
+                      {entry.label}
+                    </span>
+                    <span className="text-muted-foreground">
+                      {entry.message}
+                    </span>
+                  </div>
+                ),
+              )}
             </div>
           )}
         </div>

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { RotateCcw } from "lucide-react";
+import { GripHorizontal, RotateCcw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { MultiModelEditor } from "@/components/editor/MultiModelEditor";
@@ -264,7 +264,20 @@ export function MainLayout() {
                     />
                   </div>
                 </ResizablePanel>
-                <ResizableHandle withHandle />
+                <ResizableHandle className="h-auto w-full">
+                  <div
+                    className={cn(
+                      "flex h-4 cursor-row-resize items-center justify-center",
+                      "border-y border-border bg-muted/20",
+                    )}
+                    aria-hidden
+                  >
+                    <GripHorizontal
+                      className="size-3.5 text-muted-foreground/50"
+                      aria-hidden
+                    />
+                  </div>
+                </ResizableHandle>
                 <ResizablePanel defaultSize={25} minSize={10}>
                   <WebContainerLogsPanel
                     expanded={showLogsPanel}
@@ -339,7 +352,20 @@ export function MainLayout() {
                   className="flex h-full min-w-0 flex-col"
                 />
               </ResizablePanel>
-              <ResizableHandle withHandle />
+              <ResizableHandle className="h-auto w-full">
+                <div
+                  className={cn(
+                    "flex h-4 cursor-row-resize items-center justify-center",
+                    "border-y border-border bg-muted/20",
+                  )}
+                  aria-hidden
+                >
+                  <GripHorizontal
+                    className="size-3.5 text-muted-foreground/50"
+                    aria-hidden
+                  />
+                </div>
+              </ResizableHandle>
               <ResizablePanel defaultSize={25} minSize={10}>
                 <WebContainerLogsPanel
                   expanded={showLogsPanel}

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -249,8 +249,31 @@ export function MainLayout() {
       >
         <ResizablePanelGroup orientation="horizontal" className="h-full">
           <ResizablePanel defaultSize={40} minSize={25}>
-            <div className="flex h-full min-w-0 flex-col">
-              <div className="min-h-0 flex-1">
+            {showLogsPanel ? (
+              <ResizablePanelGroup orientation="vertical" className="h-full">
+                <ResizablePanel defaultSize={75} minSize={30}>
+                  <div className="flex h-full min-w-0 flex-col">
+                    <MultiModelEditor
+                      tabs={editorTabs}
+                      value={editorTabId}
+                      onValueChange={setEditorTabId}
+                      onProgramContentChange={handleProgramContentChange}
+                      typesReady={webContainer.typesReady}
+                      headerExtra={programSelectorHeader}
+                      className="flex h-full min-w-0 flex-col"
+                    />
+                  </div>
+                </ResizablePanel>
+                <ResizableHandle withHandle />
+                <ResizablePanel defaultSize={25} minSize={10}>
+                  <WebContainerLogsPanel
+                    expanded={showLogsPanel}
+                    onToggle={() => setShowLogsPanel((v) => !v)}
+                  />
+                </ResizablePanel>
+              </ResizablePanelGroup>
+            ) : (
+              <div className="flex h-full min-w-0 flex-col">
                 <MultiModelEditor
                   tabs={editorTabs}
                   value={editorTabId}
@@ -260,12 +283,12 @@ export function MainLayout() {
                   headerExtra={programSelectorHeader}
                   className="flex h-full min-w-0 flex-col"
                 />
+                <WebContainerLogsPanel
+                  expanded={showLogsPanel}
+                  onToggle={() => setShowLogsPanel((v) => !v)}
+                />
               </div>
-              <WebContainerLogsPanel
-                expanded={showLogsPanel}
-                onToggle={() => setShowLogsPanel((v) => !v)}
-              />
-            </div>
+            )}
           </ResizablePanel>
 
           <ResizableHandle withHandle />
@@ -298,21 +321,49 @@ export function MainLayout() {
       >
         {/* Editor - always full width */}
         <div className="flex h-full min-w-0 flex-col">
-          <div className="min-h-0 flex-1">
-            <MultiModelEditor
-              tabs={editorTabs}
-              value={editorTabId}
-              onValueChange={setEditorTabId}
-              onProgramContentChange={handleProgramContentChange}
-              typesReady={webContainer.typesReady}
-              headerExtra={programSelectorHeader}
-              className="flex h-full min-w-0 flex-col"
-            />
-          </div>
-          <WebContainerLogsPanel
-            expanded={showLogsPanel}
-            onToggle={() => setShowLogsPanel((v) => !v)}
-          />
+          {showLogsPanel ? (
+            <ResizablePanelGroup
+              orientation="vertical"
+              className="min-h-0 flex-1"
+            >
+              <ResizablePanel defaultSize={75} minSize={30}>
+                <MultiModelEditor
+                  tabs={editorTabs}
+                  value={editorTabId}
+                  onValueChange={setEditorTabId}
+                  onProgramContentChange={handleProgramContentChange}
+                  typesReady={webContainer.typesReady}
+                  headerExtra={programSelectorHeader}
+                  className="flex h-full min-w-0 flex-col"
+                />
+              </ResizablePanel>
+              <ResizableHandle withHandle />
+              <ResizablePanel defaultSize={25} minSize={10}>
+                <WebContainerLogsPanel
+                  expanded={showLogsPanel}
+                  onToggle={() => setShowLogsPanel((v) => !v)}
+                />
+              </ResizablePanel>
+            </ResizablePanelGroup>
+          ) : (
+            <>
+              <div className="min-h-0 flex-1">
+                <MultiModelEditor
+                  tabs={editorTabs}
+                  value={editorTabId}
+                  onValueChange={setEditorTabId}
+                  onProgramContentChange={handleProgramContentChange}
+                  typesReady={webContainer.typesReady}
+                  headerExtra={programSelectorHeader}
+                  className="flex h-full min-w-0 flex-col"
+                />
+              </div>
+              <WebContainerLogsPanel
+                expanded={showLogsPanel}
+                onToggle={() => setShowLogsPanel((v) => !v)}
+              />
+            </>
+          )}
         </div>
 
         {/* Visualizer - slides in from right */}

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -269,6 +269,7 @@ export function MainLayout() {
                   <WebContainerLogsPanel
                     expanded={showLogsPanel}
                     onToggle={() => setShowLogsPanel((v) => !v)}
+                    webContainerMode={canSupportWebContainer}
                   />
                 </ResizablePanel>
               </ResizablePanelGroup>
@@ -286,6 +287,7 @@ export function MainLayout() {
                 <WebContainerLogsPanel
                   expanded={showLogsPanel}
                   onToggle={() => setShowLogsPanel((v) => !v)}
+                  webContainerMode={canSupportWebContainer}
                 />
               </div>
             )}
@@ -342,6 +344,7 @@ export function MainLayout() {
                 <WebContainerLogsPanel
                   expanded={showLogsPanel}
                   onToggle={() => setShowLogsPanel((v) => !v)}
+                  webContainerMode={canSupportWebContainer}
                 />
               </ResizablePanel>
             </ResizablePanelGroup>
@@ -361,6 +364,7 @@ export function MainLayout() {
               <WebContainerLogsPanel
                 expanded={showLogsPanel}
                 onToggle={() => setShowLogsPanel((v) => !v)}
+                webContainerMode={canSupportWebContainer}
               />
             </>
           )}

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -57,6 +57,14 @@ function ResizableHandle({
           data-[panel-group-direction=vertical]:after:-translate-y-1/2
           [&[data-panel-group-direction=vertical]>div]:rotate-90
         `,
+        `
+          data-[separator=active]:ring-1 data-[separator=active]:ring-ring
+          data-[separator=hover]:ring-1 data-[separator=hover]:ring-ring
+          data-[separator=inactive]:ring-0
+          data-[separator=inactive]:focus-visible:ring-0
+          data-[separator=inactive]:focus-visible:ring-offset-0
+          data-[separator=inactive]:focus-visible:outline-none
+        `,
         className,
       )}
       {...props}

--- a/src/effects/spawnAndParse.ts
+++ b/src/effects/spawnAndParse.ts
@@ -65,9 +65,11 @@ export interface SpawnAndParseCallbacks {
 export function spawnAndParseTraceEvents({
   callbacks,
   onFirstChunk,
+  onStdout,
 }: {
   callbacks: SpawnAndParseCallbacks;
   onFirstChunk: () => void;
+  onStdout?: (line: string) => void;
 }) {
   return Effect.gen(function* () {
     const wc = yield* WebContainer;
@@ -132,9 +134,9 @@ export function spawnAndParseTraceEvents({
             })
           : line.startsWith(TRACE_EVENT_PREFIX) || line.trim() === ""
             ? Effect.void
-            : Effect.sync(() =>
-                console.warn("[spawnAndParse] container output:", line),
-              ),
+            : Effect.sync(() => {
+                onStdout?.(line);
+              }),
       ),
       Stream.filterMap((line) => Option.fromNullable(parseTraceEvent(line))),
     );

--- a/src/stores/webContainerLogsStore.tsx
+++ b/src/stores/webContainerLogsStore.tsx
@@ -19,6 +19,10 @@ interface WebContainerLogsStore {
   addLog: (label: string, message: string) => void;
   /** Clear all logs */
   clear: () => void;
+  /** Clear logs only (keeps errors) */
+  clearLogs: () => void;
+  /** Clear errors only */
+  clearErrors: () => void;
 }
 
 const WebContainerLogsStoreContext =
@@ -41,13 +45,23 @@ export function WebContainerLogsStoreProvider({
     setLogs([]);
   }, []);
 
+  const clearLogs = useCallback(() => {
+    setLogs((prev) => prev.filter((e) => e.label === "error"));
+  }, []);
+
+  const clearErrors = useCallback(() => {
+    setLogs((prev) => prev.filter((e) => e.label !== "error"));
+  }, []);
+
   const store = useMemo(
     () => ({
       logs,
       addLog,
       clear,
+      clearLogs,
+      clearErrors,
     }),
-    [logs, addLog, clear],
+    [logs, addLog, clear, clearLogs, clearErrors],
   );
 
   return (

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,6 +71,9 @@ export default defineConfig({
     },
     allowedHosts: [".ngrok-free.app"],
   },
+  optimizeDeps: {
+    include: ["ansi-to-react"],
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary

Exposes WebContainer stdout (`console.log`, etc.) and transpile errors in the in-app console panel, adds a resizable split between editor and console, and fixes layout/scroll behavior.

## Changes

### Console / logs panel

- **Stdout and transpile errors in UI**: Container stdout (`console.log`, `console.error`) is now sent to the panel via a new `onStdout` callback in `spawnAndParseTraceEvents`. Transpile errors are surfaced via `addLog("error", msg)` instead of only `console.error`.
- **ANSI support**: Uses `ansi-to-react` to render ANSI escape codes in logs and errors (no `dangerouslySetInnerHTML`).
- **Tabs (WebContainer mode only)**: Logs vs Errors tabs with a badge for error count; separate "Clear" per tab.
- **Simplified fallback mode**: When WebContainer is unavailable (e.g. iOS/Safari), the panel shows a single "Logs" view without tabs.
- **Scroll fixes**: Adjusted flex layout so tabs stay visible and log content scrolls inside its container; auto-scroll to bottom works correctly.

### Layout / resizing

- **Resizable editor/console split**: When the console is expanded, editor and console are in a vertical `ResizablePanelGroup` with a draggable handle (GripHorizontal icon).
- **Handle styling**: Uses `data-separator` for ring on active/hover and hides it when inactive.
- **Behavior in both layouts**: Resizable split works in desktop (horizontal panels) and mobile (vertical stack) layouts.

### Technical

- New dependency: `ansi-to-react`.
- Vite: `ansi-to-react` added to `optimizeDeps.include` for CJS/ESM interop.

## Files changed


| File                                              | Purpose                                                    |
| ------------------------------------------------- | ---------------------------------------------------------- |
| `src/components/editor/WebContainerLogsPanel.tsx` | Tabs, ANSI output, scroll, fallback mode                   |
| `src/components/layout/MainLayout.tsx`            | Resizable editor/console split, `webContainerMode` prop    |
| `src/components/ui/resizable.tsx`                 | `data-separator` styles for handle ring                    |
| `src/effects/spawnAndParse.ts`                    | `onStdout` callback for non-trace container output         |
| `src/hooks/useWebContainerBoot.ts`                | Wire `onStdout` and `addLog("error")` for transpile errors |
| `src/stores/webContainerLogsStore.tsx`            | `clearLogs` / `clearErrors` split                          |
| `vite.config.ts`                                  | `optimizeDeps.include` for ansi-to-react                   |
| `package.json`                                    | Add ansi-to-react                                          |


## Testing notes

- WebContainer mode: Run a program with `console.log` and verify output in Logs tab; introduce a transpile error and verify it appears in Errors tab.
- Fallback mode: Test on iOS Safari or disable WebContainer; confirm "Logs" view (no tabs) works.
- Resize: Confirm the editor/console handle is draggable and sizing behaves correctly.