### PR TITLE
fix(#14): fall back to in-browser execution when offline

### DIFF
--- a/src/hooks/useWebContainerBoot.ts
+++ b/src/hooks/useWebContainerBoot.ts
@@ -13,7 +13,10 @@ import {
   acquireMonacoTypes,
   acquireMonacoTypesFallback,
 } from "@/effects/typeAcquisition";
-import { canSupportWebContainer } from "@/lib/mobileDetection";
+import {
+  canSupportWebContainer,
+  shouldUseFallback,
+} from "@/lib/mobileDetection";
 import { transformImportsForContainer } from "@/lib/transformForContainer";
 import { transpileForContainer } from "@/lib/transpileForContainer";
 import type { WebContainerHandle } from "@/services/webcontainer";
@@ -36,18 +39,31 @@ export function useWebContainerBoot() {
   const lastSyncedContentRef = useRef<string | null>(null);
   const [isSyncing, setIsSyncing] = useState(false);
 
+  // Checked once at mount, not reactively - an already-booted container keeps running
+  // offline fine, so this only needs to catch starting cold while offline.
   useEffect(() => {
-    if (!canSupportWebContainer()) {
+    if (shouldUseFallback()) {
       setStatus("booting");
       setError(null);
-      addLog(
-        "boot",
-        "Mobile or Safari detected, using fallback (no WebContainer) - readonly mode.",
-      );
-      addLog(
-        "boot",
-        "To edit the example programs, you need a Desktop Chrome / Firefox browser.",
-      );
+      if (!canSupportWebContainer()) {
+        addLog(
+          "boot",
+          "Mobile or Safari detected, using fallback (no WebContainer) - readonly mode.",
+        );
+        addLog(
+          "boot",
+          "To edit the example programs, you need a Desktop Chrome / Firefox browser.",
+        );
+      } else {
+        addLog(
+          "boot",
+          "Offline detected, using fallback (no WebContainer) - readonly mode.",
+        );
+        addLog(
+          "boot",
+          "WebContainer needs a live connection to StackBlitz's servers to boot; reconnect to edit and run arbitrary code.",
+        );
+      }
       Effect.runPromise(acquireMonacoTypesFallback)
         .then(() => {
           setTypesReady(true);

--- a/src/lib/mobileDetection.ts
+++ b/src/lib/mobileDetection.ts
@@ -61,3 +61,21 @@ export function useCanSupportWebContainer(): boolean {
   const [can] = useState(() => canSupportWebContainer());
   return can;
 }
+
+/**
+ * Whether the fallback (no-WebContainer) path should be used: mobile/Safari
+ * (subject to `?webcontainer=` override), or offline - WebContainer boots via
+ * a cross-origin iframe we can't cache into, and StackBlitz doesn't reliably
+ * support reload-while-offline itself (stackblitz/webcontainer-core#992).
+ *
+ * Check once at mount, not on a timer/listener: an already-booted container
+ * keeps running offline fine, so this should only gate the initial boot
+ * attempt, not tear down a working session.
+ */
+export function shouldUseFallback(): boolean {
+  if (!canSupportWebContainer()) return true;
+  if (typeof navigator !== "undefined" && navigator.onLine === false) {
+    return true;
+  }
+  return false;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,8 +48,8 @@ export default defineConfig({
         globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
         runtimeCaching: [
           {
-            urlPattern:
-              /^https:\/\/cdn\.jsdelivr\.net\/npm\/monaco-editor\/.*/i,
+            // Note: jsdelivr serves versioned paths like monaco-editor@0.55.1/...
+            urlPattern: /^https:\/\/cdn\.jsdelivr\.net\/npm\/monaco-editor@.*/i,
             handler: "CacheFirst",
             options: {
               cacheName: "monaco-editor-cdn",
@@ -62,6 +62,9 @@ export default defineConfig({
               },
             },
           },
+          // No rules for c/t/nr.staticblitz.com: WebContainer boots via a cross-origin
+          // iframe, so those requests never reach this app's service worker to cache.
+          // See workshop/WebContainer/MOBILE_FALLBACK.md.
         ],
       },
     }),

--- a/workshop/WebContainer/MOBILE_FALLBACK.md
+++ b/workshop/WebContainer/MOBILE_FALLBACK.md
@@ -1,12 +1,14 @@
-# Mobile and Safari Fallback
+# Mobile, Safari, and Offline Fallback
 
 ## Why a Fallback Path?
 
 WebContainer does not run reliably on mobile devices (boot often fails at `pnpm install`) or Safari (desktop and iOS). Play can fail on Safari without devtools open due to WebAssembly instantiation issues. To provide a usable experience, the app uses a fallback path when the user agent indicates a mobile device or Safari.
 
+The same fallback is also used when offline. WebContainer boots via a cross-origin iframe to `stackblitz.com/headless` (needed for its `SharedArrayBuffer` sandbox); every request after that is issued by that iframe's own document, not this app's, so our service worker can never see or cache any of it — there's no `vite.config.ts` rule that could help. StackBlitz's own reload-while-offline story isn't reliable either ([webcontainer-core#992](https://github.com/stackblitz/webcontainer-core/issues/992)), so offline reuses the same readonly/in-browser path as mobile and Safari rather than getting stuck on a broken boot.
+
 ## What the Fallback Provides
 
-| Feature          | Supported (WebContainer)             | Fallback (Mobile / Safari)                 |
+| Feature          | Supported (WebContainer)             | Fallback (Mobile / Safari / Offline)       |
 | ---------------- | ------------------------------------ | ------------------------------------------ |
 | Editor           | Editable                             | Readonly                                   |
 | Execution        | WebContainer (`pnpm run`, etc.)      | In-browser Effect (`runFallbackPlay`)      |
@@ -24,13 +26,13 @@ This split ensures tracedRunner-related types remain up to date via the build pi
 
 ## WebContainer Support Detection
 
-WebContainer support is determined via **user agent** (not media queries):
+WebContainer support is determined via **user agent** (not media queries), plus a network check:
 
 - **`canSupportWebContainer()`** returns `true` when the browser can run WebContainer (Chrome, Firefox, non-Safari Chromium).
 - **`useCanSupportWebContainer()`** is the React hook version.
-- Fallback is used when `!canSupportWebContainer()` — i.e. mobile (Android, iPhone, iPad, iPod, webOS, BlackBerry, IEMobile, Opera Mini) or Safari (desktop and iOS).
+- **`shouldUseFallback()`** is what `useWebContainerBoot` actually checks: `true` when `!canSupportWebContainer()` (mobile: Android, iPhone, iPad, iPod, webOS, BlackBerry, IEMobile, Opera Mini; or Safari, desktop and iOS) **or** `navigator.onLine === false`.
 
-See `src/lib/mobileDetection.ts` for `canSupportWebContainer()`, `useCanSupportWebContainer()`, `isMobileUserAgent()`, and `isSafariUserAgent()`.
+See `src/lib/mobileDetection.ts` for `canSupportWebContainer()`, `useCanSupportWebContainer()`, `shouldUseFallback()`, `isMobileUserAgent()`, and `isSafariUserAgent()`.
 
 ## Future: Conditional Imports
 


### PR DESCRIPTION
## Summary
- Fix the jsdelivr `runtimeCaching` regex so Monaco's CDN assets actually get cached (it never matched jsdelivr's versioned `monaco-editor@x.y.z/...` paths)
- Reuse the existing mobile/Safari fallback (readonly editor, in-browser execution of the example programs) when offline, since WebContainer boots through a cross-origin iframe our service worker can't cache into

Fixes #14

## Test plan
- [ ] `npm run build && npm run preview`
- [ ] Load once online to warm the service worker cache
- [ ] Cut network, hard-reload: Monaco should load from cache, app should drop into readonly fallback instead of hanging on the dead `stackblitz.com/headless` request
- [ ] Restore network, reload: normal WebContainer boot still works (editable editor, arbitrary `Run`)