### PR TITLE
rootEffect + requirements contract

### DIFF
--- a/src/effects/spawnAndParse.ts
+++ b/src/effects/spawnAndParse.ts
@@ -1,6 +1,7 @@
 /**
- * Effect that spawns `node --enable-source-maps program.js` in the WebContainer and parses
- * TRACE_EVENT: lines from stdout, pushing to addEvent and processEvent.
+ * Effect that spawns `node --enable-source-maps runner.js` in the WebContainer and parses
+ * TRACE_EVENT: lines from stdout. The runner imports program.js (rootEffect, requirements)
+ * and injects the trace layer before running.
  */
 import { Duration, Effect, Option, Ref, Stream } from "effect";
 
@@ -83,7 +84,7 @@ export function spawnAndParseTraceEvents({
       ...(isPerfPlayEnabled() && { env: { PERF_PLAY: "1" } }),
     };
     const proc = yield* Effect.acquireRelease(
-      wc.spawn("node", ["--enable-source-maps", "program.js"], spawnOptions),
+      wc.spawn("node", ["--enable-source-maps", "runner.js"], spawnOptions),
       (p) => Effect.sync(() => p.kill()),
     );
 
@@ -107,7 +108,7 @@ export function spawnAndParseTraceEvents({
                   const t2 = performance.now();
                   yield* Ref.set(t2Ref, t2);
                   logPerf("t2 (first stdout chunk)", t0, t2);
-                  logPerf("t1→t2 node program.js", t1, t2);
+                  logPerf("t1→t2 node runner.js", t1, t2);
                 }),
           ),
         ),

--- a/src/hooks/useWebContainerBoot.ts
+++ b/src/hooks/useWebContainerBoot.ts
@@ -6,7 +6,6 @@ import { Effect, Fiber, Layer } from "effect";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
-  isPerfPlayEnabled,
   spawnAndParseTraceEvents,
   type SpawnAndParseCallbacks,
 } from "@/effects/spawnAndParse";
@@ -15,7 +14,7 @@ import {
   acquireMonacoTypesFallback,
 } from "@/effects/typeAcquisition";
 import { canSupportWebContainer } from "@/lib/mobileDetection";
-import { transformForContainer } from "@/lib/transformForContainer";
+import { transformImportsForContainer } from "@/lib/transformForContainer";
 import { transpileForContainer } from "@/lib/transpileForContainer";
 import type { WebContainerHandle } from "@/services/webcontainer";
 import { WebContainer, WebContainerLive } from "@/services/webcontainer";
@@ -186,7 +185,7 @@ export function useWebContainerBoot() {
 
       setIsSyncing(true);
       try {
-        const transformed = transformForContainer(content, isPerfPlayEnabled());
+        const transformed = transformImportsForContainer(content);
         await Effect.runPromise(handle.writeFile("program.ts", transformed));
 
         try {

--- a/src/lib/programCache.test.ts
+++ b/src/lib/programCache.test.ts
@@ -16,6 +16,7 @@ const mockPrograms: ProgramsMap = {
   retry: { source: "// retry template" },
   basicFinalizers: { source: "// basicFinalizers template" },
   acquireRelease: { source: "// acquireRelease template" },
+  loggerWithRequirements: { source: "// loggerWithRequirements template" },
 };
 
 describe("programCache", () => {

--- a/src/lib/programs.ts
+++ b/src/lib/programs.ts
@@ -3,6 +3,7 @@
  * These demonstrate different Effect patterns with tracing.
  */
 
+import type { Layer } from "effect";
 import { Effect, Fiber, Ref } from "effect";
 
 import {
@@ -280,11 +281,23 @@ export const acquireReleaseExample = Effect.scoped(
 // Program Registry (with source code for display)
 // =============================================================================
 
+/**
+ * Contract for visualizable programs.
+ * Programs export rootEffect (the effect to run) and requirements (layers to provide).
+ * TraceEmitter is injected by the runner; do not include it in requirements.
+ */
+export interface VisualizableProgramContract {
+  readonly rootEffect: Effect.Effect<unknown, unknown, unknown>;
+  readonly requirements: ReadonlyArray<Layer.Layer<unknown>>;
+}
+
 export const programs = {
   basic: {
     name: "Basic Example",
     description: "Sequential + concurrent execution with fiber joins",
     program: basicExample,
+    rootEffect: basicExample,
+    requirements: [] as const,
     source: `import { Effect, Fiber } from "effect";
 import {
   forkWithTrace,
@@ -353,6 +366,8 @@ const fiber = Effect.runFork(tracedProgramWithLayer);
     name: "Multi-Step Worker",
     description: "A fiber performing multiple sequential steps",
     program: multiStepExample,
+    rootEffect: multiStepExample,
+    requirements: [] as const,
     source: `import { Effect, Fiber } from "effect";
 import {
   forkWithTrace,
@@ -397,6 +412,8 @@ const fiber = Effect.runFork(tracedProgramWithLayer);`,
     name: "Nested Forks",
     description: "Parent -> child -> grandchild fiber hierarchy",
     program: nestedForksExample,
+    rootEffect: nestedForksExample,
+    requirements: [] as const,
     source: `import { Effect, Fiber } from "effect";
 import {
   forkWithTrace,
@@ -463,6 +480,8 @@ const fiber = Effect.runFork(tracedProgramWithLayer);
     description:
       "Two fibers racing - first to complete wins, loser interrupted",
     program: racingExample,
+    rootEffect: racingExample,
+    requirements: [] as const,
     source: `import { Effect, Fiber } from "effect";
 import {
   forkWithTrace,
@@ -521,6 +540,8 @@ const fiber = Effect.runFork(tracedProgramWithLayer);
     name: "Failure & Recovery",
     description: "A step fails, then we recover and continue",
     program: failureExample,
+    rootEffect: failureExample,
+    requirements: [] as const,
     source: `import { Effect } from "effect";
 import {
   withTrace,
@@ -574,6 +595,8 @@ const fiber = Effect.runFork(tracedProgramWithLayer);
     description:
       "Effect fails twice then succeeds; retryWithTrace retries until success",
     program: retryExample,
+    rootEffect: retryExample,
+    requirements: [] as const,
     source: `import { Effect, Ref } from "effect";
 import {
   retryWithTrace,
@@ -624,6 +647,8 @@ const fiber = Effect.runFork(tracedProgramWithLayer);
     description:
       "Register 3 finalizers; they run in LIFO order when the scope closes",
     program: basicFinalizersExample,
+    rootEffect: basicFinalizersExample,
+    requirements: [] as const,
     source: `import { Effect } from "effect";
 import {
   addFinalizerWithTrace,
@@ -669,6 +694,8 @@ const fiber = Effect.runFork(tracedProgramWithLayer);
     description:
       "acquireReleaseWithTrace: acquire a resource, use it, release on scope exit",
     program: acquireReleaseExample,
+    rootEffect: acquireReleaseExample,
+    requirements: [] as const,
     source: `import { Effect } from "effect";
 import {
   acquireReleaseWithTrace,

--- a/src/lib/programs.ts
+++ b/src/lib/programs.ts
@@ -286,7 +286,11 @@ interface Logger {
 
 const Logger = Context.GenericTag<Logger>("app/Logger");
 
-const makeLoggerLayer = (
+/**
+ * Create a Logger layer. Export for fallback mode
+ * (in order to log directly to panel instead of console).
+ */
+export const makeLoggerLayer = (
   onLog: (message: string) => void,
 ): Layer.Layer<Logger> =>
   Layer.succeed(Logger, {

--- a/src/lib/programs.ts
+++ b/src/lib/programs.ts
@@ -295,7 +295,6 @@ export const programs = {
   basic: {
     name: "Basic Example",
     description: "Sequential + concurrent execution with fiber joins",
-    program: basicExample,
     rootEffect: basicExample,
     requirements: [] as const,
     source: `import { Effect, Fiber } from "effect";
@@ -303,11 +302,9 @@ import {
   forkWithTrace,
   withTrace,
   sleepWithTrace,
-  runProgramWithTrace,
-  makeTraceEmitterLayer,
 } from "@/runtime/tracedRunner";
 
-const program = Effect.gen(function* () {
+export const rootEffect = Effect.gen(function* () {
   // Step 1: Sequential initialization
   yield* withTrace(
     Effect.sync(() => console.log("Initializing...")),
@@ -344,28 +341,12 @@ const program = Effect.gen(function* () {
   return { result1, result2 };
 });
 
-// ---
-// Example code to launch the program (inject service before)
-// ---
-
-const tracedProgram = runProgramWithTrace(program, "basic");
-//^ Effect<{ result1: string; result2: string; }, never, TraceEmitter>
-
-// create a layer that emits to the trace store in react context
-const layer = makeTraceEmitterLayer((event) => {
-  // process the event
-});
-
-const tracedProgramWithLayer = tracedProgram.pipe(Effect.provide(layer))
-//^ Effect<{ result1: string; result2: string; }, never, never>
-
-const fiber = Effect.runFork(tracedProgramWithLayer);
+export const requirements = [];
 `,
   },
   multiStep: {
     name: "Multi-Step Worker",
     description: "A fiber performing multiple sequential steps",
-    program: multiStepExample,
     rootEffect: multiStepExample,
     requirements: [] as const,
     source: `import { Effect, Fiber } from "effect";
@@ -373,11 +354,9 @@ import {
   forkWithTrace,
   withTrace,
   sleepWithTrace,
-  runProgramWithTrace,
-  makeTraceEmitterLayer,
 } from "@/runtime/tracedRunner";
 
-const program = Effect.gen(function* () {
+export const rootEffect = Effect.gen(function* () {
   const worker = yield* forkWithTrace(
     Effect.gen(function* () {
       yield* withTrace(sleepWithTrace("500 millis"), "step-1-prepare");
@@ -391,27 +370,11 @@ const program = Effect.gen(function* () {
   return yield* Fiber.join(worker);
 });
 
-// ---
-// Example code to launch the program (inject service before)
-// ---
-
-const tracedProgram = runProgramWithTrace(program, "multiStep");
-//^ Effect.Effect<string, never, TraceEmitter>
-
-// create a layer that emits to the trace store in react context
-const layer = makeTraceEmitterLayer((event) => {
-  // process the event
-});
-
-const tracedProgramWithLayer = tracedProgram.pipe(Effect.provide(layer))
-//^ Effect.Effect<string, never, never>
-
-const fiber = Effect.runFork(tracedProgramWithLayer);`,
+export const requirements = [];`,
   },
   nestedForks: {
     name: "Nested Forks",
     description: "Parent -> child -> grandchild fiber hierarchy",
-    program: nestedForksExample,
     rootEffect: nestedForksExample,
     requirements: [] as const,
     source: `import { Effect, Fiber } from "effect";
@@ -419,11 +382,9 @@ import {
   forkWithTrace,
   withTrace,
   sleepWithTrace,
-  runProgramWithTrace,
-  makeTraceEmitterLayer,
 } from "@/runtime/tracedRunner";
 
-const program = Effect.gen(function* () {
+export const rootEffect = Effect.gen(function* () {
   const parent = yield* forkWithTrace(
     Effect.gen(function* () {
       yield* withTrace(Effect.succeed("parent started"), "parent-init");
@@ -457,29 +418,13 @@ const program = Effect.gen(function* () {
   return yield* Fiber.join(parent);
 });
 
-// ---
-// Example code to launch the program (inject service before)
-// ---
-
-const tracedProgram = runProgramWithTrace(program, "nestedForks");
-//^ Effect.Effect<string, never, TraceEmitter>
-
-// create a layer that emits to the trace store in react context
-const layer = makeTraceEmitterLayer((event) => {
-  // process the event
-});
-
-const tracedProgramWithLayer = tracedProgram.pipe(Effect.provide(layer))
-//^ Effect.Effect<string, never, never>
-
-const fiber = Effect.runFork(tracedProgramWithLayer);
+export const requirements = [];
 `,
   },
   racing: {
     name: "Racing",
     description:
       "Two fibers racing - first to complete wins, loser interrupted",
-    program: racingExample,
     rootEffect: racingExample,
     requirements: [] as const,
     source: `import { Effect, Fiber } from "effect";
@@ -487,11 +432,9 @@ import {
   forkWithTrace,
   withTrace,
   sleepWithTrace,
-  runProgramWithTrace,
-  makeTraceEmitterLayer,
 } from "@/runtime/tracedRunner";
 
-const program = Effect.gen(function* () {
+export const rootEffect = Effect.gen(function* () {
   yield* withTrace(Effect.succeed("starting race"), "race-start");
 
   // Fork two fibers explicitly so we can visualize them
@@ -518,38 +461,18 @@ const program = Effect.gen(function* () {
   return winner;
 });
 
-// ---
-// Example code to launch the program (inject service before)
-// ---
-
-const tracedProgram = runProgramWithTrace(program, "racing");
-//^ Effect.Effect<string, never, TraceEmitter>
-
-// create a layer that emits to the trace store in react context
-const layer = makeTraceEmitterLayer((event) => {
-  // process the event
-});
-
-const tracedProgramWithLayer = tracedProgram.pipe(Effect.provide(layer))
-//^ Effect.Effect<string, never, never>
-
-const fiber = Effect.runFork(tracedProgramWithLayer);
+export const requirements = [];
 `,
   },
   failureAndRecovery: {
     name: "Failure & Recovery",
     description: "A step fails, then we recover and continue",
-    program: failureExample,
     rootEffect: failureExample,
     requirements: [] as const,
     source: `import { Effect } from "effect";
-import {
-  withTrace,
-  runProgramWithTrace,
-  makeTraceEmitterLayer,
-} from "@/runtime/tracedRunner";
+import { withTrace } from "@/runtime/tracedRunner";
 
-const program = Effect.gen(function* () {
+export const rootEffect = Effect.gen(function* () {
   // Step 1: Setup succeeds
   yield* withTrace(Effect.succeed("ready"), "setup");
 
@@ -572,39 +495,19 @@ const program = Effect.gen(function* () {
   return recovered;
 });
 
-// ---
-// Example code to launch the program (inject service before)
-// ---
-
-const tracedProgram = runProgramWithTrace(program, "failureAndRecovery");
-//^ Effect.Effect<string, never, TraceEmitter>
-
-// create a layer that emits to the trace store in react context
-const layer = makeTraceEmitterLayer((event) => {
-  // process the event
-});
-
-const tracedProgramWithLayer = tracedProgram.pipe(Effect.provide(layer))
-//^ Effect.Effect<string, never, never>
-
-const fiber = Effect.runFork(tracedProgramWithLayer);
+export const requirements = [];
 `,
   },
   retry: {
     name: "Retry",
     description:
       "Effect fails twice then succeeds; retryWithTrace retries until success",
-    program: retryExample,
     rootEffect: retryExample,
     requirements: [] as const,
     source: `import { Effect, Ref } from "effect";
-import {
-  retryWithTrace,
-  runProgramWithTrace,
-  makeTraceEmitterLayer,
-} from "@/runtime/tracedRunner";
+import { retryWithTrace } from "@/runtime/tracedRunner";
 
-const program = Effect.gen(function* () {
+export const rootEffect = Effect.gen(function* () {
   // Step 1: Ref to count attempts
   const attempts = yield* Ref.make(0);
 
@@ -624,45 +527,27 @@ const program = Effect.gen(function* () {
   });
 });
 
-// ---
-// Example code to launch the program (inject service before)
-// ---
-
-const tracedProgram = runProgramWithTrace(program, "retry");
-//^ Effect.Effect<string, never, TraceEmitter>
-
-// create a layer that emits to the trace store in react context
-const layer = makeTraceEmitterLayer((event) => {
-  // process the event
-});
-
-const tracedProgramWithLayer = tracedProgram.pipe(Effect.provide(layer))
-//^ Effect.Effect<string, never, never>
-
-const fiber = Effect.runFork(tracedProgramWithLayer);
+export const requirements = [];
 `,
   },
   basicFinalizers: {
     name: "Basic Finalizers",
     description:
       "Register 3 finalizers; they run in LIFO order when the scope closes",
-    program: basicFinalizersExample,
     rootEffect: basicFinalizersExample,
     requirements: [] as const,
     source: `import { Effect } from "effect";
 import {
   addFinalizerWithTrace,
   withTrace,
-  runProgramWithTrace,
-  makeTraceEmitterLayer,
 } from "@/runtime/tracedRunner";
 
-const program = Effect.scoped(
+export const rootEffect = Effect.scoped(
   Effect.gen(function* () {
     // Step 1: Register 3 finalizers (LIFO: 3 runs first, then 2, then 1)
-    yield* addFinalizerWithTrace((_exit) => Effect.sync(() => {}), "finalizer-1");
-    yield* addFinalizerWithTrace((_exit) => Effect.sync(() => {}), "finalizer-2");
-    yield* addFinalizerWithTrace((_exit) => Effect.sync(() => {}), "finalizer-3");
+    yield* addFinalizerWithTrace(() => Effect.sync(() => {}), "finalizer-1");
+    yield* addFinalizerWithTrace(() => Effect.sync(() => {}), "finalizer-2");
+    yield* addFinalizerWithTrace(() => Effect.sync(() => {}), "finalizer-3");
     // Step 2: Run two traced steps
     yield* withTrace(Effect.succeed("step 1"), "step-1");
     yield* withTrace(Effect.succeed("step 2"), "step-2");
@@ -671,40 +556,22 @@ const program = Effect.scoped(
   })
 );
 
-// ---
-// Example code to launch the program (inject service before)
-// ---
-
-const tracedProgram = runProgramWithTrace(program, "basicFinalizers");
-//^ Effect.Effect<string, never, TraceEmitter>
-
-// create a layer that emits to the trace store in react context
-const layer = makeTraceEmitterLayer((event) => {
-  // process the event
-});
-
-const tracedProgramWithLayer = tracedProgram.pipe(Effect.provide(layer))
-//^ Effect.Effect<string, never, never>
-
-const fiber = Effect.runFork(tracedProgramWithLayer);
+export const requirements = [];
 `,
   },
   acquireRelease: {
     name: "Acquire / Release",
     description:
       "acquireReleaseWithTrace: acquire a resource, use it, release on scope exit",
-    program: acquireReleaseExample,
     rootEffect: acquireReleaseExample,
     requirements: [] as const,
     source: `import { Effect } from "effect";
 import {
   acquireReleaseWithTrace,
   withTrace,
-  runProgramWithTrace,
-  makeTraceEmitterLayer,
 } from "@/runtime/tracedRunner";
 
-const program = Effect.scoped(
+export const rootEffect = Effect.scoped(
   Effect.gen(function* () {
     // Step 1: Acquire resource (release runs when scope closes)
     const connection = yield* acquireReleaseWithTrace(
@@ -722,22 +589,7 @@ const program = Effect.scoped(
   })
 );
 
-// ---
-// Example code to launch the program (inject service before)
-// ---
-
-const tracedProgram = runProgramWithTrace(program, "acquireRelease");
-//^ Effect.Effect<{ id: string }, never, TraceEmitter>
-
-// create a layer that emits to the trace store in react context
-const layer = makeTraceEmitterLayer((event) => {
-  // process the event
-});
-
-const tracedProgramWithLayer = tracedProgram.pipe(Effect.provide(layer))
-//^ Effect.Effect<{ id: string }, never, never>
-
-const fiber = Effect.runFork(tracedProgramWithLayer);
+export const requirements = [];
 `,
   },
 } as const;

--- a/src/lib/transformForContainer.ts
+++ b/src/lib/transformForContainer.ts
@@ -1,82 +1,28 @@
 /**
  * Transforms editor content for execution inside the WebContainer.
  *
- * Applies:
- * 1. Import path: @/runtime/tracedRunner → ./tracedRunner.js (Node ESM requires .js extension)
- * 2. Trace emitter bridge: replace makeTraceEmitterLayer callback with stdout writer
- * 3. Program key: runProgramWithTrace(program, "user")
- * 4. In-container perf instrumentation when perfEnabled (single "ready" checkpoint before Effect.runFork)
+ * Programs export rootEffect and requirements; the fixed runner.js injects
+ * TraceEmitter and runs. Only import path fix is needed (container has no @/ alias).
  */
-
-/** Regex to match makeTraceEmitterLayer callback for replacement (handles multiline) */
-const LAYER_CALLBACK_REGEX =
-  /makeTraceEmitterLayer\s*\(\s*\([^)]*\)\s*=>\s*\{[\s\S]*?\}\s*\)/g;
-
-/** Stdout trace emitter - writes TRACE_EVENT: JSON lines for host to parse */
-const STDOUT_EMITTER =
-  '(event) => process.stdout.write("TRACE_EVENT:" + JSON.stringify(event) + "\\n")';
-
-/** The program key used for user-edited runs */
-const USER_PROGRAM_KEY = '"user"';
-
-/** Single checkpoint before Effect.runFork — ms from process start until ready to run Effect */
-const PERF_READY =
-  'process.stderr.write("PERF: ready " + performance.now().toFixed(0) + "\\n");';
-
-/**
- * Injects single perf checkpoint before Effect.runFork when perfEnabled.
- * Logs ms from process start → ready to run Effect.
- */
-function injectPerfInstrumentation(result: string): string {
-  // Match Effect.runFork( whether standalone or in `const x = Effect.runFork(`
-  return result.replace(
-    /(\n)(\s*(?:const\s+\w+\s*=\s*)?Effect\.runFork\s*\()/,
-    `$1${PERF_READY}\n$2`,
-  );
-}
 
 /**
  * Transform editor source for container execution.
- * - Replaces @/ imports with ./tracedRunner.js
- * - Replaces makeTraceEmitterLayer callback with stdout writer
- * - Uses "user" as program key for runProgramWithTrace
- * - When perfEnabled: injects perf checkpoint before Effect.runFork
+ * Only fixes import paths: @/runtime/tracedRunner → ./tracedRunner.js (Node ESM requires .js).
+ * The runner.js bootstraps execution; user code does not need runProgramWithTrace or makeTraceEmitterLayer.
  */
-export function transformForContainer(
-  source: string,
-  perfEnabled = false,
-): string {
+export function transformImportsForContainer(source: string): string {
   let result = source;
 
-  // 1. Replace import path: @/runtime/tracedRunner → ./tracedRunner.js (Node ESM requires .js)
+  // Replace import path: @/runtime/tracedRunner → ./tracedRunner.js (Node ESM requires .js)
   result = result.replace(
     /from\s+["']@\/[^"']*tracedRunner["']/g,
     'from "./tracedRunner.js"',
   );
-  // Also fix ./tracedRunner without .js (e.g. INITIAL_PROGRAM, user edits)
+  // Also fix ./tracedRunner without .js
   result = result.replace(
     /from\s+["']\.\/tracedRunner["']/g,
     'from "./tracedRunner.js"',
   );
-
-  // 2. Replace makeTraceEmitterLayer callback with stdout writer
-  // Match: makeTraceEmitterLayer((event) => { ... })
-  result = result.replace(
-    LAYER_CALLBACK_REGEX,
-    `makeTraceEmitterLayer(${STDOUT_EMITTER})`,
-  );
-
-  // 3. Use fixed "user" for runProgramWithTrace(program, "...")
-  // Match: runProgramWithTrace(program, "key") or runProgramWithTrace(program, 'key')
-  result = result.replace(
-    /runProgramWithTrace\s*\(\s*(\w+)\s*,\s*["'][^"']*["']\s*\)/g,
-    `runProgramWithTrace($1, ${USER_PROGRAM_KEY})`,
-  );
-
-  // 4. Inject perf instrumentation when enabled (PERF_PLAY=1 passed at spawn)
-  if (perfEnabled) {
-    result = injectPerfInstrumentation(result);
-  }
 
   return result;
 }


### PR DESCRIPTION
## Summary

Introduces a `rootEffect` + `requirements` contract: programs export their effect and required layers. The runner injects TraceEmitter and merges user requirements, eliminating regex-based transformations in WebContainer mode.

## Motivation

1. **Regex fragility in WebContainer** — Replacing `makeTraceEmitterLayer` and `runProgramWithTrace` via regex was brittle and had security implications.
2. **Divergent host/container paths** — Host and WebContainer ran programs differently.
3. **No user services** — Programs couldn't depend on custom services (Logger, DB, etc.).

## Solution

Programs export:

- **`rootEffect`** — The Effect to run
- **`requirements`** — Array of layers to provide (TraceEmitter is added by the runner)

The runner injects TraceEmitter and merges `requirements` via `Layer.mergeAll`.

## Changes

| Area | Change |
|------|--------|
| **Contract** | `VisualizableProgramContract` with `rootEffect` and `requirements` |
| **Container** | Fixed `runner.js` imports `program.js`; no string replacement |
| **Fallback** | Same pipeline on host with `Layer.mergeAll(traceLayer, ...requirements)` |
| **Transform** | `transformImportsForContainer` — import path only (`@/` → `./tracedRunner.js`) |
| **Validation** | Runner checks for `rootEffect` before run; missing exports → error in console panel |
| **Example** | Logger program with custom requirements; fallback logs to panel (not console) for mobile |

## Testing

- **Fallback**: Select "Logger (custom requirements)" and run; output appears in logs panel.
- **WebContainer**: Same program; trace events in visualizer and `[logger]` output in logs panel.
- **Invalid program**: Remove `rootEffect` export and run; error appears in errors tab with fix guidance.