### PR TITLE
fix: pin effect in the container to the app's own version

### DIFF
--- a/src/services/webcontainer.ts
+++ b/src/services/webcontainer.ts
@@ -27,7 +27,7 @@ const PACKAGE_JSON = `{
     "run": "pnpm exec tsx program.ts"
   },
   "dependencies": {
-    "effect": "^3.19.15",
+    "effect": "3.19.15",
     "tsx": "^4.19.0",
     "typescript": "~5.9.3"
   }


### PR DESCRIPTION
## What

The WebContainer's inner `package.json` (`PACKAGE_JSON` in `src/services/webcontainer.ts`) asks for `"effect": "3.19.15"` — an exact pin instead of the previous `^3.19.15` caret range.

## Why

The app bundles whatever its own lockfile resolves (currently 3.19.15), while the container installed *whatever 3.x was current at spawn time* (3.22.1 as of today). The two execution paths could therefore run different Effect versions, and they disagree about observable behaviour: on 3.19.15, the fiber that loses a timeout race exits as an **interrupt**; on 3.22.x, as a **success**. The same program traced `fiber:interrupt` in the browser and `fiber:end` in the container.

Documented in `workshop/phase-10.md` (step 6, "Known issue") while building issue #13's examples.

## Scope

Deliberately minimal: this pins the two paths to the same version so they cannot drift again. It does **not** upgrade Effect to 3.22.x — that is a separate piece of work needing an audit of trace-behaviour changes between 3.19 and 3.22.