### PR TITLE
feat(#13): slow mode & stepper

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -3,9 +3,11 @@
 **Quick Context**: See [`workshop/README.md`](workshop/README.md) for full documentation.
 
 ## Current Phase
-**Phase 10**: IN PROGRESS 🚧 — slow mode & stepper (issue #13). Speed, pause and step work on both paths and instrumentation events are tagged; what remains is the examples and explainers (6)
+**Phase 10**: COMPLETE ✅ — slow mode & stepper (issue #13). All steps done: VirtualClock, Effect Clock layer, Date shim, virtual timestamps, GatedScheduler + step ladder, control channel for the WebContainer, speed combo + stepper controls, origin tagging with show-internals toggle, and five new example programs.
 
-**Recent**: trace events carry an origin — the program's own, or the visualizer's — so the yield injected into a paused start can be hidden, along with the control commands the container's terminal echoes back. One shared "show internals" preference drives both panels. See [`workshop/phase-10.md`](workshop/phase-10.md).
+**Next up (not yet a phase)**: [#18](https://github.com/topheman/effect-viz/issues/18) — upgrade `effect` to latest 3.x; the trace-behaviour changes between 3.19 and 3.22 need an audit (e.g. timeout-loser exits as success instead of interrupt).
+
+**Recent**: five new examples teach what no sleep-shaped program could — `Effect.yieldNow` interleaving, bounded concurrency, structured interruption, timeout on the shared clock, and a Deferred deadlock that reaches the stepper's `noProgress`. See [`workshop/phase-10.md`](workshop/phase-10.md).
 
 ## Completed Phases
 
@@ -116,6 +118,19 @@
 - Finalizers run LIFO; use Effect.scoped(effect) so programs have a scope
 - acquireReleaseWithTrace built on addFinalizerWithTrace; AcquireEvent for acquire outcome, FinalizerEvent for release
 
+### Key Learning (Phase 10)
+- Two clocks: **wall** (performance.now, unshimmable) vs **virtual** (the program's Clock); connected by `rate`; re-anchor on every rate change so time never jumps
+- Pause must **park** timers, not `setTimeout(d/0)` — Infinity overflows to 1ms and wakes every sleeper instantly
+- Scaling the Clock preserves semantics: the program only observes virtual time, so slow motion is genuine
+- Speed stretches sleeps; the **stepper handles bursts** between them, which no rate can stretch
+- Step is a pause-mode operation; "release one task" is the primitive, the button releases until one visible trace event (`maxTasks` bounds it)
+- Never answer `shouldYield` while paused — the released task yields forever and the stepper livelocks
+- Pause sets rate to 0 AND gates the scheduler; Reset must play() before interrupting or the interrupt queues forever
+- A step needs a full event-loop turn to settle; two steps in one turn report false `noProgress`
+- The page models the container's clock (MirroredClock): extrapolate between readings, snap forward-only on each reply's `virtualNow`
+- stdin listener is the container process's keep-alive — ref'd while paused, released when the root promise settles
+- Origin tagging: absent means the program's own; only `"tool"` is ever set, so unknown events are shown, never hidden
+
 ## Design Decisions
 - **Service + Layer** pattern for TraceEmitter
 - R channel (Requirements) introduced early
@@ -142,6 +157,10 @@
 - `src/hooks/useSpeed.ts` - Speed options, localStorage persistence (Phase 10)
 - `src/runtime/gatedScheduler.ts` - GatedScheduler: pause/step the runtime by gating tasks (Phase 10)
 - `src/runtime/stepper.ts` - Stepper: the step ladder over scheduler + clock (Phase 10)
+- `src/runtime/controlChannel.ts` - Command/reply codecs over container stdin/stdout (Phase 10)
+- `src/lib/mirroredClock.ts` - Page's model of the container's virtual clock (Phase 10)
+- `src/lib/containerController.ts` - Clicks → commands; steps resolve on reply (Phase 10)
+- `src/runtime/traceOrigin.ts` - makeOriginTagger: finds the injected yield (Phase 10)
 
 ## Learning Phases
 1. ~~**Phase 1**: Lazy evaluation, success/failure~~ ✅ See [`workshop/phase-1.md`](workshop/phase-1.md)
@@ -153,7 +172,7 @@
 7. ~~**Phase 7**: Custom Tracer for Effect.withSpan~~ ✅ See [`workshop/phase-7.md`](workshop/phase-7.md)
 8. ~~**Phase 8**: Sleep visibility via onSuspend/onResume~~ ✅ See [`workshop/phase-8.md`](workshop/phase-8.md)
 9. ~~**Phase 9**: retry with Schedule API~~ ✅ See [`workshop/phase-9.md`](workshop/phase-9.md)
-10. **Phase 10**: Slow mode & stepper (issue #13) 🚧 See [`workshop/phase-10.md`](workshop/phase-10.md)
+10. ~~**Phase 10**: Slow mode & stepper (issue #13)~~ ✅ See [`workshop/phase-10.md`](workshop/phase-10.md)
 
 ## Documentation
 - [`workshop/README.md`](workshop/README.md) - Documentation overview

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -3,7 +3,7 @@
 **Quick Context**: See [`workshop/README.md`](workshop/README.md) for full documentation.
 
 ## Current Phase
-**Phase 10**: IN PROGRESS 🚧 — slow mode & stepper (issue #13), step 2 of 6 done
+**Phase 10**: IN PROGRESS 🚧 — slow mode & stepper (issue #13), step 3 of 6 done
 
 **Recent**: `VirtualClock` + `vizClock` — an Effect `Clock` over a rate-scaled virtual time source. Slow motion works and preserves race/timeout semantics. See [`workshop/phase-10.md`](workshop/phase-10.md).
 
@@ -138,6 +138,7 @@
 - `src/lib/programs.ts` - Example programs with source code
 - `src/runtime/virtualClock.ts` - VirtualClock: rate-scaled virtual time, park-on-pause, step-to-deadline (Phase 10)
 - `src/runtime/vizClock.ts` - makeVizClockLayer: Effect Clock over VirtualClock via Layer.setClock (Phase 10)
+- `src/runtime/dateShim.ts` - installDateShim: Date.now/new Date read virtual time; WebContainer only (Phase 10)
 
 ## Learning Phases
 1. ~~**Phase 1**: Lazy evaluation, success/failure~~ ✅ See [`workshop/phase-1.md`](workshop/phase-1.md)

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -3,9 +3,9 @@
 **Quick Context**: See [`workshop/README.md`](workshop/README.md) for full documentation.
 
 ## Current Phase
-**Phase 9**: COMPLETE ✅
+**Phase 10**: IN PROGRESS 🚧 — slow mode & stepper (issue #13), step 1 of 6 done
 
-**Recent**: retry with Schedule API; public APIs (retry, addFinalizer, acquireRelease); internal APIs prefixed with _
+**Recent**: `VirtualClock` — shared virtual time source for the Effect Clock layer and the Date shim. See [`workshop/phase-10.md`](workshop/phase-10.md).
 
 ## Completed Phases
 
@@ -136,6 +136,7 @@
 - `src/components/visualizer/FiberTreeView.tsx` - Fiber tree with suspended indicator
 - `src/components/visualizer/TimelineView.tsx` - Real-time timeline visualization
 - `src/lib/programs.ts` - Example programs with source code
+- `src/runtime/virtualClock.ts` - VirtualClock: rate-scaled virtual time, park-on-pause, step-to-deadline (Phase 10)
 
 ## Learning Phases
 1. ~~**Phase 1**: Lazy evaluation, success/failure~~ ✅ See [`workshop/phase-1.md`](workshop/phase-1.md)
@@ -147,6 +148,7 @@
 7. ~~**Phase 7**: Custom Tracer for Effect.withSpan~~ ✅ See [`workshop/phase-7.md`](workshop/phase-7.md)
 8. ~~**Phase 8**: Sleep visibility via onSuspend/onResume~~ ✅ See [`workshop/phase-8.md`](workshop/phase-8.md)
 9. ~~**Phase 9**: retry with Schedule API~~ ✅ See [`workshop/phase-9.md`](workshop/phase-9.md)
+10. **Phase 10**: Slow mode & stepper (issue #13) 🚧 See [`workshop/phase-10.md`](workshop/phase-10.md)
 
 ## Documentation
 - [`workshop/README.md`](workshop/README.md) - Documentation overview

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -140,6 +140,7 @@
 - `src/runtime/vizClock.ts` - makeVizClockLayer: Effect Clock over VirtualClock via Layer.setClock (Phase 10)
 - `src/runtime/dateShim.ts` - installDateShim: Date.now/new Date read virtual time; WebContainer only (Phase 10)
 - `src/hooks/useSpeed.ts` - Speed options, localStorage persistence (Phase 10)
+- `src/runtime/gatedScheduler.ts` - GatedScheduler: pause/step the runtime by gating tasks (Phase 10)
 
 ## Learning Phases
 1. ~~**Phase 1**: Lazy evaluation, success/failure~~ ✅ See [`workshop/phase-1.md`](workshop/phase-1.md)

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -3,7 +3,7 @@
 **Quick Context**: See [`workshop/README.md`](workshop/README.md) for full documentation.
 
 ## Current Phase
-**Phase 10**: IN PROGRESS 🚧 — slow mode & stepper (issue #13), step 3 of 6 done
+**Phase 10**: IN PROGRESS 🚧 — slow mode & stepper (issue #13), steps 1-3 done + virtual timestamps everywhere
 
 **Recent**: `VirtualClock` + `vizClock` — an Effect `Clock` over a rate-scaled virtual time source. Slow motion works and preserves race/timeout semantics. See [`workshop/phase-10.md`](workshop/phase-10.md).
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -3,7 +3,7 @@
 **Quick Context**: See [`workshop/README.md`](workshop/README.md) for full documentation.
 
 ## Current Phase
-**Phase 10**: IN PROGRESS 🚧 — slow mode & stepper (issue #13). Speed control works end-to-end; stepper (gated Scheduler + ⏯️⏭️) remains
+**Phase 10**: IN PROGRESS 🚧 — slow mode & stepper (issue #13). Speed control works end-to-end; stepper runs (4a done) but is not wired to the UI (5b) and has no container channel (4b)
 
 **Recent**: `VirtualClock` + `vizClock` — an Effect `Clock` over a rate-scaled virtual time source. Slow motion works and preserves race/timeout semantics. See [`workshop/phase-10.md`](workshop/phase-10.md).
 
@@ -141,6 +141,7 @@
 - `src/runtime/dateShim.ts` - installDateShim: Date.now/new Date read virtual time; WebContainer only (Phase 10)
 - `src/hooks/useSpeed.ts` - Speed options, localStorage persistence (Phase 10)
 - `src/runtime/gatedScheduler.ts` - GatedScheduler: pause/step the runtime by gating tasks (Phase 10)
+- `src/runtime/stepper.ts` - Stepper: the step ladder over scheduler + clock (Phase 10)
 
 ## Learning Phases
 1. ~~**Phase 1**: Lazy evaluation, success/failure~~ ✅ See [`workshop/phase-1.md`](workshop/phase-1.md)

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -3,9 +3,9 @@
 **Quick Context**: See [`workshop/README.md`](workshop/README.md) for full documentation.
 
 ## Current Phase
-**Phase 10**: IN PROGRESS 🚧 — slow mode & stepper (issue #13). Speed + pause/step now work on both paths; next are examples/explainers (6) and tagging instrumentation events (7)
+**Phase 10**: IN PROGRESS 🚧 — slow mode & stepper (issue #13). Speed, pause and step work on both paths and instrumentation events are tagged; what remains is the examples and explainers (6)
 
-**Recent**: a control channel over the WebContainer's stdio — commands in on stdin, replies out behind a `TRACE_CONTROL:` prefix — so pause, resume and step reach a program running in another process. The page models that process's clock, corrected by every virtual reading that comes back. See [`workshop/phase-10.md`](workshop/phase-10.md).
+**Recent**: trace events carry an origin — the program's own, or the visualizer's — so the yield injected into a paused start can be hidden, along with the control commands the container's terminal echoes back. One shared "show internals" preference drives both panels. See [`workshop/phase-10.md`](workshop/phase-10.md).
 
 ## Completed Phases
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -3,7 +3,7 @@
 **Quick Context**: See [`workshop/README.md`](workshop/README.md) for full documentation.
 
 ## Current Phase
-**Phase 10**: IN PROGRESS 🚧 — slow mode & stepper (issue #13), steps 1-3 done + virtual timestamps everywhere
+**Phase 10**: IN PROGRESS 🚧 — slow mode & stepper (issue #13). Speed control works end-to-end; stepper (gated Scheduler + ⏯️⏭️) remains
 
 **Recent**: `VirtualClock` + `vizClock` — an Effect `Clock` over a rate-scaled virtual time source. Slow motion works and preserves race/timeout semantics. See [`workshop/phase-10.md`](workshop/phase-10.md).
 
@@ -139,6 +139,7 @@
 - `src/runtime/virtualClock.ts` - VirtualClock: rate-scaled virtual time, park-on-pause, step-to-deadline (Phase 10)
 - `src/runtime/vizClock.ts` - makeVizClockLayer: Effect Clock over VirtualClock via Layer.setClock (Phase 10)
 - `src/runtime/dateShim.ts` - installDateShim: Date.now/new Date read virtual time; WebContainer only (Phase 10)
+- `src/hooks/useSpeed.ts` - Speed options, localStorage persistence (Phase 10)
 
 ## Learning Phases
 1. ~~**Phase 1**: Lazy evaluation, success/failure~~ ✅ See [`workshop/phase-1.md`](workshop/phase-1.md)

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -3,9 +3,9 @@
 **Quick Context**: See [`workshop/README.md`](workshop/README.md) for full documentation.
 
 ## Current Phase
-**Phase 10**: IN PROGRESS 🚧 — slow mode & stepper (issue #13). Speed + pause/step work in the browser (fallback path); the WebContainer needs a control channel (4b), then examples/explainers (6)
+**Phase 10**: IN PROGRESS 🚧 — slow mode & stepper (issue #13). Speed + pause/step now work on both paths; next are examples/explainers (6) and tagging instrumentation events (7)
 
-**Recent**: `VirtualClock` + `vizClock` — an Effect `Clock` over a rate-scaled virtual time source. Slow motion works and preserves race/timeout semantics. See [`workshop/phase-10.md`](workshop/phase-10.md).
+**Recent**: a control channel over the WebContainer's stdio — commands in on stdin, replies out behind a `TRACE_CONTROL:` prefix — so pause, resume and step reach a program running in another process. The page models that process's clock, corrected by every virtual reading that comes back. See [`workshop/phase-10.md`](workshop/phase-10.md).
 
 ## Completed Phases
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -3,9 +3,9 @@
 **Quick Context**: See [`workshop/README.md`](workshop/README.md) for full documentation.
 
 ## Current Phase
-**Phase 10**: IN PROGRESS 🚧 — slow mode & stepper (issue #13), step 1 of 6 done
+**Phase 10**: IN PROGRESS 🚧 — slow mode & stepper (issue #13), step 2 of 6 done
 
-**Recent**: `VirtualClock` — shared virtual time source for the Effect Clock layer and the Date shim. See [`workshop/phase-10.md`](workshop/phase-10.md).
+**Recent**: `VirtualClock` + `vizClock` — an Effect `Clock` over a rate-scaled virtual time source. Slow motion works and preserves race/timeout semantics. See [`workshop/phase-10.md`](workshop/phase-10.md).
 
 ## Completed Phases
 
@@ -137,6 +137,7 @@
 - `src/components/visualizer/TimelineView.tsx` - Real-time timeline visualization
 - `src/lib/programs.ts` - Example programs with source code
 - `src/runtime/virtualClock.ts` - VirtualClock: rate-scaled virtual time, park-on-pause, step-to-deadline (Phase 10)
+- `src/runtime/vizClock.ts` - makeVizClockLayer: Effect Clock over VirtualClock via Layer.setClock (Phase 10)
 
 ## Learning Phases
 1. ~~**Phase 1**: Lazy evaluation, success/failure~~ ✅ See [`workshop/phase-1.md`](workshop/phase-1.md)

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -3,7 +3,7 @@
 **Quick Context**: See [`workshop/README.md`](workshop/README.md) for full documentation.
 
 ## Current Phase
-**Phase 10**: IN PROGRESS 🚧 — slow mode & stepper (issue #13). Speed control works end-to-end; stepper runs (4a done) but is not wired to the UI (5b) and has no container channel (4b)
+**Phase 10**: IN PROGRESS 🚧 — slow mode & stepper (issue #13). Speed + pause/step work in the browser (fallback path); the WebContainer needs a control channel (4b), then examples/explainers (6)
 
 **Recent**: `VirtualClock` + `vizClock` — an Effect `Clock` over a rate-scaled virtual time source. Slow motion works and preserves race/timeout semantics. See [`workshop/phase-10.md`](workshop/phase-10.md).
 

--- a/src/components/editor/WebContainerLogsPanel.tsx
+++ b/src/components/editor/WebContainerLogsPanel.tsx
@@ -4,6 +4,7 @@ import { useLayoutEffect, useRef, useState } from "react";
 import type { ComponentType } from "react";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useShowInternals } from "@/hooks/useShowInternals";
 import { cn } from "@/lib/utils";
 import { useWebContainerLogsStore } from "@/stores/webContainerLogsStore";
 
@@ -25,11 +26,16 @@ export function WebContainerLogsPanel({
   webContainerMode = true,
 }: WebContainerLogsPanelProps) {
   const { logs, clearLogs, clearErrors } = useWebContainerLogsStore();
+  const [showInternals, setShowInternals] = useShowInternals();
   const [activeTab, setActiveTab] = useState<"logs" | "errors">("logs");
   const logsScrollRef = useRef<HTMLDivElement>(null);
   const errorsScrollRef = useRef<HTMLDivElement>(null);
 
-  const logEntries = logs.filter((e) => e.label !== "error");
+  // "control" is the page's own commands, echoed back by the process's terminal.
+  const controlCount = logs.filter((e) => e.label === "control").length;
+  const logEntries = logs.filter(
+    (e) => e.label !== "error" && (showInternals || e.label !== "control"),
+  );
   const errorEntries = logs.filter((e) => e.label === "error");
 
   const isPnpmInstallRunning =
@@ -136,6 +142,21 @@ export function WebContainerLogsPanel({
                 </TabsList>
               )}
             </div>
+            {controlCount > 0 && activeTab === "logs" && (
+              <button
+                type="button"
+                onClick={() => setShowInternals(!showInternals)}
+                className={`
+                  shrink-0 cursor-pointer text-xs text-muted-foreground
+                  transition-colors
+                  hover:text-foreground
+                `}
+              >
+                {showInternals
+                  ? "hide control channel"
+                  : "show control channel"}
+              </button>
+            )}
             {canClear && (
               <button
                 type="button"
@@ -187,7 +208,7 @@ export function WebContainerLogsPanel({
                             `,
                             entry.label === "boot" &&
                               "bg-primary/20 text-primary",
-                            entry.label === "npm" &&
+                            entry.label === "control" &&
                               "bg-amber-500/20 text-amber-700",
                           )}
                         >

--- a/src/components/layout/InfoModal.tsx
+++ b/src/components/layout/InfoModal.tsx
@@ -113,7 +113,7 @@ export function InfoModal({
         </DialogHeader>
 
         <div
-          className={`flex max-h-[60vh] flex-col gap-6 overflow-y-auto py-4`}
+          className={`flex max-h-[60vh] flex-col gap-4 overflow-y-auto py-4`}
           data-testid="info-modal-body"
         >
           {/* About the project */}

--- a/src/components/layout/InfoModal.tsx
+++ b/src/components/layout/InfoModal.tsx
@@ -1,4 +1,4 @@
-import { Info, X } from "lucide-react";
+import { Info, Play, StepForward, X } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
 import { useEffect, useState } from "react";
 
@@ -132,6 +132,22 @@ export function InfoModal({
                 <p>On desktop, you can also edit the example programs.</p>
               </>
             )}
+          </section>
+
+          <section
+            className="flex flex-col gap-3 text-sm text-muted-foreground"
+            aria-label="Slow motion and step by step"
+          >
+            <p>
+              You can press{" "}
+              <StepForward className="inline h-3.5 w-3.5 align-text-bottom" />{" "}
+              to run the program step by step.
+            </p>
+            <p>
+              You can pick a speed before pressing{" "}
+              <Play className="inline h-3.5 w-3.5 align-text-bottom" /> to watch
+              the same program run slower.
+            </p>
           </section>
 
           <section

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -52,7 +52,6 @@ export function MainLayout() {
     handlePause,
     handleResume,
     handleStep,
-    supportsStepping,
     handleReset,
     selectedProgram,
     setSelectedProgram,
@@ -241,18 +240,25 @@ export function MainLayout() {
     setPlaybackState("paused");
   };
 
-  const onStep = () => {
+  const onStep = async () => {
     // From idle, Step starts the program already gated so that its first events
     // can be stepped through; there is no other way into a paused run.
     if (playbackState === "idle") {
       setShowVisualizer(true);
+      // Same flush as Play: the container would otherwise step through whatever
+      // it was last given rather than what is on screen.
+      if (webContainer.isReady) {
+        await webContainer.flushSync(editorContent);
+      }
       startRun({ startPaused: true });
       setPlaybackState("paused");
       setPauseReason("user");
       return;
     }
 
-    const outcome = handleStep();
+    // A step is a round trip on the container path, so the outcome that decides
+    // whether the program is stuck arrives asynchronously on both.
+    const outcome = await handleStep();
     if (outcome === null) return;
     if (outcome._tag === "finished") {
       setPlaybackState("finished");
@@ -479,7 +485,6 @@ export function MainLayout() {
         speed={speed}
         onSpeedChange={setSpeed}
         pauseReason={pauseReason}
-        isSteppingSupported={supportsStepping}
       />
     </div>
   );

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -19,6 +19,7 @@ import {
 import { VisualizerPanel } from "@/components/visualizer/VisualizerPanel";
 import { useEventHandlers } from "@/hooks/useEventHandlers";
 import { useOnboarding } from "@/hooks/useOnboarding";
+import { useSpeed } from "@/hooks/useSpeed";
 import { useWebContainerBoot } from "@/hooks/useWebContainerBoot";
 import { useCanSupportWebContainer } from "@/lib/mobileDetection";
 import {
@@ -64,6 +65,7 @@ export function MainLayout() {
   } = useOnboarding();
 
   const [playbackState, setPlaybackState] = useState<PlaybackState>("idle");
+  const [speed, setSpeed] = useSpeed();
   const [showVisualizer, setShowVisualizer] = useState(false);
   const [showLogsPanel, setShowLogsPanel] = useState(true);
   const [editorTabId, setEditorTabId] = useState("program");
@@ -185,8 +187,8 @@ export function MainLayout() {
       await webContainer.flushSync(editorContent);
     }
     setPlaybackState("starting");
-    handlePlay({ onFirstChunk: () => setPlaybackState("running") })
-      .then(() => setPlaybackState("idle"))
+    handlePlay({ onFirstChunk: () => setPlaybackState("running"), rate: speed })
+      .then(() => setPlaybackState("finished"))
       .catch(() => setPlaybackState("idle")); // e.g. interrupt on program switch
   };
 
@@ -412,6 +414,8 @@ export function MainLayout() {
           (webContainer.status === "booting" || webContainer.isSyncing)
         }
         isSyncing={canSupportWebContainer && webContainer.isSyncing}
+        speed={speed}
+        onSpeedChange={setSpeed}
       />
     </div>
   );

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -196,6 +196,27 @@ export function MainLayout() {
     </TooltipProvider>
   );
 
+  const startRun = ({ startPaused }: { startPaused: boolean }) => {
+    const runId = ++runIdRef.current;
+    const isCurrentRun = () => runIdRef.current === runId;
+
+    setPauseReason("user");
+    handlePlay({
+      // A gated run stays paused; only a free-running one reaches "running".
+      onFirstChunk: () => {
+        if (!startPaused) setPlaybackState("running");
+      },
+      rate: speed,
+      startPaused,
+    })
+      .then(() => {
+        if (isCurrentRun()) setPlaybackState("finished");
+      })
+      .catch(() => {
+        if (isCurrentRun()) setPlaybackState("idle");
+      });
+  };
+
   const onPlay = async () => {
     setShowVisualizer(true);
 
@@ -209,18 +230,9 @@ export function MainLayout() {
     if (webContainer.isReady) {
       await webContainer.flushSync(editorContent);
     }
-    const runId = ++runIdRef.current;
-    const isCurrentRun = () => runIdRef.current === runId;
 
     setPlaybackState("starting");
-    setPauseReason("user");
-    handlePlay({ onFirstChunk: () => setPlaybackState("running"), rate: speed })
-      .then(() => {
-        if (isCurrentRun()) setPlaybackState("finished");
-      })
-      .catch(() => {
-        if (isCurrentRun()) setPlaybackState("idle");
-      });
+    startRun({ startPaused: false });
   };
 
   const onPause = () => {
@@ -230,6 +242,16 @@ export function MainLayout() {
   };
 
   const onStep = () => {
+    // From idle, Step starts the program already gated so that its first events
+    // can be stepped through; there is no other way into a paused run.
+    if (playbackState === "idle") {
+      setShowVisualizer(true);
+      startRun({ startPaused: true });
+      setPlaybackState("paused");
+      setPauseReason("user");
+      return;
+    }
+
     const outcome = handleStep();
     if (outcome === null) return;
     if (outcome._tag === "finished") {

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -30,7 +30,11 @@ import type { ProgramKey } from "@/lib/programs";
 import { cn } from "@/lib/utils";
 
 import { Header } from "./Header";
-import { PlaybackControls, type PlaybackState } from "./PlaybackControls";
+import {
+  PlaybackControls,
+  type PauseReason,
+  type PlaybackState,
+} from "./PlaybackControls";
 
 export function MainLayout() {
   const canSupportWebContainer = useCanSupportWebContainer();
@@ -45,6 +49,10 @@ export function MainLayout() {
 
   const {
     handlePlay,
+    handlePause,
+    handleResume,
+    handleStep,
+    supportsStepping,
     handleReset,
     selectedProgram,
     setSelectedProgram,
@@ -65,6 +73,13 @@ export function MainLayout() {
   } = useOnboarding();
 
   const [playbackState, setPlaybackState] = useState<PlaybackState>("idle");
+  const [pauseReason, setPauseReason] = useState<PauseReason>("user");
+  /**
+   * Identifies the current run. A run that was reset must not set the playback
+   * state when its promise finally settles, because an interrupted run settles
+   * the same way a completed one does.
+   */
+  const runIdRef = useRef(0);
   const [speed, setSpeed] = useSpeed();
   const [showVisualizer, setShowVisualizer] = useState(false);
   const [showLogsPanel, setShowLogsPanel] = useState(true);
@@ -183,30 +198,55 @@ export function MainLayout() {
 
   const onPlay = async () => {
     setShowVisualizer(true);
+
+    // Play doubles as resume: the program is already running, just gated.
+    if (playbackState === "paused") {
+      handleResume();
+      setPlaybackState("running");
+      return;
+    }
+
     if (webContainer.isReady) {
       await webContainer.flushSync(editorContent);
     }
+    const runId = ++runIdRef.current;
+    const isCurrentRun = () => runIdRef.current === runId;
+
     setPlaybackState("starting");
+    setPauseReason("user");
     handlePlay({ onFirstChunk: () => setPlaybackState("running"), rate: speed })
-      .then(() => setPlaybackState("finished"))
-      .catch(() => setPlaybackState("idle")); // e.g. interrupt on program switch
+      .then(() => {
+        if (isCurrentRun()) setPlaybackState("finished");
+      })
+      .catch(() => {
+        if (isCurrentRun()) setPlaybackState("idle");
+      });
   };
 
-  const handlePause = () => {
+  const onPause = () => {
+    handlePause();
+    setPauseReason("user");
     setPlaybackState("paused");
-    // TODO: Pause Effect execution
   };
 
-  const handleStep = () => {
-    // TODO: Step through Effect execution
+  const onStep = () => {
+    const outcome = handleStep();
+    if (outcome === null) return;
+    if (outcome._tag === "finished") {
+      setPlaybackState("finished");
+      return;
+    }
+    setPauseReason(outcome._tag === "noProgress" ? "stuck" : "user");
   };
 
-  const handleStepOver = () => {
+  const onStepOver = () => {
     // TODO: Step over in Effect execution
   };
 
   const onReset = () => {
+    runIdRef.current++;
     setPlaybackState("idle");
+    setPauseReason("user");
     handleReset();
   };
 
@@ -400,9 +440,9 @@ export function MainLayout() {
       <PlaybackControls
         state={playbackState}
         onPlay={onPlay}
-        onPause={handlePause}
-        onStep={handleStep}
-        onStepOver={handleStepOver}
+        onPause={onPause}
+        onStep={onStep}
+        onStepOver={onStepOver}
         onReset={onReset}
         showVisualizer={showVisualizer}
         onToggleVisualizer={() => setShowVisualizer(!showVisualizer)}
@@ -416,6 +456,8 @@ export function MainLayout() {
         isSyncing={canSupportWebContainer && webContainer.isSyncing}
         speed={speed}
         onSpeedChange={setSpeed}
+        pauseReason={pauseReason}
+        isSteppingSupported={supportsStepping}
       />
     </div>
   );

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -241,9 +241,10 @@ export function MainLayout() {
   };
 
   const onStep = async () => {
-    // From idle, Step starts the program already gated so that its first events
-    // can be stepped through; there is no other way into a paused run.
-    if (playbackState === "idle") {
+    // With nothing running, Step starts the program already gated so that its
+    // first events can be stepped through; there is no other way into a paused
+    // run. As with Play, a finished program starts over.
+    if (playbackState === "idle" || playbackState === "finished") {
       setShowVisualizer(true);
       // Same flush as Play: the container would otherwise step through whatever
       // it was last given rather than what is on screen.

--- a/src/components/layout/PlaybackControls.tsx
+++ b/src/components/layout/PlaybackControls.tsx
@@ -63,8 +63,6 @@ interface PlaybackControlsProps {
   onSpeedChange?: (speed: Speed) => void;
   /** Only meaningful while paused; decides whether Step can do anything */
   pauseReason?: PauseReason;
-  /** False for the WebContainer path, which has no control channel yet */
-  isSteppingSupported?: boolean;
 }
 
 export function PlaybackControls({
@@ -84,7 +82,6 @@ export function PlaybackControls({
   speed = 1,
   onSpeedChange,
   pauseReason = "user",
-  isSteppingSupported = false,
 }: PlaybackControlsProps) {
   const isRunning = state === "running";
   // Play doubles as resume (from paused) and re-run (from finished).
@@ -95,10 +92,9 @@ export function PlaybackControls({
   // can be stepped through. Otherwise stepping needs a live, frozen program; a
   // stuck pause has nothing the runtime could release.
   const canStep =
-    isSteppingSupported &&
-    ((state === "idle" && !isPlayDisabled) ||
-      (state === "paused" && pauseReason === "user"));
-  const canPause = isSteppingSupported && isRunning;
+    (state === "idle" && !isPlayDisabled) ||
+    (state === "paused" && pauseReason === "user");
+  const canPause = isRunning;
   // Nothing to reset before the first run.
   const canReset = state !== "idle";
   // The rate is fixed when the program starts: the WebContainer receives it as a
@@ -229,13 +225,7 @@ export function PlaybackControls({
                 )}
               </Button>
             </TooltipTrigger>
-            <TooltipContent>
-              {isRunning
-                ? isSteppingSupported
-                  ? "Pause"
-                  : "Pause is only available in the in-browser runtime"
-                : "Run"}
-            </TooltipContent>
+            <TooltipContent>{isRunning ? "Pause" : "Run"}</TooltipContent>
           </Tooltip>
 
           {/* Step */}

--- a/src/components/layout/PlaybackControls.tsx
+++ b/src/components/layout/PlaybackControls.tsx
@@ -88,11 +88,12 @@ export function PlaybackControls({
   const canPlay =
     (state === "idle" || state === "paused" || state === "finished") &&
     !isPlayDisabled;
-  // Step from idle starts the program already gated, so its very first events
-  // can be stepped through. Otherwise stepping needs a live, frozen program; a
-  // stuck pause has nothing the runtime could release.
+  // Step from a stopped program starts it already gated, so its very first
+  // events can be stepped through; like Play, that includes re-running one that
+  // has finished. Otherwise stepping needs a live, frozen program, and a stuck
+  // pause has nothing the runtime could release.
   const canStep =
-    (state === "idle" && !isPlayDisabled) ||
+    ((state === "idle" || state === "finished") && !isPlayDisabled) ||
     (state === "paused" && pauseReason === "user");
   const canPause = isRunning;
   // Nothing to reset before the first run.
@@ -243,7 +244,7 @@ export function PlaybackControls({
             <TooltipContent>
               {state === "paused" && pauseReason === "stuck"
                 ? "Nothing can run: deadlocked, or waiting on something outside"
-                : state === "idle"
+                : state === "idle" || state === "finished"
                   ? "Start paused, then step"
                   : "Step"}
             </TooltipContent>

--- a/src/components/layout/PlaybackControls.tsx
+++ b/src/components/layout/PlaybackControls.tsx
@@ -23,9 +23,7 @@ import { cn } from "@/lib/utils";
 
 import { InfoModal } from "./InfoModal";
 
-const STEP_IS_IMPLEMENTED = false;
 const STEP_OVER_IS_IMPLEMENTED = false;
-const PAUSE_IS_IMPLEMENTED = false;
 
 export type PlaybackState =
   | "idle"
@@ -35,10 +33,14 @@ export type PlaybackState =
   | "finished";
 
 /**
- * Why execution is paused. Only a user pause can be stepped: the other two mean
- * the runtime has nothing left to release, so Step would do nothing.
+ * Why execution is paused. Only a user pause can be stepped: `stuck` means
+ * nothing is runnable and no deadline is pending, so a step would do nothing.
+ *
+ * A stuck program is either deadlocked or waiting on something outside. Telling
+ * those apart needs a fiber's status, which is itself an Effect and so needs the
+ * scheduler that a pause is holding.
  */
-export type PauseReason = "user" | "deadlock" | "waiting-external";
+export type PauseReason = "user" | "stuck";
 
 interface PlaybackControlsProps {
   state?: PlaybackState;
@@ -61,6 +63,8 @@ interface PlaybackControlsProps {
   onSpeedChange?: (speed: Speed) => void;
   /** Only meaningful while paused; decides whether Step can do anything */
   pauseReason?: PauseReason;
+  /** False for the WebContainer path, which has no control channel yet */
+  isSteppingSupported?: boolean;
 }
 
 export function PlaybackControls({
@@ -80,15 +84,18 @@ export function PlaybackControls({
   speed = 1,
   onSpeedChange,
   pauseReason = "user",
+  isSteppingSupported = false,
 }: PlaybackControlsProps) {
   const isRunning = state === "running";
   // Play doubles as resume (from paused) and re-run (from finished).
   const canPlay =
     (state === "idle" || state === "paused" || state === "finished") &&
     !isPlayDisabled;
-  // Stepping needs something live and frozen to advance. A deadlocked or
-  // externally-blocked pause has nothing the runtime could release.
-  const canStep = state === "paused" && pauseReason === "user";
+  // Stepping needs something live and frozen to advance; a stuck pause has
+  // nothing the runtime could release.
+  const canStep =
+    isSteppingSupported && state === "paused" && pauseReason === "user";
+  const canPause = isSteppingSupported && isRunning;
   // Nothing to reset before the first run.
   const canReset = state !== "idle";
   // The rate is fixed when the program starts: the WebContainer receives it as a
@@ -192,10 +199,7 @@ export function PlaybackControls({
                     onOnboardingComplete?.("play");
                   }
                 }}
-                disabled={
-                  (!canPlay && !isRunning) ||
-                  (isRunning && !PAUSE_IS_IMPLEMENTED)
-                }
+                disabled={(!canPlay && !isRunning) || (isRunning && !canPause)}
                 onAnimationEnd={(e) => {
                   if (e.animationName === "play-button-mount") {
                     setPlayMountAnimationEnded(true);
@@ -222,25 +226,33 @@ export function PlaybackControls({
                 )}
               </Button>
             </TooltipTrigger>
-            <TooltipContent>{isRunning ? "Pause" : "Run"}</TooltipContent>
+            <TooltipContent>
+              {isRunning
+                ? isSteppingSupported
+                  ? "Pause"
+                  : "Pause is only available in the in-browser runtime"
+                : "Run"}
+            </TooltipContent>
           </Tooltip>
 
           {/* Step */}
-          {STEP_IS_IMPLEMENTED && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={onStep}
-                  disabled={!canStep}
-                >
-                  <StepForward className="h-4 w-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Step</TooltipContent>
-            </Tooltip>
-          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onStep}
+                disabled={!canStep}
+              >
+                <StepForward className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {state === "paused" && pauseReason === "stuck"
+                ? "Nothing can run: deadlocked, or waiting on something outside"
+                : "Step"}
+            </TooltipContent>
+          </Tooltip>
 
           {/* Step Over */}
           {STEP_OVER_IS_IMPLEMENTED && (

--- a/src/components/layout/PlaybackControls.tsx
+++ b/src/components/layout/PlaybackControls.tsx
@@ -10,6 +10,7 @@ import {
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Select } from "@/components/ui/select";
 import {
   Tooltip,
   TooltipContent,
@@ -17,6 +18,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import type { OnboardingStepId } from "@/hooks/useOnboarding";
+import { SPEED_OPTIONS, type Speed, formatSpeed } from "@/hooks/useSpeed";
 import { cn } from "@/lib/utils";
 
 import { InfoModal } from "./InfoModal";
@@ -31,6 +33,12 @@ export type PlaybackState =
   | "running"
   | "paused"
   | "finished";
+
+/**
+ * Why execution is paused. Only a user pause can be stepped: the other two mean
+ * the runtime has nothing left to release, so Step would do nothing.
+ */
+export type PauseReason = "user" | "deadlock" | "waiting-external";
 
 interface PlaybackControlsProps {
   state?: PlaybackState;
@@ -48,6 +56,11 @@ interface PlaybackControlsProps {
   isPlayDisabled?: boolean;
   /** When true, show "Syncing..." in status (e.g. flushing editor to container) */
   isSyncing?: boolean;
+  /** Playback speed applied on the next run */
+  speed?: Speed;
+  onSpeedChange?: (speed: Speed) => void;
+  /** Only meaningful while paused; decides whether Step can do anything */
+  pauseReason?: PauseReason;
 }
 
 export function PlaybackControls({
@@ -64,10 +77,23 @@ export function PlaybackControls({
   onRestartOnboarding,
   isPlayDisabled = false,
   isSyncing = false,
+  speed = 1,
+  onSpeedChange,
+  pauseReason = "user",
 }: PlaybackControlsProps) {
   const isRunning = state === "running";
-  const canPlay = (state === "idle" || state === "paused") && !isPlayDisabled;
-  const canStep = state === "idle" || state === "paused";
+  // Play doubles as resume (from paused) and re-run (from finished).
+  const canPlay =
+    (state === "idle" || state === "paused" || state === "finished") &&
+    !isPlayDisabled;
+  // Stepping needs something live and frozen to advance. A deadlocked or
+  // externally-blocked pause has nothing the runtime could release.
+  const canStep = state === "paused" && pauseReason === "user";
+  // Nothing to reset before the first run.
+  const canReset = state !== "idle";
+  // The rate is fixed when the program starts: the WebContainer receives it as a
+  // spawn environment variable and cannot be retuned until it is restarted.
+  const canChangeSpeed = state !== "running" && state !== "starting";
   const [playMountAnimationEnded, setPlayMountAnimationEnded] = useState(false);
 
   // Skip showVisualizer step on desktop (toggle is hidden)
@@ -139,7 +165,12 @@ export function PlaybackControls({
           {/* Reset */}
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="icon" onClick={onReset}>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onReset}
+                disabled={!canReset}
+              >
                 <RotateCcw className="h-4 w-4" />
               </Button>
             </TooltipTrigger>
@@ -261,6 +292,32 @@ export function PlaybackControls({
                   : state}
             </span>
           </div>
+
+          {/* Speed */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Select
+                aria-label="Playback speed"
+                className="h-8 w-[4.5rem] px-2"
+                value={speed}
+                disabled={!canChangeSpeed}
+                onChange={(e) =>
+                  onSpeedChange?.(Number(e.target.value) as Speed)
+                }
+              >
+                {SPEED_OPTIONS.map((option) => (
+                  <option key={option} value={option}>
+                    {formatSpeed(option)}
+                  </option>
+                ))}
+              </Select>
+            </TooltipTrigger>
+            <TooltipContent>
+              {canChangeSpeed
+                ? "Speed — slows the program's own clock"
+                : "Speed applies on the next run"}
+            </TooltipContent>
+          </Tooltip>
         </div>
 
         {/* Right: Info button */}

--- a/src/components/layout/PlaybackControls.tsx
+++ b/src/components/layout/PlaybackControls.tsx
@@ -91,10 +91,13 @@ export function PlaybackControls({
   const canPlay =
     (state === "idle" || state === "paused" || state === "finished") &&
     !isPlayDisabled;
-  // Stepping needs something live and frozen to advance; a stuck pause has
-  // nothing the runtime could release.
+  // Step from idle starts the program already gated, so its very first events
+  // can be stepped through. Otherwise stepping needs a live, frozen program; a
+  // stuck pause has nothing the runtime could release.
   const canStep =
-    isSteppingSupported && state === "paused" && pauseReason === "user";
+    isSteppingSupported &&
+    ((state === "idle" && !isPlayDisabled) ||
+      (state === "paused" && pauseReason === "user"));
   const canPause = isSteppingSupported && isRunning;
   // Nothing to reset before the first run.
   const canReset = state !== "idle";
@@ -250,7 +253,9 @@ export function PlaybackControls({
             <TooltipContent>
               {state === "paused" && pauseReason === "stuck"
                 ? "Nothing can run: deadlocked, or waiting on something outside"
-                : "Step"}
+                : state === "idle"
+                  ? "Start paused, then step"
+                  : "Step"}
             </TooltipContent>
           </Tooltip>
 

--- a/src/components/visualizer/ExecutionLog.tsx
+++ b/src/components/visualizer/ExecutionLog.tsx
@@ -9,13 +9,13 @@ import {
 } from "@/components/ui/card";
 import { useShowInternals } from "@/hooks/useShowInternals";
 import { cn } from "@/lib/utils";
+import { isToolEvent } from "@/runtime/traceOrigin";
 import { useTraceStore } from "@/stores/traceStore";
-import {
-  type EffectStartEvent,
-  type FiberForkEvent,
-  type FiberSuspendEvent,
-  type TraceEvent,
-  isToolEvent,
+import type {
+  EffectStartEvent,
+  FiberForkEvent,
+  FiberSuspendEvent,
+  TraceEvent,
 } from "@/types/trace";
 
 function formatError(err: unknown): string {

--- a/src/components/visualizer/ExecutionLog.tsx
+++ b/src/components/visualizer/ExecutionLog.tsx
@@ -7,13 +7,15 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { useShowInternals } from "@/hooks/useShowInternals";
 import { cn } from "@/lib/utils";
 import { useTraceStore } from "@/stores/traceStore";
-import type {
-  EffectStartEvent,
-  FiberForkEvent,
-  FiberSuspendEvent,
-  TraceEvent,
+import {
+  type EffectStartEvent,
+  type FiberForkEvent,
+  type FiberSuspendEvent,
+  type TraceEvent,
+  isToolEvent,
 } from "@/types/trace";
 
 function formatError(err: unknown): string {
@@ -155,7 +157,15 @@ function getEventColor(event: TraceEvent): string {
 
 export function ExecutionLog() {
   const { events } = useTraceStore();
+  const [showInternals, setShowInternals] = useShowInternals();
   const cardContentRef = useRef<HTMLDivElement>(null);
+
+  const toolEventCount = events.filter(isToolEvent).length;
+  // Positions in the full list are kept: formatEvent pairs an event with its
+  // start, and a duration measured against a filtered list would be wrong.
+  const visible = events
+    .map((event, index) => ({ event, index }))
+    .filter(({ event }) => showInternals || !isToolEvent(event));
 
   useEffect(() => {
     const ref = cardContentRef.current;
@@ -175,7 +185,24 @@ export function ExecutionLog() {
           md:pb-3
         `}
       >
-        <CardTitle className="text-base">Execution Log</CardTitle>
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base">Execution Log</CardTitle>
+          {toolEventCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowInternals(!showInternals)}
+              className={`
+                shrink-0 cursor-pointer text-xs text-muted-foreground
+                transition-colors
+                hover:text-foreground
+              `}
+            >
+              {showInternals
+                ? "hide visualizer events"
+                : `show ${toolEventCount} visualizer event${toolEventCount > 1 ? "s" : ""}`}
+            </button>
+          )}
+        </div>
         <CardDescription
           className={cn(events.length > 0 ? "hidden" : "block", "md:block")}
         >
@@ -183,7 +210,7 @@ export function ExecutionLog() {
         </CardDescription>
       </CardHeader>
       <CardContent className="flex-1 overflow-hidden">
-        {events.length === 0 ? (
+        {visible.length === 0 ? (
           <div
             className={`
               flex h-full items-center justify-center text-center
@@ -202,17 +229,24 @@ export function ExecutionLog() {
             className="h-full overflow-y-auto font-mono text-sm"
             ref={cardContentRef}
           >
-            {events.map((event, index) => {
+            {visible.map(({ event, index }, position) => {
               const emojiInfo = getEventEmoji(event);
               return (
                 <div
                   key={`${event.type}-${event.timestamp}-${index}`}
-                  className={`
-                    border-b border-border/50 py-1.5
-                    last:border-b-0
-                  `}
+                  className={cn(
+                    `
+                      border-b border-border/50 py-1.5
+                      last:border-b-0
+                    `,
+                    // Dimmed rather than styled apart: it is a real event that
+                    // really happened, just not one the program asked for.
+                    isToolEvent(event) && "opacity-60",
+                  )}
                 >
-                  <span className="text-muted-foreground">[{index + 1}]</span>{" "}
+                  <span className="text-muted-foreground">
+                    [{position + 1}]
+                  </span>{" "}
                   <span
                     role="img"
                     aria-label={emojiInfo.label}

--- a/src/components/visualizer/TimelineView.tsx
+++ b/src/components/visualizer/TimelineView.tsx
@@ -7,6 +7,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { computeTickInterval } from "@/lib/timelineTime";
 import { cn } from "@/lib/utils";
 import { useTraceStore } from "@/stores/traceStore";
 import type { FiberState, TraceEvent } from "@/types/trace";
@@ -198,8 +199,7 @@ function getSegmentColor(state: FiberState): string {
 // =============================================================================
 
 function TimeAxis({ duration }: { duration: number }) {
-  // Generate tick marks at reasonable intervals
-  const tickInterval = duration <= 1000 ? 200 : duration <= 3000 ? 500 : 1000;
+  const tickInterval = computeTickInterval(duration);
   const ticks: number[] = [];
   for (let t = 0; t <= duration; t += tickInterval) {
     ticks.push(t);
@@ -208,6 +208,7 @@ function TimeAxis({ duration }: { duration: number }) {
   // Format time label
   const formatTime = (ms: number) => {
     if (ms === 0) return "0s";
+    if (ms >= 10_000) return `${Math.round(ms / 1000)}s`;
     if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
     return `${ms}ms`;
   };
@@ -313,8 +314,10 @@ function FiberLaneRow({
 // =============================================================================
 
 export function TimelineView() {
-  const { events } = useTraceStore();
-  const [now, setNow] = useState(() => Date.now());
+  const { events, getVirtualNow } = useTraceStore();
+  // Virtual, not wall: event timestamps are virtual, so the live cursor has to
+  // be measured in the same units or the two disagree by a factor of the speed.
+  const [now, setNow] = useState(() => getVirtualNow());
 
   // Build timeline data
   const lanes = useMemo(() => buildTimelineSegments(events), [events]);
@@ -330,12 +333,15 @@ export function TimelineView() {
   useEffect(() => {
     if (!hasOngoingSegments) return;
 
+    // A `now` left over from a previous run yields a negative elapsed against
+    // the new first event, which the DEFAULT_DURATION_MS floor absorbs, so the
+    // first tick 50ms from now is soon enough.
     const interval = setInterval(() => {
-      setNow(Date.now());
+      setNow(getVirtualNow());
     }, 50);
 
     return () => clearInterval(interval);
-  }, [hasOngoingSegments]);
+  }, [hasOngoingSegments, getVirtualNow]);
 
   // Calculate time range
   const timeRange = useMemo(() => {

--- a/src/effects/app-lib-dts-urls.json
+++ b/src/effects/app-lib-dts-urls.json
@@ -4,6 +4,10 @@
     "path": "file:///types/trace.d.ts"
   },
   {
+    "url": "/app/runtime/controlChannel.d.ts",
+    "path": "file:///runtime/controlChannel.d.ts"
+  },
+  {
     "url": "/app/runtime/dateShim.d.ts",
     "path": "file:///runtime/dateShim.d.ts"
   },

--- a/src/effects/app-lib-dts-urls.json
+++ b/src/effects/app-lib-dts-urls.json
@@ -8,12 +8,20 @@
     "path": "file:///runtime/dateShim.d.ts"
   },
   {
+    "url": "/app/runtime/gatedScheduler.d.ts",
+    "path": "file:///runtime/gatedScheduler.d.ts"
+  },
+  {
     "url": "/app/runtime/index.d.ts",
     "path": "file:///runtime/index.d.ts"
   },
   {
     "url": "/app/runtime/runProgram.d.ts",
     "path": "file:///runtime/runProgram.d.ts"
+  },
+  {
+    "url": "/app/runtime/stepper.d.ts",
+    "path": "file:///runtime/stepper.d.ts"
   },
   {
     "url": "/app/runtime/traceEmitter.d.ts",

--- a/src/effects/app-lib-dts-urls.json
+++ b/src/effects/app-lib-dts-urls.json
@@ -4,6 +4,10 @@
     "path": "file:///types/trace.d.ts"
   },
   {
+    "url": "/app/runtime/dateShim.d.ts",
+    "path": "file:///runtime/dateShim.d.ts"
+  },
+  {
     "url": "/app/runtime/index.d.ts",
     "path": "file:///runtime/index.d.ts"
   },
@@ -18,6 +22,14 @@
   {
     "url": "/app/runtime/tracedRunner.d.ts",
     "path": "file:///runtime/tracedRunner.d.ts"
+  },
+  {
+    "url": "/app/runtime/virtualClock.d.ts",
+    "path": "file:///runtime/virtualClock.d.ts"
+  },
+  {
+    "url": "/app/runtime/vizClock.d.ts",
+    "path": "file:///runtime/vizClock.d.ts"
   },
   {
     "url": "/app/runtime/vizSupervisor.d.ts",

--- a/src/effects/app-lib-dts-urls.json
+++ b/src/effects/app-lib-dts-urls.json
@@ -32,6 +32,10 @@
     "path": "file:///runtime/traceEmitter.d.ts"
   },
   {
+    "url": "/app/runtime/traceOrigin.d.ts",
+    "path": "file:///runtime/traceOrigin.d.ts"
+  },
+  {
     "url": "/app/runtime/tracedRunner.d.ts",
     "path": "file:///runtime/tracedRunner.d.ts"
   },

--- a/src/effects/spawnAndParse.ts
+++ b/src/effects/spawnAndParse.ts
@@ -9,11 +9,12 @@ import {
   CONTROL_REPLY_PREFIX,
   type ControlCommand,
   type ControlReply,
+  decodeCommand,
   decodeReply,
   encodeCommand,
 } from "@/runtime/controlChannel";
 import { WebContainer } from "@/services/webcontainer";
-import type { TraceEvent } from "@/types/trace";
+import type { TraceEvent, TraceOrigin } from "@/types/trace";
 
 const TRACE_EVENT_PREFIX = "TRACE_EVENT:";
 const PERF_PREFIX = "PERF:";
@@ -91,7 +92,7 @@ export function spawnAndParseTraceEvents({
 }: {
   callbacks: SpawnAndParseCallbacks;
   onFirstChunk: () => void;
-  onStdout?: (line: string) => void;
+  onStdout?: (line: string, origin: TraceOrigin) => void;
   /** Virtual ms per wall ms, read by runner.js. Fixed for the life of the process. */
   rate: number;
   /** Gate the runtime before the program runs, so its first step is the user's. */
@@ -190,11 +191,19 @@ export function spawnAndParseTraceEvents({
             if (reply !== null) control?.handleReply(reply);
             return;
           }
+          // Every process gets a pseudoterminal, and a terminal echoes what is
+          // written to it, so each command we send comes straight back here.
+          // Nothing else writes to this stdin, so a line that decodes as a
+          // command is one of ours rather than the program's output.
+          if (decodeCommand(line) !== null) {
+            onStdout?.(line, "tool");
+            return;
+          }
           // Anything left that is not a trace event comes from something else
           // writing to stdout inside the container (Node errors, stack traces,
           // the program's own console.log).
           if (line.startsWith(TRACE_EVENT_PREFIX) || line.trim() === "") return;
-          onStdout?.(line);
+          onStdout?.(line, "program");
         }),
       ),
       Stream.filterMap((line) => Option.fromNullable(parseTraceEvent(line))),

--- a/src/effects/spawnAndParse.ts
+++ b/src/effects/spawnAndParse.ts
@@ -67,10 +67,13 @@ export function spawnAndParseTraceEvents({
   callbacks,
   onFirstChunk,
   onStdout,
+  rate,
 }: {
   callbacks: SpawnAndParseCallbacks;
   onFirstChunk: () => void;
   onStdout?: (line: string) => void;
+  /** Virtual ms per wall ms, read by runner.js. Fixed for the life of the process. */
+  rate: number;
 }) {
   return Effect.gen(function* () {
     const wc = yield* WebContainer;
@@ -81,7 +84,10 @@ export function spawnAndParseTraceEvents({
 
     const spawnOptions = {
       output: true as const,
-      ...(isPerfPlayEnabled() && { env: { PERF_PLAY: "1" } }),
+      env: {
+        VIZ_RATE: String(rate),
+        ...(isPerfPlayEnabled() && { PERF_PLAY: "1" }),
+      },
     };
     const proc = yield* Effect.acquireRelease(
       wc.spawn("node", ["--enable-source-maps", "runner.js"], spawnOptions),

--- a/src/effects/spawnAndParse.ts
+++ b/src/effects/spawnAndParse.ts
@@ -5,6 +5,13 @@
  */
 import { Duration, Effect, Option, Ref, Stream } from "effect";
 
+import {
+  CONTROL_REPLY_PREFIX,
+  type ControlCommand,
+  type ControlReply,
+  decodeReply,
+  encodeCommand,
+} from "@/runtime/controlChannel";
 import { WebContainer } from "@/services/webcontainer";
 import type { TraceEvent } from "@/types/trace";
 
@@ -54,6 +61,17 @@ export interface SpawnAndParseCallbacks {
 }
 
 /**
+ * Whoever drives pause, resume and step for this process. Held for the life of
+ * the process: `attach` when its stdin is writable, `detach` when it is gone, so
+ * a click landing between runs is dropped rather than sent into a dead pipe.
+ */
+export interface ControlSink {
+  attach: (send: (command: ControlCommand) => void) => void;
+  handleReply: (reply: ControlReply) => void;
+  detach: () => void;
+}
+
+/**
  * Spawn pnpm exec tsx program.ts, parse TRACE_EVENT lines from stdout,
  * and push to the provided callbacks.
  *
@@ -68,12 +86,17 @@ export function spawnAndParseTraceEvents({
   onFirstChunk,
   onStdout,
   rate,
+  startPaused = false,
+  control,
 }: {
   callbacks: SpawnAndParseCallbacks;
   onFirstChunk: () => void;
   onStdout?: (line: string) => void;
   /** Virtual ms per wall ms, read by runner.js. Fixed for the life of the process. */
   rate: number;
+  /** Gate the runtime before the program runs, so its first step is the user's. */
+  startPaused?: boolean;
+  control?: ControlSink;
 }) {
   return Effect.gen(function* () {
     const wc = yield* WebContainer;
@@ -86,6 +109,7 @@ export function spawnAndParseTraceEvents({
       output: true as const,
       env: {
         VIZ_RATE: String(rate),
+        ...(startPaused && { VIZ_START_PAUSED: "1" }),
         ...(isPerfPlayEnabled() && { PERF_PLAY: "1" }),
       },
     };
@@ -93,6 +117,29 @@ export function spawnAndParseTraceEvents({
       wc.spawn("node", ["--enable-source-maps", "runner.js"], spawnOptions),
       (p) => Effect.sync(() => p.kill()),
     );
+
+    if (control !== undefined) {
+      yield* Effect.acquireRelease(
+        Effect.sync(() => {
+          const writer = proc.input.getWriter();
+          control.attach((command) => {
+            // A command racing the end of a run finds a closed pipe. There is
+            // nothing to do about it: the run it was meant for is over.
+            void writer.write(encodeCommand(command)).catch(() => {});
+          });
+          return writer;
+        }),
+        (writer) =>
+          Effect.sync(() => {
+            control.detach();
+            try {
+              writer.releaseLock();
+            } catch {
+              // The stream went with the process; the lock went with it.
+            }
+          }),
+      );
+    }
 
     const t1 = performance.now();
     logPerf("t1 (spawn returned)", t0, t1);
@@ -125,25 +172,30 @@ export function spawnAndParseTraceEvents({
       Stream.mapConcat((chunk) => chunk.split("\n")),
     );
     const traceStream = lineStream.pipe(
-      // Any line not starting with TRACE_EVENT or PERF comes from something writing
-      // to stdout inside the container (e.g. Node errors, stack traces, user's console.log).
       Stream.tap((line) =>
-        line.startsWith(PERF_PREFIX)
-          ? Effect.sync(() => {
-              const rest = line.slice(PERF_PREFIX.length).trim();
-              const spaceIdx = rest.indexOf(" ");
-              const label = spaceIdx >= 0 ? rest.slice(0, spaceIdx) : rest;
-              const ts = spaceIdx >= 0 ? rest.slice(spaceIdx + 1).trim() : "";
-              const t1 = ts ? Number.parseFloat(ts) : undefined;
-              if (t1 !== undefined && !Number.isNaN(t1)) {
-                logPerf(`[container] ${label}`, 0, t1);
-              }
-            })
-          : line.startsWith(TRACE_EVENT_PREFIX) || line.trim() === ""
-            ? Effect.void
-            : Effect.sync(() => {
-                onStdout?.(line);
-              }),
+        Effect.sync(() => {
+          if (line.startsWith(PERF_PREFIX)) {
+            const rest = line.slice(PERF_PREFIX.length).trim();
+            const spaceIdx = rest.indexOf(" ");
+            const label = spaceIdx >= 0 ? rest.slice(0, spaceIdx) : rest;
+            const ts = spaceIdx >= 0 ? rest.slice(spaceIdx + 1).trim() : "";
+            const t1 = ts ? Number.parseFloat(ts) : undefined;
+            if (t1 !== undefined && !Number.isNaN(t1)) {
+              logPerf(`[container] ${label}`, 0, t1);
+            }
+            return;
+          }
+          if (line.startsWith(CONTROL_REPLY_PREFIX)) {
+            const reply = decodeReply(line);
+            if (reply !== null) control?.handleReply(reply);
+            return;
+          }
+          // Anything left that is not a trace event comes from something else
+          // writing to stdout inside the container (Node errors, stack traces,
+          // the program's own console.log).
+          if (line.startsWith(TRACE_EVENT_PREFIX) || line.trim() === "") return;
+          onStdout?.(line);
+        }),
       ),
       Stream.filterMap((line) => Option.fromNullable(parseTraceEvent(line))),
     );

--- a/src/hooks/useEventHandlers.ts
+++ b/src/hooks/useEventHandlers.ts
@@ -18,9 +18,11 @@ export interface WebContainerBridge {
   runPlay: ({
     callbacks,
     onFirstChunk,
+    rate,
   }: {
     callbacks: SpawnAndParseCallbacks;
     onFirstChunk: () => void;
+    rate: number;
   }) => Promise<{
     success: boolean;
     exitCode?: number;
@@ -39,7 +41,14 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
     null,
   );
 
-  const handlePlay = ({ onFirstChunk }: { onFirstChunk: () => void }) => {
+  const handlePlay = ({
+    onFirstChunk,
+    rate,
+  }: {
+    onFirstChunk: () => void;
+    /** Virtual ms per wall ms. Fixed for the run: see PlaybackControls. */
+    rate: number;
+  }) => {
     clearEvents();
     clearFibers();
 
@@ -51,6 +60,7 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
             processEvent,
           },
           onFirstChunk,
+          rate,
         })
         .then((result) => {
           if (!result.success) {
@@ -60,10 +70,16 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
         });
     }
 
-    return runFallbackPlay({ onFirstChunk });
+    return runFallbackPlay({ onFirstChunk, rate });
   };
 
-  function runFallbackPlay({ onFirstChunk }: { onFirstChunk: () => void }) {
+  function runFallbackPlay({
+    onFirstChunk,
+    rate,
+  }: {
+    onFirstChunk: () => void;
+    rate: number;
+  }) {
     const { rootEffect, requirements } = programs[selectedProgram];
     const scoped = Effect.scoped(
       rootEffect as Effect.Effect<unknown, unknown, unknown>,
@@ -73,8 +89,8 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
       processEvent(event); // For FiberTreeView
     };
     // Same virtual clock as the WebContainer path, so both record virtual
-    // timestamps. Rate is fixed at 1 until the speed control is wired.
-    const virtualClock = new VirtualClock();
+    // timestamps and slow down identically.
+    const virtualClock = new VirtualClock({ rate });
     const now = () => virtualClock.now();
     const traceLayer = makeTraceEmitterLayer(onEmit);
     const supervisorLayer = makeVizLayers(onEmit, now);

--- a/src/hooks/useEventHandlers.ts
+++ b/src/hooks/useEventHandlers.ts
@@ -34,7 +34,12 @@ export interface WebContainerBridge {
 }
 
 export function useEventHandlers(webContainer?: WebContainerBridge | null) {
-  const { addEvent, clear: clearEvents, setRate } = useTraceStore();
+  const {
+    addEvent,
+    clear: clearEvents,
+    setRate,
+    setNowSource,
+  } = useTraceStore();
   const { processEvent, clear: clearFibers } = useFiberStore();
   const { addLog } = useWebContainerLogsStore();
 
@@ -78,6 +83,8 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
     setRate(rate);
 
     if (webContainer?.isReady) {
+      // No clock to read on this path: the program runs in another process.
+      setNowSource(null);
       stepperRef.current = null;
       return webContainer
         .runPlay({
@@ -144,6 +151,9 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
         runningFiberRef.current.unsafePoll() !== null,
     });
     stepperRef.current = stepper;
+    // The timeline follows this clock directly, so it freezes when the stepper
+    // does and jumps when a step moves virtual time.
+    setNowSource(() => virtualClock.now());
     // Gate before the program is forked, so even its first task is held.
     if (startPaused) stepper.pause();
     const now = () => virtualClock.now();

--- a/src/hooks/useEventHandlers.ts
+++ b/src/hooks/useEventHandlers.ts
@@ -50,18 +50,24 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
    */
   const runIdRef = useRef(0);
   /**
-   * Only the in-browser path can be stepped. The WebContainer runs the program
+   * Only the in-browser path can be stepped: the WebContainer runs the program
    * in another process, which needs a control channel we do not have yet.
+   *
+   * Derived rather than set when a run starts, because Step can *begin* a run —
+   * the button has to know before there is anything to step.
    */
-  const [supportsStepping, setSupportsStepping] = useState(false);
+  const supportsStepping = !webContainer?.isReady;
 
   const handlePlay = ({
     onFirstChunk,
     rate,
+    startPaused = false,
   }: {
     onFirstChunk: () => void;
     /** Virtual ms per wall ms. Fixed for the run: see PlaybackControls. */
     rate: number;
+    /** Gate the scheduler before the program runs, so its first step is yours. */
+    startPaused?: boolean;
   }) => {
     const runId = ++runIdRef.current;
     const isCurrentRun = () => runIdRef.current === runId;
@@ -72,7 +78,6 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
     setRate(rate);
 
     if (webContainer?.isReady) {
-      setSupportsStepping(false);
       stepperRef.current = null;
       return webContainer
         .runPlay({
@@ -95,22 +100,32 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
         });
     }
 
-    return runFallbackPlay({ onFirstChunk, rate, isCurrentRun });
+    return runFallbackPlay({ onFirstChunk, rate, isCurrentRun, startPaused });
   };
 
   function runFallbackPlay({
     onFirstChunk,
     rate,
     isCurrentRun,
+    startPaused,
   }: {
     onFirstChunk: () => void;
     rate: number;
     isCurrentRun: () => boolean;
+    startPaused: boolean;
   }) {
     const { rootEffect, requirements } = programs[selectedProgram];
-    const scoped = Effect.scoped(
-      rootEffect as Effect.Effect<unknown, unknown, unknown>,
-    );
+    // `Effect.runFork` runs a fiber synchronously until its first yield, and the
+    // scheduler only governs resumption. Yielding first therefore hands the very
+    // first operation to the gate, so a paused start can be stepped from event
+    // one instead of after the opening burst.
+    const body = startPaused
+      ? Effect.zipRight(
+          Effect.yieldNow(),
+          rootEffect as Effect.Effect<unknown, unknown, unknown>,
+        )
+      : (rootEffect as Effect.Effect<unknown, unknown, unknown>);
+    const scoped = Effect.scoped(body);
     const onEmit = (event: TraceEvent) => {
       if (!isCurrentRun()) return;
       addEvent(event); // For ExecutionLog
@@ -129,7 +144,8 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
         runningFiberRef.current.unsafePoll() !== null,
     });
     stepperRef.current = stepper;
-    setSupportsStepping(true);
+    // Gate before the program is forked, so even its first task is held.
+    if (startPaused) stepper.pause();
     const now = () => virtualClock.now();
     const traceLayer = makeTraceEmitterLayer(onEmit);
     const supervisorLayer = makeVizLayers(onEmit, now);
@@ -183,7 +199,6 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
     }
     stepperRef.current?.reset();
     stepperRef.current = null;
-    setSupportsStepping(false);
     clearEvents();
     clearFibers();
   };

--- a/src/hooks/useEventHandlers.ts
+++ b/src/hooks/useEventHandlers.ts
@@ -12,6 +12,7 @@ import { GatedScheduler } from "@/runtime/gatedScheduler";
 import { runProgramFork } from "@/runtime/runProgram";
 import { Stepper, type StepOutcome } from "@/runtime/stepper";
 import { makeTraceEmitterLayer } from "@/runtime/tracedRunner";
+import { makeOriginTagger } from "@/runtime/traceOrigin";
 import { VirtualClock } from "@/runtime/virtualClock";
 import { makeVizClockLayer } from "@/runtime/vizClock";
 import { makeVizLayers } from "@/runtime/vizSupervisor";
@@ -170,10 +171,14 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
         )
       : (rootEffect as Effect.Effect<unknown, unknown, unknown>);
     const scoped = Effect.scoped(body);
+    // A paused start injects a yield the program never wrote; the tagger marks
+    // the suspend and resume it produces so the log can offer to hide them.
+    const tagOrigin = makeOriginTagger({ startPaused });
     const onEmit = (event: TraceEvent) => {
       if (!isCurrentRun()) return;
-      addEvent(event); // For ExecutionLog
-      processEvent(event); // For FiberTreeView
+      const tagged = tagOrigin(event);
+      addEvent(tagged); // For ExecutionLog
+      processEvent(tagged); // For FiberTreeView
       stepperRef.current?.noteEvent(); // A step runs until this moves
     };
     // Same virtual clock as the WebContainer path, so both record virtual

--- a/src/hooks/useEventHandlers.ts
+++ b/src/hooks/useEventHandlers.ts
@@ -3,7 +3,9 @@ import { useRef, useState } from "react";
 
 import type { SpawnAndParseCallbacks } from "@/effects/spawnAndParse";
 import { type ProgramKey, makeLoggerLayer, programs } from "@/lib/programs";
+import { GatedScheduler } from "@/runtime/gatedScheduler";
 import { runProgramFork } from "@/runtime/runProgram";
+import { Stepper, type StepOutcome } from "@/runtime/stepper";
 import { makeTraceEmitterLayer } from "@/runtime/tracedRunner";
 import { VirtualClock } from "@/runtime/virtualClock";
 import { makeVizClockLayer } from "@/runtime/vizClock";
@@ -40,6 +42,18 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
   const runningFiberRef = useRef<Fiber.RuntimeFiber<unknown, unknown> | null>(
     null,
   );
+  const stepperRef = useRef<Stepper | null>(null);
+  /**
+   * Identifies the current run. Interrupting a program emits trace events of its
+   * own, and they arrive after Reset has already cleared the stores, so events
+   * from a run that is no longer current are dropped.
+   */
+  const runIdRef = useRef(0);
+  /**
+   * Only the in-browser path can be stepped. The WebContainer runs the program
+   * in another process, which needs a control channel we do not have yet.
+   */
+  const [supportsStepping, setSupportsStepping] = useState(false);
 
   const handlePlay = ({
     onFirstChunk,
@@ -49,17 +63,26 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
     /** Virtual ms per wall ms. Fixed for the run: see PlaybackControls. */
     rate: number;
   }) => {
+    const runId = ++runIdRef.current;
+    const isCurrentRun = () => runIdRef.current === runId;
+
     clearEvents();
     clearFibers();
     // The timeline's live cursor advances at this rate; see computeVirtualNow.
     setRate(rate);
 
     if (webContainer?.isReady) {
+      setSupportsStepping(false);
+      stepperRef.current = null;
       return webContainer
         .runPlay({
           callbacks: {
-            addEvent,
-            processEvent,
+            addEvent: (event) => {
+              if (isCurrentRun()) addEvent(event);
+            },
+            processEvent: (event) => {
+              if (isCurrentRun()) processEvent(event);
+            },
           },
           onFirstChunk,
           rate,
@@ -72,27 +95,41 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
         });
     }
 
-    return runFallbackPlay({ onFirstChunk, rate });
+    return runFallbackPlay({ onFirstChunk, rate, isCurrentRun });
   };
 
   function runFallbackPlay({
     onFirstChunk,
     rate,
+    isCurrentRun,
   }: {
     onFirstChunk: () => void;
     rate: number;
+    isCurrentRun: () => boolean;
   }) {
     const { rootEffect, requirements } = programs[selectedProgram];
     const scoped = Effect.scoped(
       rootEffect as Effect.Effect<unknown, unknown, unknown>,
     );
     const onEmit = (event: TraceEvent) => {
+      if (!isCurrentRun()) return;
       addEvent(event); // For ExecutionLog
       processEvent(event); // For FiberTreeView
+      stepperRef.current?.noteEvent(); // A step runs until this moves
     };
     // Same virtual clock as the WebContainer path, so both record virtual
     // timestamps and slow down identically.
     const virtualClock = new VirtualClock({ rate });
+    const scheduler = new GatedScheduler();
+    const stepper = new Stepper({
+      scheduler,
+      clock: virtualClock,
+      isFinished: () =>
+        runningFiberRef.current !== null &&
+        runningFiberRef.current.unsafePoll() !== null,
+    });
+    stepperRef.current = stepper;
+    setSupportsStepping(true);
     const now = () => virtualClock.now();
     const traceLayer = makeTraceEmitterLayer(onEmit);
     const supervisorLayer = makeVizLayers(onEmit, now);
@@ -112,11 +149,10 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
     );
 
     onFirstChunk(); // No compile step on mobile; program runs immediately
-    const program = scoped.pipe(Effect.provide(allLayers)) as Effect.Effect<
-      unknown,
-      unknown,
-      never
-    >;
+    const program = scoped.pipe(
+      Effect.withScheduler(scheduler),
+      Effect.provide(allLayers),
+    ) as Effect.Effect<unknown, unknown, never>;
     const { fiber, promise } = runProgramFork(program, onEmit, now);
     runningFiberRef.current = fiber;
 
@@ -135,19 +171,41 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
   }
 
   const handleReset = () => {
+    runIdRef.current++;
     if (webContainer?.isReady) {
       webContainer.interruptPlay();
     } else if (runningFiberRef.current) {
+      // Interruption reaches a fiber as a task, so a gated program cannot be
+      // torn down: the scheduler has to be running first.
+      stepperRef.current?.play();
       Effect.runPromise(Fiber.interrupt(runningFiberRef.current));
       runningFiberRef.current = null;
     }
+    stepperRef.current?.reset();
+    stepperRef.current = null;
+    setSupportsStepping(false);
     clearEvents();
     clearFibers();
   };
 
+  const handlePause = () => {
+    stepperRef.current?.pause();
+  };
+
+  const handleResume = () => {
+    stepperRef.current?.play();
+  };
+
+  const handleStep = (): StepOutcome | null =>
+    stepperRef.current?.step() ?? null;
+
   return {
     handlePlay,
     handleReset,
+    handlePause,
+    handleResume,
+    handleStep,
+    supportsStepping,
     selectedProgram,
     setSelectedProgram,
     programs,

--- a/src/hooks/useEventHandlers.ts
+++ b/src/hooks/useEventHandlers.ts
@@ -32,7 +32,7 @@ export interface WebContainerBridge {
 }
 
 export function useEventHandlers(webContainer?: WebContainerBridge | null) {
-  const { addEvent, clear: clearEvents } = useTraceStore();
+  const { addEvent, clear: clearEvents, setRate } = useTraceStore();
   const { processEvent, clear: clearFibers } = useFiberStore();
   const { addLog } = useWebContainerLogsStore();
 
@@ -51,6 +51,8 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
   }) => {
     clearEvents();
     clearFibers();
+    // The timeline's live cursor advances at this rate; see computeVirtualNow.
+    setRate(rate);
 
     if (webContainer?.isReady) {
       return webContainer

--- a/src/hooks/useEventHandlers.ts
+++ b/src/hooks/useEventHandlers.ts
@@ -5,6 +5,8 @@ import type { SpawnAndParseCallbacks } from "@/effects/spawnAndParse";
 import { type ProgramKey, makeLoggerLayer, programs } from "@/lib/programs";
 import { runProgramFork } from "@/runtime/runProgram";
 import { makeTraceEmitterLayer } from "@/runtime/tracedRunner";
+import { VirtualClock } from "@/runtime/virtualClock";
+import { makeVizClockLayer } from "@/runtime/vizClock";
 import { makeVizLayers } from "@/runtime/vizSupervisor";
 import { makeVizTracer } from "@/runtime/vizTracer";
 import { useFiberStore } from "@/stores/fiberStore";
@@ -70,17 +72,23 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
       addEvent(event); // For ExecutionLog
       processEvent(event); // For FiberTreeView
     };
+    // Same virtual clock as the WebContainer path, so both record virtual
+    // timestamps. Rate is fixed at 1 until the speed control is wired.
+    const virtualClock = new VirtualClock();
+    const now = () => virtualClock.now();
     const traceLayer = makeTraceEmitterLayer(onEmit);
-    const supervisorLayer = makeVizLayers(onEmit);
+    const supervisorLayer = makeVizLayers(onEmit, now);
     // Fallback Logger layer: logs to panel (addLog) instead of console, so mobile users see output
     const fallbackLoggerLayer = makeLoggerLayer((msg) =>
       addLog("output", `[logger] ${msg}`),
     );
-    const tracerLayer = Layer.setTracer(makeVizTracer(onEmit));
+    const tracerLayer = Layer.setTracer(makeVizTracer(onEmit, now));
+    const clockLayer = makeVizClockLayer(virtualClock);
     const allLayers = Layer.mergeAll(
       traceLayer,
       supervisorLayer,
       tracerLayer,
+      clockLayer,
       ...requirements,
       fallbackLoggerLayer,
     );
@@ -91,7 +99,7 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
       unknown,
       never
     >;
-    const { fiber, promise } = runProgramFork(program, onEmit);
+    const { fiber, promise } = runProgramFork(program, onEmit, now);
     runningFiberRef.current = fiber;
 
     return promise.then(

--- a/src/hooks/useEventHandlers.ts
+++ b/src/hooks/useEventHandlers.ts
@@ -1,7 +1,12 @@
 import { Effect, Fiber, Layer } from "effect";
 import { useRef, useState } from "react";
 
-import type { SpawnAndParseCallbacks } from "@/effects/spawnAndParse";
+import type {
+  ControlSink,
+  SpawnAndParseCallbacks,
+} from "@/effects/spawnAndParse";
+import { ContainerController } from "@/lib/containerController";
+import { MirroredClock } from "@/lib/mirroredClock";
 import { type ProgramKey, makeLoggerLayer, programs } from "@/lib/programs";
 import { GatedScheduler } from "@/runtime/gatedScheduler";
 import { runProgramFork } from "@/runtime/runProgram";
@@ -21,10 +26,14 @@ export interface WebContainerBridge {
     callbacks,
     onFirstChunk,
     rate,
+    startPaused,
+    control,
   }: {
     callbacks: SpawnAndParseCallbacks;
     onFirstChunk: () => void;
     rate: number;
+    startPaused?: boolean;
+    control?: ControlSink;
   }) => Promise<{
     success: boolean;
     exitCode?: number;
@@ -49,20 +58,19 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
   );
   const stepperRef = useRef<Stepper | null>(null);
   /**
+   * The container's half of the same three verbs. Outlives a single run — it is
+   * attached when a process starts and detached when it exits.
+   */
+  const containerRef = useRef<ContainerController>(null);
+  containerRef.current ??= new ContainerController();
+  /** The page's model of the container's clock; null on the in-browser path, which reads the real one. */
+  const mirrorRef = useRef<MirroredClock | null>(null);
+  /**
    * Identifies the current run. Interrupting a program emits trace events of its
    * own, and they arrive after Reset has already cleared the stores, so events
    * from a run that is no longer current are dropped.
    */
   const runIdRef = useRef(0);
-  /**
-   * Only the in-browser path can be stepped: the WebContainer runs the program
-   * in another process, which needs a control channel we do not have yet.
-   *
-   * Derived rather than set when a run starts, because Step can *begin* a run —
-   * the button has to know before there is anything to step.
-   */
-  const supportsStepping = !webContainer?.isReady;
-
   const handlePlay = ({
     onFirstChunk,
     rate,
@@ -83,14 +91,41 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
     setRate(rate);
 
     if (webContainer?.isReady) {
-      // No clock to read on this path: the program runs in another process.
-      setNowSource(null);
       stepperRef.current = null;
+      const controller = containerRef.current;
+      // The real clock is in the other process, so the timeline follows a model
+      // of it, corrected by every virtual reading that comes back.
+      const mirror = new MirroredClock(rate);
+      mirrorRef.current = mirror;
+      setNowSource(() => mirror.now());
+      if (startPaused) mirror.pause();
+
+      const control: ControlSink = {
+        attach: (send) => controller?.attach(send),
+        handleReply: (reply) => {
+          mirror.sync(reply.virtualNow);
+          // Resuming is driven by the reply rather than by the click: the
+          // container keeps running for the length of a round trip either way,
+          // and a model resumed early would run ahead of it for good, since
+          // corrections only move the cursor forward.
+          if (reply.reply === "resume") mirror.resume();
+          controller?.handleReply(reply);
+        },
+        detach: () => controller?.detach(),
+      };
+
       return webContainer
         .runPlay({
           callbacks: {
             addEvent: (event) => {
-              if (isCurrentRun()) addEvent(event);
+              if (!isCurrentRun()) return;
+              // Every event timestamp is a virtual reading taken in the
+              // container, so the model is corrected continuously while a
+              // program runs, not only when a command is sent.
+              if (typeof event.timestamp === "number") {
+                mirror.sync(event.timestamp);
+              }
+              addEvent(event);
             },
             processEvent: (event) => {
               if (isCurrentRun()) processEvent(event);
@@ -98,6 +133,8 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
           },
           onFirstChunk,
           rate,
+          startPaused,
+          control,
         })
         .then((result) => {
           if (!result.success) {
@@ -200,6 +237,7 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
     runIdRef.current++;
     if (webContainer?.isReady) {
       webContainer.interruptPlay();
+      mirrorRef.current = null;
     } else if (runningFiberRef.current) {
       // Interruption reaches a fiber as a task, so a gated program cannot be
       // torn down: the scheduler has to be running first.
@@ -213,16 +251,37 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
     clearFibers();
   };
 
+  /**
+   * Pause, resume and step reach the runtime directly in the browser and as
+   * messages in the container, so a step is a promise on both paths: one that is
+   * already settled, and one that waits for a round trip.
+   */
   const handlePause = () => {
+    if (webContainer?.isReady) {
+      // Frozen on the click rather than on the reply, so the cursor stops when
+      // the user expects. The container runs on for a round trip, and the
+      // reply's reading corrects the cursor forward to meet it.
+      mirrorRef.current?.pause();
+      containerRef.current?.pause();
+      return;
+    }
     stepperRef.current?.pause();
   };
 
   const handleResume = () => {
+    if (webContainer?.isReady) {
+      containerRef.current?.play();
+      return;
+    }
     stepperRef.current?.play();
   };
 
-  const handleStep = (): StepOutcome | null =>
-    stepperRef.current?.step() ?? null;
+  const handleStep = async (): Promise<StepOutcome | null> => {
+    if (webContainer?.isReady) {
+      return (await containerRef.current?.step()) ?? null;
+    }
+    return stepperRef.current?.step() ?? null;
+  };
 
   return {
     handlePlay,
@@ -230,7 +289,6 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
     handlePause,
     handleResume,
     handleStep,
-    supportsStepping,
     selectedProgram,
     setSelectedProgram,
     programs,

--- a/src/hooks/useShowInternals.ts
+++ b/src/hooks/useShowInternals.ts
@@ -1,0 +1,54 @@
+/**
+ * Whether the visualizer shows what *it* is doing, alongside what the program
+ * does.
+ *
+ * Two panels have something to hide. The Execution Log carries the suspend and
+ * resume pair produced by the yield injected into a paused start; the console
+ * carries the control commands the page sends the container, echoed back by the
+ * process's terminal. From the user's side that is one question — am I looking
+ * at my program, or at the tool — so it is one preference rather than a
+ * checkbox in each panel.
+ *
+ * Kept outside React because both panels ask independently and must agree. The
+ * answer survives a reload: someone who turned the internals on is usually
+ * looking into how the thing works, and will want them again.
+ */
+import { useSyncExternalStore } from "react";
+
+const STORAGE_KEY = "effect-flow-show-internals";
+
+function readStored(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "true";
+  } catch {
+    // Private browsing: the preference simply does not persist.
+    return false;
+  }
+}
+
+let showInternals = readStored();
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot(): boolean {
+  return showInternals;
+}
+
+export function setShowInternals(next: boolean): void {
+  if (next === showInternals) return;
+  showInternals = next;
+  try {
+    localStorage.setItem(STORAGE_KEY, String(next));
+  } catch {
+    // As above: the toggle still works for this session.
+  }
+  for (const listener of listeners) listener();
+}
+
+export function useShowInternals(): [boolean, (next: boolean) => void] {
+  return [useSyncExternalStore(subscribe, getSnapshot), setShowInternals];
+}

--- a/src/hooks/useSpeed.ts
+++ b/src/hooks/useSpeed.ts
@@ -1,0 +1,52 @@
+import { useCallback, useState } from "react";
+
+/**
+ * Playback speed, in virtual milliseconds per wall millisecond.
+ *
+ * 1 is real time; lower values stretch the program's own sense of time so every
+ * sleep, timeout and schedule delay scales by the same factor. See
+ * `workshop/phase-10.md`.
+ */
+export const SPEED_OPTIONS = [1, 0.75, 0.5, 0.25] as const;
+
+export type Speed = (typeof SPEED_OPTIONS)[number];
+
+export const DEFAULT_SPEED: Speed = 1;
+
+const STORAGE_KEY = "effect-flow-speed";
+
+function isSpeed(value: unknown): value is Speed {
+  return SPEED_OPTIONS.some((option) => option === value);
+}
+
+function readStored(): Speed {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw == null) return DEFAULT_SPEED;
+    const parsed: unknown = JSON.parse(raw);
+    return isSpeed(parsed) ? parsed : DEFAULT_SPEED;
+  } catch {
+    return DEFAULT_SPEED;
+  }
+}
+
+/** Speed survives a reload: someone who chose 0.25x wants it on the next run too. */
+export function useSpeed(): [Speed, (speed: Speed) => void] {
+  const [speed, setSpeedState] = useState<Speed>(readStored);
+
+  const setSpeed = useCallback((next: Speed) => {
+    setSpeedState(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    } catch {
+      // Private browsing or a full quota: the speed simply will not persist.
+    }
+  }, []);
+
+  return [speed, setSpeed];
+}
+
+/** `0.25` → `"0.25x"` */
+export function formatSpeed(speed: Speed): string {
+  return `${speed}x`;
+}

--- a/src/hooks/useWebContainerBoot.ts
+++ b/src/hooks/useWebContainerBoot.ts
@@ -159,7 +159,8 @@ export function useWebContainerBoot() {
         spawnAndParseTraceEvents({
           callbacks,
           onFirstChunk,
-          onStdout: (line) => addLog("output", line),
+          onStdout: (line, origin) =>
+            addLog(origin === "tool" ? "control" : "output", line),
           rate,
           startPaused,
           control,

--- a/src/hooks/useWebContainerBoot.ts
+++ b/src/hooks/useWebContainerBoot.ts
@@ -137,9 +137,11 @@ export function useWebContainerBoot() {
     ({
       callbacks,
       onFirstChunk,
+      rate,
     }: {
       callbacks: SpawnAndParseCallbacks;
       onFirstChunk: () => void;
+      rate: number;
     }): Promise<{ success: boolean; exitCode?: number }> => {
       const handle = handleRef.current;
       if (!handle || status !== "ready") {
@@ -153,6 +155,7 @@ export function useWebContainerBoot() {
           callbacks,
           onFirstChunk,
           onStdout: (line) => addLog("output", line),
+          rate,
         }).pipe(Effect.provide(layer)),
       );
       // Use runFork (not scoped fork): scoped(fork(program)) closes the scope

--- a/src/hooks/useWebContainerBoot.ts
+++ b/src/hooks/useWebContainerBoot.ts
@@ -6,6 +6,7 @@ import { Effect, Fiber, Layer } from "effect";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
+  type ControlSink,
   spawnAndParseTraceEvents,
   type SpawnAndParseCallbacks,
 } from "@/effects/spawnAndParse";
@@ -138,10 +139,14 @@ export function useWebContainerBoot() {
       callbacks,
       onFirstChunk,
       rate,
+      startPaused = false,
+      control,
     }: {
       callbacks: SpawnAndParseCallbacks;
       onFirstChunk: () => void;
       rate: number;
+      startPaused?: boolean;
+      control?: ControlSink;
     }): Promise<{ success: boolean; exitCode?: number }> => {
       const handle = handleRef.current;
       if (!handle || status !== "ready") {
@@ -156,6 +161,8 @@ export function useWebContainerBoot() {
           onFirstChunk,
           onStdout: (line) => addLog("output", line),
           rate,
+          startPaused,
+          control,
         }).pipe(Effect.provide(layer)),
       );
       // Use runFork (not scoped fork): scoped(fork(program)) closes the scope

--- a/src/lib/containerController.test.ts
+++ b/src/lib/containerController.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { ContainerController } from "@/lib/containerController";
+import type { ControlCommand } from "@/runtime/controlChannel";
+
+function setup() {
+  const controller = new ContainerController();
+  const sent: ControlCommand[] = [];
+  controller.attach((command) => sent.push(command));
+  return { controller, sent };
+}
+
+describe("ContainerController", () => {
+  it("sends pause and resume without waiting for an answer", () => {
+    const { controller, sent } = setup();
+
+    controller.pause();
+    controller.play();
+
+    expect(sent).toEqual([{ cmd: "pause" }, { cmd: "resume" }]);
+  });
+
+  it("resolves a step with the outcome the container reports", async () => {
+    const { controller, sent } = setup();
+
+    const stepped = controller.step();
+    expect(sent).toEqual([{ cmd: "step" }]);
+    controller.handleReply({
+      reply: "step",
+      virtualNow: 10,
+      outcome: { _tag: "released", tasks: 2 },
+    });
+
+    await expect(stepped).resolves.toEqual({ _tag: "released", tasks: 2 });
+  });
+
+  it("answers steps in the order they were sent", async () => {
+    const { controller } = setup();
+
+    const first = controller.step();
+    const second = controller.step();
+    controller.handleReply({
+      reply: "step",
+      virtualNow: 1,
+      outcome: { _tag: "released", tasks: 1 },
+    });
+    controller.handleReply({
+      reply: "step",
+      virtualNow: 2,
+      outcome: { _tag: "noProgress" },
+    });
+
+    await expect(first).resolves.toEqual({ _tag: "released", tasks: 1 });
+    await expect(second).resolves.toEqual({ _tag: "noProgress" });
+  });
+
+  it("ignores replies that are not answers to a step", async () => {
+    const { controller } = setup();
+    const stepped = controller.step();
+
+    controller.handleReply({ reply: "ready", virtualNow: 0 });
+    controller.handleReply({ reply: "pause", virtualNow: 1 });
+    controller.handleReply({
+      reply: "step",
+      virtualNow: 2,
+      outcome: { _tag: "finished" },
+    });
+
+    await expect(stepped).resolves.toEqual({ _tag: "finished" });
+  });
+
+  it("resolves a step that will never be answered when the process goes away", async () => {
+    const { controller } = setup();
+
+    const stepped = controller.step();
+    controller.detach();
+
+    await expect(stepped).resolves.toBeNull();
+    expect(controller.isAttached).toBe(false);
+  });
+
+  it("abandons a pending step when the user resumes instead", async () => {
+    const { controller } = setup();
+
+    const stepped = controller.step();
+    controller.play();
+
+    await expect(stepped).resolves.toBeNull();
+  });
+
+  it("drops clicks that land between runs", async () => {
+    const controller = new ContainerController();
+
+    controller.pause();
+    await expect(controller.step()).resolves.toBeNull();
+  });
+});

--- a/src/lib/containerController.ts
+++ b/src/lib/containerController.ts
@@ -1,0 +1,69 @@
+/**
+ * Page-side half of the control channel: turns button clicks into commands and
+ * waits for the container to answer.
+ *
+ * The in-browser path calls its `Stepper` directly and gets a `StepOutcome`
+ * back on the spot. Here the same call is a round trip, so `step` returns a
+ * promise that a reply resolves. Everything the UI does with a step — deciding
+ * whether the program is stuck, whether it has finished — needs that outcome,
+ * which is why the channel has a return path at all.
+ *
+ * The controller outlives any single run: `attach` is called when a process
+ * starts and `detach` when it goes away, so a click that lands between runs is
+ * dropped rather than throwing.
+ */
+import type { ControlCommand, ControlReply } from "@/runtime/controlChannel";
+import type { StepOutcome } from "@/runtime/stepper";
+
+/** Resolves to null when the run ends before the container answers. */
+type PendingStep = (outcome: StepOutcome | null) => void;
+
+export class ContainerController {
+  #send: ((command: ControlCommand) => void) | null = null;
+  /** Steps awaiting a reply, oldest first. Replies answer them in order. */
+  #pending: PendingStep[] = [];
+
+  get isAttached(): boolean {
+    return this.#send !== null;
+  }
+
+  attach(send: (command: ControlCommand) => void): void {
+    this.#send = send;
+  }
+
+  /** The process is gone: nothing can answer, so settle whoever is waiting. */
+  detach(): void {
+    this.#send = null;
+    this.#settleAll();
+  }
+
+  handleReply(reply: ControlReply): void {
+    if (reply.reply !== "step") return;
+    this.#pending.shift()?.(reply.outcome);
+  }
+
+  pause(): void {
+    this.#send?.({ cmd: "pause" });
+  }
+
+  play(): void {
+    // A pending step can never be answered now: resuming is what the user chose
+    // instead of waiting for it.
+    this.#settleAll();
+    this.#send?.({ cmd: "resume" });
+  }
+
+  step(): Promise<StepOutcome | null> {
+    if (this.#send === null) return Promise.resolve(null);
+    return new Promise<StepOutcome | null>((resolve) => {
+      this.#pending.push(resolve);
+      this.#send?.({ cmd: "step" });
+    });
+  }
+
+  #settleAll(): void {
+    const pending = this.#pending;
+    this.#pending = [];
+    for (const resolve of pending) resolve(null);
+  }
+}

--- a/src/lib/mirroredClock.test.ts
+++ b/src/lib/mirroredClock.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MirroredClock } from "@/lib/mirroredClock";
+
+/** Drives `performance.now`, which the mirror reads for wall time. */
+function elapse(ms: number) {
+  vi.advanceTimersByTime(ms);
+}
+
+describe("MirroredClock", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("extrapolates at the run's rate between readings", () => {
+    const clock = new MirroredClock(0.5);
+    clock.sync(1000);
+
+    elapse(200);
+
+    expect(clock.now()).toBe(1100);
+  });
+
+  it("snaps forward to a reading the rate could not have predicted", () => {
+    const clock = new MirroredClock(1);
+    clock.sync(1000);
+
+    // A step over a five second sleep: the container jumped, we did not.
+    clock.sync(6000);
+
+    expect(clock.now()).toBe(6000);
+  });
+
+  it("never moves backwards when a stale reading lands behind the prediction", () => {
+    const clock = new MirroredClock(1);
+    clock.sync(1000);
+    elapse(50);
+    const beforeCorrection = clock.now();
+
+    clock.sync(1030); // in flight for 20ms
+
+    expect(clock.now()).toBe(beforeCorrection);
+  });
+
+  it("holds still while paused, however long the wall clock runs", () => {
+    const clock = new MirroredClock(1);
+    clock.sync(1000);
+    elapse(100);
+
+    clock.pause();
+    elapse(10_000);
+
+    expect(clock.rate).toBe(0);
+    expect(clock.now()).toBe(1100);
+  });
+
+  it("resumes from where it froze, at the run's rate", () => {
+    const clock = new MirroredClock(0.25);
+    clock.sync(1000);
+    clock.pause();
+    elapse(5000);
+
+    clock.resume();
+    elapse(400);
+
+    expect(clock.rate).toBe(0.25);
+    expect(clock.now()).toBe(1100);
+  });
+
+  it("keeps stepping visible while paused: each reply moves the cursor", () => {
+    const clock = new MirroredClock(1);
+    clock.sync(1000);
+    clock.pause();
+
+    clock.sync(3000);
+    elapse(1000);
+
+    expect(clock.now()).toBe(3000);
+  });
+
+  it("does not re-read the paused interval at the resumed rate", () => {
+    const clock = new MirroredClock(1);
+    clock.sync(1000);
+    clock.pause();
+    elapse(2000);
+    clock.resume();
+
+    expect(clock.now()).toBe(1000);
+  });
+});

--- a/src/lib/mirroredClock.ts
+++ b/src/lib/mirroredClock.ts
@@ -1,0 +1,79 @@
+/**
+ * The page's model of a virtual clock running in the WebContainer.
+ *
+ * The container's `VirtualClock` is the only clock: it is what `Effect.sleep`
+ * counts down in and what stamps every trace event. This is a *predictor* over
+ * it, used for the one thing event timestamps cannot supply — the timeline's
+ * cursor in the gaps between events.
+ *
+ * Between readings it extrapolates at the run's rate, exactly as the container
+ * does. On every authoritative reading — a trace event's timestamp, or the
+ * `virtualNow` on a control reply — it snaps. Both clocks derive from the same
+ * monotonic hardware source, so the two never tick at different speeds; the
+ * error is an offset of about one message latency, and snapping bounds it
+ * instead of letting it accumulate.
+ *
+ * A step is why the snapping is not optional: stepping over a five second sleep
+ * moves the container's clock five seconds in one go, which no amount of
+ * extrapolating from a rate will predict.
+ */
+import { computeVirtualNow, type VirtualAnchor } from "@/lib/timelineTime";
+
+export class MirroredClock {
+  /** The run's rate; 0 while paused. */
+  #rate: number;
+  readonly #runRate: number;
+  #anchor: VirtualAnchor | null = null;
+
+  constructor(rate: number) {
+    this.#rate = rate;
+    this.#runRate = rate;
+  }
+
+  get rate(): number {
+    return this.#rate;
+  }
+
+  now(): number {
+    return computeVirtualNow(this.#anchor, this.#rate, performance.now());
+  }
+
+  /**
+   * Take an authoritative reading from the container.
+   *
+   * Corrections only ever move the cursor forward. A reading is always a little
+   * stale by the time it arrives, so one that lands behind the prediction means
+   * the page ran ahead by a message latency rather than that time went
+   * backwards — and a playhead that rewinds reads as a bug in a way that one
+   * briefly running ahead does not.
+   */
+  sync(virtualNow: number): void {
+    const current = this.#anchor === null ? -Infinity : this.now();
+    this.#anchor = {
+      virtual: Math.max(virtualNow, current),
+      wall: performance.now(),
+    };
+  }
+
+  /**
+   * Freeze, because the container has frozen. While paused no trace events
+   * arrive, so there are no corrections: a frozen cursor holds a static error
+   * where a running one would drift for as long as the user reads the screen.
+   */
+  pause(): void {
+    this.#setRate(0);
+  }
+
+  resume(): void {
+    this.#setRate(this.#runRate);
+  }
+
+  /** Re-anchor before the slope changes, or the elapsed interval is re-read at a rate that was never in effect for it. */
+  #setRate(rate: number): void {
+    if (rate === this.#rate) return;
+    if (this.#anchor !== null) {
+      this.#anchor = { virtual: this.now(), wall: performance.now() };
+    }
+    this.#rate = rate;
+  }
+}

--- a/src/lib/programCache.test.ts
+++ b/src/lib/programCache.test.ts
@@ -12,12 +12,17 @@ const mockPrograms: ProgramsMap = {
   multiStep: { source: "// multiStep template" },
   nestedForks: { source: "// nestedForks template" },
   racing: { source: "// racing template" },
+  interleaving: { source: "// interleaving template" },
+  boundedConcurrency: { source: "// boundedConcurrency template" },
+  structuredInterruption: { source: "// structuredInterruption template" },
   failureAndRecovery: { source: "// failureAndRecovery template" },
   retry: { source: "// retry template" },
   retryExponentialBackoff: { source: "// retryExponentialBackoff template" },
+  timeout: { source: "// timeout template" },
   basicFinalizers: { source: "// basicFinalizers template" },
   acquireRelease: { source: "// acquireRelease template" },
   loggerWithRequirements: { source: "// loggerWithRequirements template" },
+  deadlock: { source: "// deadlock template" },
 };
 
 describe("programCache", () => {

--- a/src/lib/programs.test.ts
+++ b/src/lib/programs.test.ts
@@ -1,0 +1,121 @@
+import { Effect, Fiber, Layer } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { makeTraceEmitterLayer } from "@/runtime/tracedRunner";
+import type { TraceEmitter } from "@/runtime/traceEmitter";
+import { VirtualClock, type VirtualClockHost } from "@/runtime/virtualClock";
+import { makeVizClockLayer } from "@/runtime/vizClock";
+import type { TraceEvent } from "@/types/trace";
+
+import {
+  boundedConcurrencyExample,
+  deadlockExample,
+  interleavingExample,
+  structuredInterruptionExample,
+  timeoutExample,
+} from "./programs";
+
+const fakeHost: VirtualClockHost = {
+  now: () => Date.now(),
+  setTimeout: (run, ms) => setTimeout(run, ms),
+  clearTimeout: (handle) =>
+    clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+/** Runs an example the way the app does, on a clock the test can advance. */
+function start(effect: Effect.Effect<unknown, unknown, TraceEmitter>) {
+  const events: TraceEvent[] = [];
+  const clock = new VirtualClock({ rate: 1, origin: 0, host: fakeHost });
+  const fiber = Effect.runFork(
+    Effect.scoped(effect).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          makeTraceEmitterLayer((event) => events.push(event)),
+          makeVizClockLayer(clock),
+        ),
+      ),
+    ) as Effect.Effect<unknown, unknown, never>,
+  );
+  return { clock, events, fiber };
+}
+
+/** Runs to completion, advancing virtual time as far as any example needs. */
+async function settle(fiber: Fiber.RuntimeFiber<unknown, unknown>) {
+  const done = Effect.runPromise(Fiber.join(fiber));
+  await vi.advanceTimersByTimeAsync(10_000);
+  return done;
+}
+
+describe("example programs", () => {
+  let logged: string[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    logged = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logged.push(String(args[0]));
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("interleaving: the two fibers alternate at every yield", async () => {
+    const { fiber } = start(interleavingExample);
+    await expect(settle(fiber)).resolves.toEqual(["A done", "B done"]);
+    expect(logged).toEqual([
+      "A step 1",
+      "B step 1",
+      "A step 2",
+      "B step 2",
+      "A step 3",
+      "B step 3",
+    ]);
+  });
+
+  it("boundedConcurrency: only two tasks are in flight at a time", async () => {
+    const at: number[] = [];
+    const { clock, fiber } = start(boundedConcurrencyExample);
+    vi.mocked(console.log).mockImplementation((...args: unknown[]) => {
+      logged.push(String(args[0]));
+      at.push(clock.now());
+    });
+
+    await expect(settle(fiber)).resolves.toEqual([1, 2, 3, 4, 5]);
+    // Three batches of 500ms rather than one: the limit, not the tasks, sets the pace.
+    expect(at).toEqual([500, 500, 1000, 1000, 1500]);
+  });
+
+  it("structuredInterruption: children and their finalizers unwind with the parent", async () => {
+    const { events, fiber } = start(structuredInterruptionExample);
+    await expect(settle(fiber)).resolves.toBe(
+      "parent and children interrupted",
+    );
+
+    const finalizers = events
+      .filter((event) => event.type === "finalizer")
+      .map((event) => event.label);
+    expect(finalizers.sort()).toEqual([
+      "child-1-cleanup",
+      "child-2-cleanup",
+      "parent-cleanup",
+    ]);
+  });
+
+  it("timeout: the deadline interrupts only the work that overruns it", async () => {
+    const { fiber } = start(timeoutExample);
+    await expect(settle(fiber)).resolves.toEqual({
+      quick: "quick-task finished",
+      slow: "slow-task timed out",
+    });
+  });
+
+  it("deadlock: the program never finishes", async () => {
+    const { fiber } = start(deadlockExample);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(fiber.unsafePoll()).toBeNull();
+    await Effect.runPromise(Fiber.interrupt(fiber));
+  });
+});

--- a/src/lib/programs.ts
+++ b/src/lib/programs.ts
@@ -3,7 +3,16 @@
  * These demonstrate different Effect patterns with tracing.
  */
 
-import { Context, Effect, Fiber, Layer, Ref, Schedule } from "effect";
+import {
+  Context,
+  Deferred,
+  Duration,
+  Effect,
+  Fiber,
+  Layer,
+  Ref,
+  Schedule,
+} from "effect";
 
 import { addFinalizer, acquireRelease, retry } from "@/runtime";
 
@@ -315,6 +324,155 @@ export const loggerWithRequirementsExample = Effect.gen(function* () {
 });
 
 // =============================================================================
+// Cooperative Interleaving: fibers take turns at yield points
+// =============================================================================
+
+/**
+ * Two fibers that never sleep, yet still interleave.
+ */
+export const interleavingExample = Effect.gen(function* () {
+  const worker = (label: string) =>
+    Effect.gen(function* () {
+      for (let step = 1; step <= 3; step++) {
+        yield* Effect.withSpan(`${label}-step-${step}`)(
+          Effect.sync(() => console.log(`${label} step ${step}`)),
+        );
+        // Hand the runtime back. Drop this line and the whole loop runs to the
+        // end before the other fiber gets a single turn.
+        yield* Effect.yieldNow();
+      }
+      return `${label} done`;
+    });
+
+  // Neither fiber sleeps, yet they still alternate: Effect is concurrent, not
+  // parallel, so a fiber keeps the runtime until it yields.
+  const a = yield* Effect.fork(worker("A"));
+  const b = yield* Effect.fork(worker("B"));
+  return [yield* Fiber.join(a), yield* Fiber.join(b)];
+});
+
+// =============================================================================
+// Bounded Concurrency: Effect.all with a concurrency limit
+// =============================================================================
+
+/**
+ * Five tasks run two at a time.
+ * Effect.all runs a whole collection; `concurrency` is what stops it from
+ * starting everything at once.
+ */
+export const boundedConcurrencyExample = Effect.gen(function* () {
+  const task = (id: number) =>
+    Effect.withSpan(`task-${id}`)(
+      Effect.gen(function* () {
+        yield* Effect.sleep("500 millis");
+        yield* Effect.sync(() => console.log(`task ${id} done`));
+        return id;
+      }),
+    );
+
+  // Tasks 3 and 4 only start once 1 and 2 are done: two fibers are alive at a
+  // time, not five. Use "unbounded" to lift the limit.
+  return yield* Effect.all([task(1), task(2), task(3), task(4), task(5)], {
+    concurrency: 2,
+  });
+});
+
+// =============================================================================
+// Structured Interruption: cancelling a parent unwinds its children
+// =============================================================================
+
+/**
+ * One interrupt at the top, and everything below it unwinds.
+ * Interruption is structured: children are cancelled with their parent, and
+ * the finalizers registered along the way still run, in reverse order.
+ */
+export const structuredInterruptionExample = Effect.gen(function* () {
+  const child = (label: string) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        yield* addFinalizer(() => Effect.sync(() => {}), `${label}-cleanup`);
+        // Far longer than the program lasts: this sleep never completes.
+        yield* Effect.withSpan(label)(Effect.sleep("10 seconds"));
+      }),
+    );
+
+  const parent = yield* Effect.fork(
+    Effect.scoped(
+      Effect.gen(function* () {
+        yield* addFinalizer(() => Effect.sync(() => {}), "parent-cleanup");
+        yield* Effect.fork(child("child-1"));
+        yield* Effect.fork(child("child-2"));
+        yield* Effect.sleep("10 seconds");
+      }),
+    ),
+  );
+
+  yield* Effect.sleep("300 millis");
+  // The children are never named here; cancelling their parent is enough.
+  yield* Fiber.interrupt(parent);
+  return "parent and children interrupted";
+});
+
+// =============================================================================
+// Timeout: a deadline measured on the program's own clock
+// =============================================================================
+
+/**
+ * A deadline that interrupts work which takes too long.
+ * Effect.timeout reads the same clock the program sleeps on, so slowing
+ * playback stretches the work and the deadline alike and the outcome holds.
+ */
+export const timeoutExample = Effect.gen(function* () {
+  const withDeadline = (label: string, work: Duration.DurationInput) =>
+    Effect.withSpan(label)(Effect.sleep(work)).pipe(
+      Effect.timeout("1 second"),
+      Effect.as(`${label} finished`),
+      // A missed deadline fails the effect, so recover to keep going.
+      Effect.catchAll(() => Effect.succeed(`${label} timed out`)),
+    );
+
+  const quick = yield* withDeadline("quick-task", "300 millis");
+  const slow = yield* withDeadline("slow-task", "2 seconds");
+  return { quick, slow };
+});
+
+// =============================================================================
+// Deadlock: two fibers waiting on each other
+// =============================================================================
+
+/**
+ * A program that never finishes, on purpose.
+ * A Deferred is a value a fiber can wait for. Here each fiber waits for the
+ * one the other would complete, so no fiber can ever run again. Step will
+ * report that nothing can run; Reset stops it.
+ */
+export const deadlockExample = Effect.gen(function* () {
+  const first = yield* Deferred.make<string>();
+  const second = yield* Deferred.make<string>();
+
+  yield* Effect.fork(
+    Effect.withSpan("waits-for-second")(
+      Effect.gen(function* () {
+        const value = yield* Deferred.await(second);
+        yield* Deferred.succeed(first, value);
+      }),
+    ),
+  );
+
+  yield* Effect.fork(
+    Effect.withSpan("waits-for-first")(
+      Effect.gen(function* () {
+        const value = yield* Deferred.await(first);
+        yield* Deferred.succeed(second, value);
+      }),
+    ),
+  );
+
+  // Never returns: both fibers are parked on a Deferred nobody will complete.
+  return yield* Deferred.await(first);
+});
+
+// =============================================================================
 // Program Registry (with source code for display)
 // =============================================================================
 
@@ -432,6 +590,37 @@ export const rootEffect = Effect.gen(function* () {
 export const requirements = [];
 `,
   },
+  interleaving: {
+    name: "Cooperative Interleaving",
+    description: "Two fibers taking turns at yield points",
+    rootEffect: interleavingExample,
+    requirements: [] as const,
+    source: `import { Effect, Fiber } from "effect";
+
+export const rootEffect = Effect.gen(function* () {
+  const worker = (label: string) =>
+    Effect.gen(function* () {
+      for (let step = 1; step <= 3; step++) {
+        yield* Effect.withSpan(\`\${label}-step-\${step}\`)(
+          Effect.sync(() => console.log(\`\${label} step \${step}\`))
+        );
+        // Hand the runtime back. Drop this line and the whole loop runs to the
+        // end before the other fiber gets a single turn.
+        yield* Effect.yieldNow();
+      }
+      return \`\${label} done\`;
+    });
+
+  // Neither fiber sleeps, yet they still alternate: Effect is concurrent, not
+  // parallel, so a fiber keeps the runtime until it yields.
+  const a = yield* Effect.fork(worker("A"));
+  const b = yield* Effect.fork(worker("B"));
+  return [yield* Fiber.join(a), yield* Fiber.join(b)];
+});
+
+export const requirements = [];
+`,
+  },
   racing: {
     name: "Racing",
     description:
@@ -462,6 +651,73 @@ export const rootEffect = Effect.gen(function* () {
   yield* Fiber.interrupt(slowRunner);
 
   return winner;
+});
+
+export const requirements = [];
+`,
+  },
+  boundedConcurrency: {
+    name: "Bounded Concurrency",
+    description: "Effect.all running five tasks two at a time",
+    rootEffect: boundedConcurrencyExample,
+    requirements: [] as const,
+    source: `import { Effect } from "effect";
+
+export const rootEffect = Effect.gen(function* () {
+  const task = (id: number) =>
+    Effect.withSpan(\`task-\${id}\`)(
+      Effect.gen(function* () {
+        yield* Effect.sleep("500 millis");
+        yield* Effect.sync(() => console.log(\`task \${id} done\`));
+        return id;
+      })
+    );
+
+  // Tasks 3 and 4 only start once 1 and 2 are done: two fibers are alive at a
+  // time, not five. Use "unbounded" to lift the limit.
+  return yield* Effect.all([task(1), task(2), task(3), task(4), task(5)], {
+    concurrency: 2,
+  });
+});
+
+export const requirements = [];
+`,
+  },
+  structuredInterruption: {
+    name: "Structured Interruption",
+    description: "Interrupt a parent, children and finalizers unwind",
+    rootEffect: structuredInterruptionExample,
+    requirements: [] as const,
+    source: `import { Effect, Fiber } from "effect";
+// Use @/runtime (not Effect.addFinalizer) so the visualizer can trace finalizers
+import { addFinalizer } from "@/runtime";
+
+export const rootEffect = Effect.gen(function* () {
+  const child = (label: string) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        yield* addFinalizer(() => Effect.sync(() => {}), \`\${label}-cleanup\`);
+        // Far longer than the program lasts: this sleep never completes.
+        yield* Effect.withSpan(label)(Effect.sleep("10 seconds"));
+      })
+    );
+
+  const parent = yield* Effect.fork(
+    Effect.scoped(
+      Effect.gen(function* () {
+        yield* addFinalizer(() => Effect.sync(() => {}), "parent-cleanup");
+        yield* Effect.fork(child("child-1"));
+        yield* Effect.fork(child("child-2"));
+        yield* Effect.sleep("10 seconds");
+      })
+    )
+  );
+
+  yield* Effect.sleep("300 millis");
+  // The children are never named here; cancelling their parent is enough.
+  // Every finalizer still runs, in reverse order.
+  yield* Fiber.interrupt(parent);
+  return "parent and children interrupted";
 });
 
 export const requirements = [];
@@ -562,6 +818,32 @@ export const rootEffect = Effect.gen(function* () {
 export const requirements = [];
 `,
   },
+  timeout: {
+    name: "Timeout",
+    description: "A deadline that interrupts work taking too long",
+    rootEffect: timeoutExample,
+    requirements: [] as const,
+    source: `import { Duration, Effect } from "effect";
+
+export const rootEffect = Effect.gen(function* () {
+  const withDeadline = (label: string, work: Duration.DurationInput) =>
+    Effect.withSpan(label)(Effect.sleep(work)).pipe(
+      Effect.timeout("1 second"),
+      Effect.as(\`\${label} finished\`),
+      // A missed deadline fails the effect, so recover to keep going.
+      Effect.catchAll(() => Effect.succeed(\`\${label} timed out\`))
+    );
+
+  // The deadline is read from the same clock the program sleeps on, so slowing
+  // playback stretches the work and the deadline alike: quick still wins.
+  const quick = yield* withDeadline("quick-task", "300 millis");
+  const slow = yield* withDeadline("slow-task", "2 seconds");
+  return { quick, slow };
+});
+
+export const requirements = [];
+`,
+  },
   basicFinalizers: {
     name: "Basic Finalizers",
     description:
@@ -648,6 +930,44 @@ export const rootEffect = Effect.gen(function* () {
 });
 
 export const requirements = [loggerLayer];
+`,
+  },
+  deadlock: {
+    name: "Deadlock (never finishes)",
+    description: "Two fibers each waiting on the other, forever",
+    rootEffect: deadlockExample,
+    requirements: [] as const,
+    source: `import { Deferred, Effect } from "effect";
+
+export const rootEffect = Effect.gen(function* () {
+  // A Deferred is a value a fiber can wait for, completed by another fiber.
+  const first = yield* Deferred.make<string>();
+  const second = yield* Deferred.make<string>();
+
+  yield* Effect.fork(
+    Effect.withSpan("waits-for-second")(
+      Effect.gen(function* () {
+        const value = yield* Deferred.await(second);
+        yield* Deferred.succeed(first, value);
+      })
+    )
+  );
+
+  yield* Effect.fork(
+    Effect.withSpan("waits-for-first")(
+      Effect.gen(function* () {
+        const value = yield* Deferred.await(first);
+        yield* Deferred.succeed(second, value);
+      })
+    )
+  );
+
+  // Each fiber waits for the one the other would complete, so no fiber can ever
+  // run again. Step reports that nothing can run; Reset stops the program.
+  return yield* Deferred.await(first);
+});
+
+export const requirements = [];
 `,
   },
 } as const;

--- a/src/lib/programs.ts
+++ b/src/lib/programs.ts
@@ -442,9 +442,9 @@ export const timeoutExample = Effect.gen(function* () {
 
 /**
  * A program that never finishes, on purpose.
- * A Deferred is a value a fiber can wait for. Here each fiber waits for the
- * one the other would complete, so no fiber can ever run again. Step will
- * report that nothing can run; Reset stops it.
+ *
+ * A Deferred is a value a fiber can wait for, completed by another fiber. Each fiber here waits for the one the other would complete, so no fiber can ever run again.
+ * Step reports that nothing can run; Reset stops the program.
  */
 export const deadlockExample = Effect.gen(function* () {
   const first = yield* Deferred.make<string>();
@@ -468,7 +468,6 @@ export const deadlockExample = Effect.gen(function* () {
     ),
   );
 
-  // Never returns: both fibers are parked on a Deferred nobody will complete.
   return yield* Deferred.await(first);
 });
 
@@ -939,8 +938,9 @@ export const requirements = [loggerLayer];
     requirements: [] as const,
     source: `import { Deferred, Effect } from "effect";
 
+// A Deferred is a value a fiber can wait for, completed by another fiber. Each fiber here waits for the one the other would complete, so no fiber can ever run again.
+// Step reports that nothing can run; Reset stops the program.
 export const rootEffect = Effect.gen(function* () {
-  // A Deferred is a value a fiber can wait for, completed by another fiber.
   const first = yield* Deferred.make<string>();
   const second = yield* Deferred.make<string>();
 
@@ -962,8 +962,6 @@ export const rootEffect = Effect.gen(function* () {
     )
   );
 
-  // Each fiber waits for the one the other would complete, so no fiber can ever
-  // run again. Step reports that nothing can run; Reset stops the program.
   return yield* Deferred.await(first);
 });
 

--- a/src/lib/timelineTime.test.ts
+++ b/src/lib/timelineTime.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { computeTickInterval, computeVirtualNow } from "@/lib/timelineTime";
+
+const ANCHOR = { virtual: 1_600_000_000_000, wall: 500 };
+
+describe("computeVirtualNow", () => {
+  it("tracks wall time at rate 1", () => {
+    expect(computeVirtualNow(ANCHOR, 1, 1500)).toBe(ANCHOR.virtual + 1000);
+  });
+
+  /**
+   * The bug this guards: the timeline's live cursor used wall time while event
+   * timestamps were virtual, so at 0.25x the elapsed grew four times too fast
+   * during a run and snapped back the moment the run finished.
+   */
+  it("advances at a quarter of wall time at rate 0.25", () => {
+    expect(computeVirtualNow(ANCHOR, 0.25, 4500)).toBe(ANCHOR.virtual + 1000);
+  });
+
+  it("stands still at rate 0", () => {
+    expect(computeVirtualNow(ANCHOR, 0, 60_000)).toBe(ANCHOR.virtual);
+  });
+
+  it("agrees with the anchor at the instant it was taken", () => {
+    expect(computeVirtualNow(ANCHOR, 0.5, ANCHOR.wall)).toBe(ANCHOR.virtual);
+  });
+
+  it("falls back to wall time before the first event of a run", () => {
+    const before = Date.now();
+    expect(computeVirtualNow(null, 0.25, 1234)).toBeGreaterThanOrEqual(before);
+  });
+});
+
+/** Number of labels the axis would render for a span. */
+const tickCount = (duration: number) =>
+  Math.floor(duration / computeTickInterval(duration)) + 1;
+
+describe("computeTickInterval", () => {
+  it("uses fine steps for short spans", () => {
+    expect(computeTickInterval(1000)).toBe(200);
+    expect(computeTickInterval(3000)).toBe(500);
+  });
+
+  /**
+   * The bug this guards: the interval was capped at one second, so a long
+   * timeline rendered a label per second until they overlapped into a smear.
+   */
+  it("keeps the label count bounded at any span", () => {
+    for (const duration of [
+      1_000, 3_000, 6_000, 12_000, 30_000, 60_000, 120_000, 600_000, 3_600_000,
+    ]) {
+      expect(tickCount(duration)).toBeLessThanOrEqual(12);
+    }
+  });
+
+  it("still renders several ticks rather than collapsing to one", () => {
+    for (const duration of [1_000, 6_000, 60_000, 600_000, 3_600_000]) {
+      expect(tickCount(duration)).toBeGreaterThanOrEqual(4);
+    }
+  });
+
+  it("never returns a step of zero", () => {
+    expect(computeTickInterval(0)).toBeGreaterThan(0);
+    expect(computeTickInterval(1)).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/timelineTime.ts
+++ b/src/lib/timelineTime.ts
@@ -1,0 +1,48 @@
+/**
+ * Time helpers shared by the visualiser's live views.
+ *
+ * Trace event timestamps are expressed in *virtual* time, so anything measured
+ * against them has to be virtual too. See `workshop/phase-10.md`.
+ */
+
+/** Wall/virtual pair captured when the first event of a run arrives. */
+export interface VirtualAnchor {
+  virtual: number;
+  wall: number;
+}
+
+/**
+ * Virtual "now", for views that need a cursor between events.
+ *
+ * Reading wall time here instead makes an in-progress elapsed grow `1 / rate`
+ * times too fast, then snap back to the true span the moment the run ends and
+ * the last event becomes the end.
+ */
+export function computeVirtualNow(
+  anchor: VirtualAnchor | null,
+  rate: number,
+  wallNow: number,
+): number {
+  if (anchor === null) return Date.now();
+  return anchor.virtual + (wallNow - anchor.wall) * rate;
+}
+
+const TARGET_TICK_COUNT = 8;
+
+/**
+ * Spacing for the timeline's time axis.
+ *
+ * Rounds up to the nearest 1, 2 or 5 times a power of ten, so the spacing is a
+ * readable round number at any magnitude and the label count stays bounded. A
+ * fixed cap instead crams one label per unit onto a long timeline until they
+ * overlap into a smear.
+ */
+export function computeTickInterval(duration: number): number {
+  const target = Math.max(duration, 1) / TARGET_TICK_COUNT;
+  const magnitude = 10 ** Math.floor(Math.log10(target));
+  for (const multiple of [1, 2, 5]) {
+    const step = multiple * magnitude;
+    if (step >= target) return step;
+  }
+  return 10 * magnitude;
+}

--- a/src/runtime/controlChannel.test.ts
+++ b/src/runtime/controlChannel.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  CONTROL_REPLY_PREFIX,
+  type ControlCommand,
+  type ControlReply,
+  applyCommand,
+  decodeCommand,
+  decodeReply,
+  encodeCommand,
+  encodeReply,
+  makeLineReader,
+} from "@/runtime/controlChannel";
+import { GatedScheduler } from "@/runtime/gatedScheduler";
+import { Stepper } from "@/runtime/stepper";
+import { VirtualClock, type VirtualClockHost } from "@/runtime/virtualClock";
+
+const fakeHost: VirtualClockHost = {
+  now: () => Date.now(),
+  setTimeout: (run, ms) => setTimeout(run, ms),
+  clearTimeout: (handle) =>
+    clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+function setup({
+  isFinished = () => false,
+}: { isFinished?: () => boolean } = {}) {
+  const scheduler = new GatedScheduler();
+  const clock = new VirtualClock({ rate: 1, origin: 0, host: fakeHost });
+  const stepper = new Stepper({ scheduler, clock, isFinished });
+  return { scheduler, clock, stepper, target: { stepper, clock } };
+}
+
+describe("command codec", () => {
+  it.each<ControlCommand>([
+    { cmd: "pause" },
+    { cmd: "resume" },
+    { cmd: "step" },
+  ])("round-trips %o", (command) => {
+    const encoded = encodeCommand(command);
+    expect(encoded.endsWith("\n")).toBe(true);
+    expect(decodeCommand(encoded)).toEqual(command);
+  });
+
+  it.each([
+    ["empty", ""],
+    ["whitespace", "   "],
+    ["not json", "pause"],
+    ["json but not an object", "42"],
+    ["null", "null"],
+    ["object without cmd", '{"foo":1}'],
+    ["unknown verb", '{"cmd":"explode"}'],
+  ])("returns null for %s", (_label, line) => {
+    expect(decodeCommand(line)).toBeNull();
+  });
+});
+
+describe("reply codec", () => {
+  it.each<ControlReply>([
+    { reply: "ready", virtualNow: 0 },
+    { reply: "pause", virtualNow: 1234.5 },
+    { reply: "resume", virtualNow: 9 },
+    { reply: "step", virtualNow: 7, outcome: { _tag: "released", tasks: 3 } },
+    {
+      reply: "step",
+      virtualNow: 5000,
+      outcome: { _tag: "advancedClock", toVirtual: 5000, tasks: 1 },
+    },
+    { reply: "step", virtualNow: 2, outcome: { _tag: "noProgress" } },
+    { reply: "step", virtualNow: 2, outcome: { _tag: "finished" } },
+  ])("round-trips %o", (reply) => {
+    const line = encodeReply(reply);
+    expect(line.startsWith(CONTROL_REPLY_PREFIX)).toBe(true);
+    expect(decodeReply(line.trimEnd())).toEqual(reply);
+  });
+
+  it("ignores lines without the prefix, including bare trace events", () => {
+    expect(decodeReply('{"reply":"pause","virtualNow":1}')).toBeNull();
+    expect(decodeReply('TRACE_EVENT:{"type":"fiber:fork"}')).toBeNull();
+  });
+
+  it.each([
+    ["malformed json", `${CONTROL_REPLY_PREFIX}{`],
+    ["nothing after the prefix", CONTROL_REPLY_PREFIX],
+    ["missing virtualNow", `${CONTROL_REPLY_PREFIX}{"reply":"pause"}`],
+    [
+      "non-numeric virtualNow",
+      `${CONTROL_REPLY_PREFIX}{"reply":"pause","virtualNow":"soon"}`,
+    ],
+    [
+      "step without an outcome",
+      `${CONTROL_REPLY_PREFIX}{"reply":"step","virtualNow":1}`,
+    ],
+    [
+      "step with an untagged outcome",
+      `${CONTROL_REPLY_PREFIX}{"reply":"step","virtualNow":1,"outcome":{}}`,
+    ],
+    ["unknown reply", `${CONTROL_REPLY_PREFIX}{"reply":"burp","virtualNow":1}`],
+  ])("returns null for %s", (_label, line) => {
+    expect(decodeReply(line)).toBeNull();
+  });
+});
+
+describe("applyCommand", () => {
+  it("pause freezes the clock and gates the scheduler", () => {
+    const { scheduler, clock, target } = setup();
+
+    const reply = applyCommand({ cmd: "pause" }, target);
+
+    expect(reply.reply).toBe("pause");
+    expect(scheduler.mode).toBe("paused");
+    expect(clock.rate).toBe(0);
+  });
+
+  it("resume restores the rate the run started with", () => {
+    const { scheduler, clock, target } = setup();
+    applyCommand({ cmd: "pause" }, target);
+
+    applyCommand({ cmd: "resume" }, target);
+
+    expect(scheduler.mode).toBe("playing");
+    expect(clock.rate).toBe(1);
+  });
+
+  it("reports the outcome of a step", () => {
+    const { scheduler, target } = setup();
+    applyCommand({ cmd: "pause" }, target);
+    const task = vi.fn();
+    scheduler.scheduleTask(task, 0);
+
+    const reply = applyCommand({ cmd: "step" }, target);
+
+    expect(task).toHaveBeenCalledOnce();
+    expect(reply).toMatchObject({
+      reply: "step",
+      outcome: { _tag: "released" },
+    });
+  });
+
+  it("reports noProgress when nothing is runnable and nothing is due", () => {
+    const { target } = setup();
+    applyCommand({ cmd: "pause" }, target);
+
+    const reply = applyCommand({ cmd: "step" }, target);
+
+    expect(reply).toMatchObject({ outcome: { _tag: "noProgress" } });
+  });
+
+  it("carries the clock jump a step over a sleep produces", () => {
+    const { clock, target } = setup();
+    applyCommand({ cmd: "pause" }, target);
+    clock.sleep(5000, () => {});
+
+    const reply = applyCommand({ cmd: "step" }, target);
+
+    // The page cannot predict this from a rate: it is the whole reason replies
+    // carry a virtual reading.
+    expect(reply).toMatchObject({
+      virtualNow: 5000,
+      outcome: { _tag: "advancedClock", toVirtual: 5000 },
+    });
+  });
+
+  it("reports finished without touching the runtime", () => {
+    const { scheduler, target } = setup({ isFinished: () => true });
+    applyCommand({ cmd: "pause" }, target);
+    const task = vi.fn();
+    scheduler.scheduleTask(task, 0);
+
+    const reply = applyCommand({ cmd: "step" }, target);
+
+    expect(reply).toMatchObject({ outcome: { _tag: "finished" } });
+    expect(task).not.toHaveBeenCalled();
+  });
+});
+
+describe("makeLineReader", () => {
+  it("emits one line per newline, without it", () => {
+    const lines: string[] = [];
+    const read = makeLineReader((line) => lines.push(line));
+
+    read("a\nb\n");
+
+    expect(lines).toEqual(["a", "b"]);
+  });
+
+  it("holds a partial line until its newline arrives", () => {
+    const lines: string[] = [];
+    const read = makeLineReader((line) => lines.push(line));
+
+    read('{"cmd":"st');
+    expect(lines).toEqual([]);
+
+    read('ep"}\n');
+    expect(lines).toEqual(['{"cmd":"step"}']);
+  });
+
+  it("splits several commands arriving in one chunk", () => {
+    const commands: (ControlCommand | null)[] = [];
+    const read = makeLineReader((line) => commands.push(decodeCommand(line)));
+
+    read(encodeCommand({ cmd: "step" }) + encodeCommand({ cmd: "resume" }));
+
+    expect(commands).toEqual([{ cmd: "step" }, { cmd: "resume" }]);
+  });
+
+  it("does not emit a trailing fragment that never ends", () => {
+    const lines: string[] = [];
+    const read = makeLineReader((line) => lines.push(line));
+
+    read("done\nunterminated");
+
+    expect(lines).toEqual(["done"]);
+  });
+});

--- a/src/runtime/controlChannel.ts
+++ b/src/runtime/controlChannel.ts
@@ -1,0 +1,155 @@
+/**
+ * The wire between the page and a program running in the WebContainer.
+ *
+ * The in-browser fallback holds its `Stepper` in a ref and calls it directly.
+ * The container runs the program in another process, so the same three verbs —
+ * pause, resume, step — have to travel as messages: commands in on the process's
+ * stdin, replies out on its stdout, one JSON object per line.
+ *
+ * Replies exist for two reasons. A step returns a `StepOutcome`, which is what
+ * tells the user a program is stuck rather than merely slow. And every reply
+ * carries the clock's virtual now, because the page draws a timeline cursor
+ * between events and cannot otherwise see a step that moved virtual time: a step
+ * over a five second sleep jumps the clock by five seconds in one go, which no
+ * amount of extrapolating from a rate will predict. See `workshop/phase-10.md`.
+ *
+ * Speed is deliberately not on the wire. It is fixed for the life of a run on
+ * both paths — the container reads it once from `VIZ_RATE` at spawn — so a live
+ * rate command would give the container path a capability the fallback does not
+ * have.
+ */
+import type { StepOutcome, Stepper } from "@/runtime/stepper";
+import type { VirtualClock } from "@/runtime/virtualClock";
+
+/** Page → container. */
+export type ControlCommand =
+  | { readonly cmd: "pause" }
+  | { readonly cmd: "resume" }
+  | { readonly cmd: "step" };
+
+/**
+ * Container → page. `virtualNow` is the authoritative reading of the container's
+ * clock at the moment the command finished being applied.
+ */
+export type ControlReply =
+  /** Sent once, when the runner can accept commands. */
+  | { readonly reply: "ready"; readonly virtualNow: number }
+  | { readonly reply: "pause"; readonly virtualNow: number }
+  | { readonly reply: "resume"; readonly virtualNow: number }
+  | {
+      readonly reply: "step";
+      readonly virtualNow: number;
+      readonly outcome: StepOutcome;
+    };
+
+/**
+ * Replies share stdout with trace events and with anything the program itself
+ * prints, so they are prefixed the same way `TRACE_EVENT:` is.
+ */
+export const CONTROL_REPLY_PREFIX = "TRACE_CONTROL:";
+
+const COMMANDS = ["pause", "resume", "step"] as const;
+
+export function encodeCommand(command: ControlCommand): string {
+  return `${JSON.stringify(command)}\n`;
+}
+
+/** Returns null for anything unrecognised, so junk on stdin cannot crash a run. */
+export function decodeCommand(line: string): ControlCommand | null {
+  const trimmed = line.trim();
+  if (trimmed === "") return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const cmd = (parsed as { cmd?: unknown }).cmd;
+  return COMMANDS.some((known) => known === cmd)
+    ? ({ cmd } as ControlCommand)
+    : null;
+}
+
+export function encodeReply(reply: ControlReply): string {
+  return `${CONTROL_REPLY_PREFIX}${JSON.stringify(reply)}\n`;
+}
+
+export function decodeReply(line: string): ControlReply | null {
+  if (!line.startsWith(CONTROL_REPLY_PREFIX)) return null;
+  const json = line.slice(CONTROL_REPLY_PREFIX.length).trim();
+  if (json === "") return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const { reply, virtualNow } = parsed as {
+    reply?: unknown;
+    virtualNow?: unknown;
+  };
+  if (typeof virtualNow !== "number" || !Number.isFinite(virtualNow)) {
+    return null;
+  }
+  if (reply === "ready" || reply === "pause" || reply === "resume") {
+    return { reply, virtualNow };
+  }
+  if (reply === "step") {
+    const outcome = (parsed as { outcome?: unknown }).outcome;
+    if (typeof outcome !== "object" || outcome === null) return null;
+    if (typeof (outcome as { _tag?: unknown })._tag !== "string") return null;
+    return { reply, virtualNow, outcome: outcome as StepOutcome };
+  }
+  return null;
+}
+
+export interface ControlTarget {
+  readonly stepper: Stepper;
+  /** Read for `virtualNow`; the stepper drives it but does not expose it. */
+  readonly clock: VirtualClock;
+}
+
+/**
+ * Run one command against the runtime and describe what happened.
+ *
+ * Trace events emitted while a step runs are written to stdout during
+ * `step()`, so they reach the page ahead of the reply that accounts for them.
+ * The page can therefore snap its clock forward knowing it has already seen
+ * everything that happened before that reading.
+ */
+export function applyCommand(
+  command: ControlCommand,
+  { stepper, clock }: ControlTarget,
+): ControlReply {
+  switch (command.cmd) {
+    case "pause":
+      stepper.pause();
+      return { reply: "pause", virtualNow: clock.now() };
+    case "resume":
+      stepper.play();
+      return { reply: "resume", virtualNow: clock.now() };
+    case "step": {
+      const outcome = stepper.step();
+      return { reply: "step", virtualNow: clock.now(), outcome };
+    }
+  }
+}
+
+/**
+ * Reassembles lines from stream chunks, which split wherever they please — a
+ * command can arrive in two pieces, and two commands can arrive as one chunk.
+ */
+export function makeLineReader(onLine: (line: string) => void) {
+  let buffer = "";
+  return (chunk: string): void => {
+    buffer += chunk;
+    let newline = buffer.indexOf("\n");
+    while (newline >= 0) {
+      onLine(buffer.slice(0, newline));
+      buffer = buffer.slice(newline + 1);
+      newline = buffer.indexOf("\n");
+    }
+  };
+}

--- a/src/runtime/dateShim.test.ts
+++ b/src/runtime/dateShim.test.ts
@@ -123,13 +123,16 @@ describe("installDateShim", () => {
   });
 
   describe("the clock does not read its own shim", () => {
-    it("keeps working when a clock is created after the shim is installed", () => {
+    it("keeps reading wall time from a clock created after the shim", () => {
       installFrozen();
-      // Default host: captured the real Date.now at module load, so this must
-      // not recurse into the shim.
+
+      // The default host reads `performance`, never `Date`, so this cannot
+      // recurse into the shim regardless of module evaluation order.
       const later = new VirtualClock({ rate: 0 });
-      expect(Number.isFinite(later.now())).toBe(true);
+      const wall = performance.timeOrigin + performance.now();
+
       expect(later.now()).not.toBe(ORIGIN);
+      expect(Math.abs(later.now() - wall)).toBeLessThan(1000);
     });
   });
 });

--- a/src/runtime/dateShim.test.ts
+++ b/src/runtime/dateShim.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { installDateShim } from "@/runtime/dateShim";
+import { VirtualClock } from "@/runtime/virtualClock";
+
+const ORIGIN = 1_600_000_000_000;
+
+let uninstall: (() => void) | null = null;
+
+/** Frozen clock: virtual time cannot drift mid-assertion. */
+function installFrozen(origin = ORIGIN) {
+  const virtual = new VirtualClock({ rate: 0, origin });
+  uninstall = installDateShim(virtual);
+  return virtual;
+}
+
+afterEach(() => {
+  uninstall?.();
+  uninstall = null;
+});
+
+describe("installDateShim", () => {
+  describe("reads virtual time", () => {
+    it("overrides Date.now()", () => {
+      installFrozen();
+      expect(Date.now()).toBe(ORIGIN);
+    });
+
+    it("overrides the zero-argument constructor", () => {
+      installFrozen();
+      expect(new Date().getTime()).toBe(ORIGIN);
+    });
+
+    it("overrides Date() called without new", () => {
+      installFrozen();
+      expect(Date()).toBe(new Date(ORIGIN).toString());
+    });
+
+    it("follows the clock when it is advanced", () => {
+      const virtual = installFrozen();
+      expect(Date.now()).toBe(ORIGIN);
+
+      virtual.sleep(5000, () => {});
+      virtual.advanceToNextDeadline();
+
+      expect(Date.now()).toBe(ORIGIN + 5000);
+      expect(new Date().getTime()).toBe(ORIGIN + 5000);
+    });
+
+    it("returns whole milliseconds", () => {
+      const virtual = new VirtualClock({ rate: 0, origin: ORIGIN + 0.7 });
+      uninstall = installDateShim(virtual);
+      expect(Number.isInteger(Date.now())).toBe(true);
+      expect(Date.now()).toBe(ORIGIN);
+    });
+  });
+
+  describe("leaves explicit dates alone", () => {
+    it("keeps new Date(ms)", () => {
+      installFrozen();
+      expect(new Date(0).getTime()).toBe(0);
+      expect(new Date(12345).getTime()).toBe(12345);
+    });
+
+    it("keeps the multi-argument constructor", () => {
+      installFrozen();
+      const date = new Date(2020, 0, 15);
+      expect(date.getFullYear()).toBe(2020);
+      expect(date.getMonth()).toBe(0);
+      expect(date.getDate()).toBe(15);
+    });
+
+    it("keeps the string constructor", () => {
+      installFrozen();
+      expect(new Date("2020-01-01T00:00:00.000Z").toISOString()).toBe(
+        "2020-01-01T00:00:00.000Z",
+      );
+    });
+  });
+
+  describe("stays a faithful Date", () => {
+    it("keeps the static helpers", () => {
+      installFrozen();
+      expect(Date.parse("2020-01-01T00:00:00.000Z")).toBe(1577836800000);
+      expect(Date.UTC(2020, 0, 1)).toBe(1577836800000);
+    });
+
+    it("keeps instanceof and the prototype methods", () => {
+      installFrozen();
+      const date = new Date();
+      expect(date).toBeInstanceOf(Date);
+      expect(typeof date.toISOString()).toBe("string");
+      expect(date.toISOString()).toBe(new Date(ORIGIN).toISOString());
+    });
+  });
+
+  describe("leaves the rest of the platform alone", () => {
+    it("does not touch performance.now()", () => {
+      installFrozen();
+      const before = performance.now();
+      // Busy-wait: real time passes while virtual time is frozen.
+      while (performance.now() === before) {
+        /* spin */
+      }
+
+      expect(performance.now()).toBeGreaterThan(before);
+      expect(Date.now()).toBe(ORIGIN); // unmoved
+    });
+  });
+
+  describe("uninstall", () => {
+    it("restores the original Date", () => {
+      const RealDate = globalThis.Date;
+      const restore = installDateShim(
+        new VirtualClock({ rate: 0, origin: ORIGIN }),
+      );
+      expect(Date.now()).toBe(ORIGIN);
+
+      restore();
+      expect(globalThis.Date).toBe(RealDate);
+      expect(Date.now()).not.toBe(ORIGIN);
+    });
+  });
+
+  describe("the clock does not read its own shim", () => {
+    it("keeps working when a clock is created after the shim is installed", () => {
+      installFrozen();
+      // Default host: captured the real Date.now at module load, so this must
+      // not recurse into the shim.
+      const later = new VirtualClock({ rate: 0 });
+      expect(Number.isFinite(later.now())).toBe(true);
+      expect(later.now()).not.toBe(ORIGIN);
+    });
+  });
+});

--- a/src/runtime/dateShim.ts
+++ b/src/runtime/dateShim.ts
@@ -1,0 +1,65 @@
+/**
+ * Makes raw `Date` read virtual time instead of wall time.
+ *
+ * Effect's own notion of time already comes from the `Clock` service, so once
+ * `vizClock` is provided, `Effect.sleep`, `Schedule`, `timeout` and even
+ * `Effect.log` timestamps are all scaled. Code calling `Date.now()` directly
+ * bypasses that and would keep reading wall time, disagreeing with everything
+ * around it. This shim closes that gap.
+ *
+ * Installed **only in the WebContainer**, where the process runs nothing but the
+ * user's program. The in-browser fallback path shares a realm with React, so
+ * patching `Date` there would distort the UI's own timing and animations.
+ *
+ * Deliberately untouched:
+ * - `performance.now()` stays on wall time, so there is always a way to measure
+ *   how much real time something actually took.
+ * - `setTimeout` is not intercepted. Raw timers are already invisible to Effect's
+ *   runtime, so code using them has stepped outside the model being visualised.
+ */
+import type { VirtualClock } from "@/runtime/virtualClock";
+
+/**
+ * Replace the global `Date` with one reading `virtual`. Returns a function that
+ * restores the original.
+ *
+ * Must be called *after* the module holding `VirtualClock` has been evaluated,
+ * so that the clock captured the real `Date.now` before it was replaced —
+ * otherwise the shim and the clock would read each other. In `runner.js` this is
+ * guaranteed: `runtime.js` is a static import and therefore evaluates before any
+ * statement in `main()`.
+ */
+export function installDateShim(virtual: VirtualClock): () => void {
+  const RealDate = globalThis.Date;
+
+  /** `Date.now()` returns whole milliseconds; virtual time is fractional. */
+  const virtualNow = () => Math.floor(virtual.now());
+
+  // A Proxy rather than a subclass: `Date()` without `new` is legal JavaScript
+  // and returns a string, which a class constructor cannot do. The Proxy also
+  // keeps `instanceof`, `Date.parse`, `Date.UTC` and the prototype intact for
+  // free, since the target is the real `Date`.
+  const ShimmedDate = new Proxy(RealDate, {
+    construct(target, args, newTarget) {
+      // Only the zero-argument form means "now". `new Date(ms)` and
+      // `new Date(y, m, d)` must keep their explicit meaning — Effect itself
+      // builds log timestamps with `new Date(clock.unsafeCurrentTimeMillis())`.
+      const resolved = args.length === 0 ? [virtualNow()] : args;
+      return Reflect.construct(target, resolved, newTarget);
+    },
+    apply() {
+      // `Date(...)` ignores its arguments and returns the current time as a string.
+      return new RealDate(virtualNow()).toString();
+    },
+    get(target, property, receiver) {
+      if (property === "now") return virtualNow;
+      return Reflect.get(target, property, receiver);
+    },
+  });
+
+  globalThis.Date = ShimmedDate;
+
+  return () => {
+    globalThis.Date = RealDate;
+  };
+}

--- a/src/runtime/dateShim.ts
+++ b/src/runtime/dateShim.ts
@@ -23,11 +23,12 @@ import type { VirtualClock } from "@/runtime/virtualClock";
  * Replace the global `Date` with one reading `virtual`. Returns a function that
  * restores the original.
  *
- * Must be called *after* the module holding `VirtualClock` has been evaluated,
- * so that the clock captured the real `Date.now` before it was replaced —
- * otherwise the shim and the clock would read each other. In `runner.js` this is
- * guaranteed: `runtime.js` is a static import and therefore evaluates before any
- * statement in `main()`.
+ * Safe to call at any point: `VirtualClock` reads wall time from `performance`,
+ * which is never shimmed, so the two cannot read each other however the modules
+ * are ordered.
+ *
+ * It must still be installed *before* the code it is meant to affect is
+ * evaluated — a module that runs first sees the real `Date`.
  */
 export function installDateShim(virtual: VirtualClock): () => void {
   const RealDate = globalThis.Date;

--- a/src/runtime/gatedScheduler.test.ts
+++ b/src/runtime/gatedScheduler.test.ts
@@ -167,19 +167,27 @@ describe("GatedScheduler", () => {
     it("bounds the work when the condition never becomes true", async () => {
       const { scheduler, run } = setup();
       const steps: string[] = [];
+      // More steps than the bound, so the bound is what stops the release and
+      // not an empty queue.
+      const totalSteps = 6;
+      const maxTasks = 3;
       run(
         Effect.gen(function* () {
-          steps.push("a");
-          yield* Effect.yieldNow();
-          steps.push("b");
+          for (let i = 0; i < totalSteps; i++) {
+            steps.push(String(i));
+            yield* Effect.yieldNow();
+          }
         }),
       );
 
       scheduler.pause();
       await settle();
 
-      const released = scheduler.releaseUntil(() => false, 2);
-      expect(released).toBe(2);
+      const released = scheduler.releaseUntil(() => false, maxTasks);
+
+      expect(released).toBe(maxTasks);
+      expect(steps.length).toBeLessThan(totalSteps);
+      expect(scheduler.queuedCount).toBeGreaterThan(0);
     });
 
     it("reports when there is nothing to release", async () => {
@@ -242,6 +250,67 @@ describe("GatedScheduler", () => {
       await vi.advanceTimersByTimeAsync(10);
       await Effect.runPromise(Fiber.join(fiber));
       expect(steps).toEqual(["worker-1", "worker-2", "root"]);
+    });
+  });
+
+  describe("work arriving from outside", () => {
+    /**
+     * We do not control the outside world: a promise settles when it settles.
+     * But settling does not resume the fiber, it only hands the continuation to
+     * the Scheduler as a task — our queue. So a pause holds across I/O, and the
+     * reply becomes the user's next step rather than something that already
+     * happened.
+     */
+    it("holds an external resume until the next step", async () => {
+      const { scheduler, run } = setup();
+      const steps: string[] = [];
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+
+      run(
+        Effect.gen(function* () {
+          steps.push("before");
+          yield* Effect.promise(() => gate);
+          steps.push("after");
+        }),
+      );
+      await settle();
+      scheduler.pause();
+
+      release();
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(steps).toEqual(["before"]);
+      expect(scheduler.queuedCount).toBeGreaterThan(0);
+
+      scheduler.releaseUntil(() => steps.length > 1);
+      expect(steps).toEqual(["before", "after"]);
+    });
+
+    /**
+     * Interruption is delivered as a task too, so a paused program cannot be
+     * interrupted. Anything that tears a run down — the Reset button — has to
+     * resume the scheduler first.
+     */
+    it("cannot interrupt a paused program until it resumes", async () => {
+      const { scheduler, run } = setup();
+      const fiber = run(Effect.never);
+      await settle();
+      scheduler.pause();
+
+      let interrupted = false;
+      void Effect.runPromise(Fiber.interrupt(fiber)).then(() => {
+        interrupted = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(interrupted).toBe(false);
+
+      scheduler.play();
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(interrupted).toBe(true);
     });
   });
 

--- a/src/runtime/gatedScheduler.test.ts
+++ b/src/runtime/gatedScheduler.test.ts
@@ -73,8 +73,10 @@ describe("GatedScheduler", () => {
 
   describe("paused", () => {
     /**
-     * Even the program's first step is a scheduled task, so pausing before Play
-     * means the program does not begin at all until the user steps.
+     * Pause does not stop the program instantly. The task already handed to
+     * Effect's scheduler is out of our hands, so it runs, and it carries the
+     * fiber to its first natural yield point — hence "a". The continuation
+     * comes back to us and waits there.
      */
     it("stops the program and queues its next task", async () => {
       const { scheduler, run } = setup();
@@ -89,19 +91,24 @@ describe("GatedScheduler", () => {
 
       scheduler.pause();
       await settle();
-      const atPause = [...steps];
 
+      expect(steps).toEqual(["a"]);
       expect(scheduler.queuedCount).toBeGreaterThan(0);
 
       // Wall time passing changes nothing: only a step can.
       await vi.advanceTimersByTimeAsync(10_000);
-      expect(steps).toEqual(atPause);
+      expect(steps).toEqual(["a"]);
     });
 
     /**
-     * A released task is often runtime bookkeeping — here, building the Clock
-     * layer — rather than user code. So a step is "release until something
-     * visible happens", not "release exactly one task".
+     * A step is "release until something visible happens", not "release exactly
+     * one task". The queue holds runtime bookkeeping alongside user
+     * continuations — one such task is still queued here after the program's
+     * last visible step — so a step tied to a single release could land on one
+     * and appear to do nothing.
+     *
+     * In this program each step happens to need exactly one release. The
+     * predicate is what makes that a guarantee rather than a coincidence.
      */
     it("advances one visible step at a time", async () => {
       const { scheduler, run } = setup();

--- a/src/runtime/gatedScheduler.test.ts
+++ b/src/runtime/gatedScheduler.test.ts
@@ -1,0 +1,285 @@
+import { Effect, Fiber } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GatedScheduler } from "@/runtime/gatedScheduler";
+import { VirtualClock, type VirtualClockHost } from "@/runtime/virtualClock";
+import { makeVizClockLayer } from "@/runtime/vizClock";
+
+const fakeHost: VirtualClockHost = {
+  now: () => Date.now(),
+  setTimeout: (run, ms) => setTimeout(run, ms),
+  clearTimeout: (handle) =>
+    clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+function setup(rate = 1) {
+  const scheduler = new GatedScheduler();
+  const virtual = new VirtualClock({ rate, origin: 0, host: fakeHost });
+  const run = <A>(effect: Effect.Effect<A>) =>
+    Effect.runFork(
+      effect.pipe(
+        Effect.withScheduler(scheduler),
+        Effect.provide(makeVizClockLayer(virtual)),
+      ),
+    );
+  return { scheduler, virtual, run };
+}
+
+/** Lets already-dispatched work reach the scheduler. */
+const settle = () => vi.advanceTimersByTimeAsync(0);
+
+describe("GatedScheduler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("playing", () => {
+    it("runs a program to completion unchanged", async () => {
+      const { scheduler, run } = setup();
+      const steps: string[] = [];
+      const fiber = run(
+        Effect.gen(function* () {
+          steps.push("a");
+          yield* Effect.yieldNow();
+          steps.push("b");
+          yield* Effect.yieldNow();
+          steps.push("c");
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(steps).toEqual(["a", "b", "c"]);
+      expect(scheduler.queuedCount).toBe(0);
+      await Effect.runPromise(Fiber.join(fiber));
+    });
+
+    it("queues nothing while playing", async () => {
+      const { scheduler, run } = setup();
+      run(
+        Effect.gen(function* () {
+          yield* Effect.yieldNow();
+          yield* Effect.yieldNow();
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(scheduler.queuedCount).toBe(0);
+    });
+  });
+
+  describe("paused", () => {
+    /**
+     * Even the program's first step is a scheduled task, so pausing before Play
+     * means the program does not begin at all until the user steps.
+     */
+    it("stops the program and queues its next task", async () => {
+      const { scheduler, run } = setup();
+      const steps: string[] = [];
+      run(
+        Effect.gen(function* () {
+          steps.push("a");
+          yield* Effect.yieldNow();
+          steps.push("b");
+        }),
+      );
+
+      scheduler.pause();
+      await settle();
+      const atPause = [...steps];
+
+      expect(scheduler.queuedCount).toBeGreaterThan(0);
+
+      // Wall time passing changes nothing: only a step can.
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(steps).toEqual(atPause);
+    });
+
+    /**
+     * A released task is often runtime bookkeeping — here, building the Clock
+     * layer — rather than user code. So a step is "release until something
+     * visible happens", not "release exactly one task".
+     */
+    it("advances one visible step at a time", async () => {
+      const { scheduler, run } = setup();
+      const steps: string[] = [];
+      run(
+        Effect.gen(function* () {
+          steps.push("a");
+          yield* Effect.yieldNow();
+          steps.push("b");
+          yield* Effect.yieldNow();
+          steps.push("c");
+        }),
+      );
+
+      scheduler.pause();
+      await settle();
+
+      const step = () => {
+        const before = steps.length;
+        scheduler.releaseUntil(() => steps.length > before);
+      };
+
+      while (steps.length < 3 && scheduler.queuedCount > 0) {
+        const before = steps.length;
+        step();
+        // Every step makes exactly one thing visible.
+        expect(steps.length).toBe(before + 1);
+      }
+
+      expect(steps).toEqual(["a", "b", "c"]);
+    });
+
+    it("stops releasing once the condition is met", async () => {
+      const { scheduler, run } = setup();
+      const steps: string[] = [];
+      run(
+        Effect.gen(function* () {
+          steps.push("a");
+          yield* Effect.yieldNow();
+          steps.push("b");
+          yield* Effect.yieldNow();
+          steps.push("c");
+        }),
+      );
+
+      scheduler.pause();
+      await settle();
+
+      const before = steps.length;
+      scheduler.releaseUntil(() => steps.length > before);
+      expect(steps.length).toBe(before + 1);
+      // The rest is still held.
+      expect(scheduler.queuedCount).toBeGreaterThan(0);
+    });
+
+    it("bounds the work when the condition never becomes true", async () => {
+      const { scheduler, run } = setup();
+      const steps: string[] = [];
+      run(
+        Effect.gen(function* () {
+          steps.push("a");
+          yield* Effect.yieldNow();
+          steps.push("b");
+        }),
+      );
+
+      scheduler.pause();
+      await settle();
+
+      const released = scheduler.releaseUntil(() => false, 2);
+      expect(released).toBe(2);
+    });
+
+    it("reports when there is nothing to release", async () => {
+      const { scheduler, run } = setup();
+      run(Effect.succeed(1));
+      await settle();
+
+      scheduler.pause();
+      expect(scheduler.releaseOne()).toBe(false);
+    });
+
+    it("resumes normal execution on play", async () => {
+      const { scheduler, run } = setup();
+      const steps: string[] = [];
+      run(
+        Effect.gen(function* () {
+          steps.push("a");
+          yield* Effect.yieldNow();
+          steps.push("b");
+          yield* Effect.yieldNow();
+          steps.push("c");
+        }),
+      );
+
+      scheduler.pause();
+      await settle();
+
+      scheduler.play();
+      await vi.advanceTimersByTimeAsync(10);
+      expect(steps).toEqual(["a", "b", "c"]);
+      expect(scheduler.queuedCount).toBe(0);
+    });
+
+    it("holds concurrent fibers still", async () => {
+      const { scheduler, run } = setup();
+      const steps: string[] = [];
+      const fiber = run(
+        Effect.gen(function* () {
+          // Joined, so the children must finish before the root does.
+          const w1 = yield* Effect.fork(
+            Effect.sync(() => steps.push("worker-1")),
+          );
+          const w2 = yield* Effect.fork(
+            Effect.sync(() => steps.push("worker-2")),
+          );
+          yield* Fiber.join(w1);
+          yield* Fiber.join(w2);
+          steps.push("root");
+        }),
+      );
+
+      scheduler.pause();
+      await settle();
+      const atPause = steps.length;
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(steps.length).toBe(atPause);
+
+      scheduler.play();
+      await vi.advanceTimersByTimeAsync(10);
+      await Effect.runPromise(Fiber.join(fiber));
+      expect(steps).toEqual(["worker-1", "worker-2", "root"]);
+    });
+  });
+
+  describe("stuck detection", () => {
+    it("has nothing pending once a program has finished", async () => {
+      const { scheduler, virtual, run } = setup();
+      const fiber = run(Effect.succeed(1));
+      await vi.advanceTimersByTimeAsync(10);
+      await Effect.runPromise(Fiber.join(fiber));
+
+      expect(scheduler.pendingCount).toBe(0);
+      expect(virtual.pendingCount).toBe(0);
+    });
+
+    /**
+     * A sleeping program is not stuck: the scheduler has nothing, but the clock
+     * does. Telling the two apart is what rung 2 of the step ladder needs.
+     */
+    it("distinguishes a sleeping program from a finished one", async () => {
+      const { scheduler, virtual, run } = setup();
+      run(Effect.sleep("10 seconds"));
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(scheduler.pendingCount).toBe(0);
+      expect(virtual.pendingCount).toBe(1);
+    });
+  });
+
+  describe("clear", () => {
+    it("drops queued tasks", async () => {
+      const { scheduler, run } = setup();
+      run(
+        Effect.gen(function* () {
+          yield* Effect.yieldNow();
+          yield* Effect.yieldNow();
+        }),
+      );
+
+      scheduler.pause();
+      await settle();
+      expect(scheduler.queuedCount).toBeGreaterThan(0);
+
+      scheduler.clear();
+      expect(scheduler.queuedCount).toBe(0);
+      expect(scheduler.releaseOne()).toBe(false);
+    });
+  });
+});

--- a/src/runtime/gatedScheduler.ts
+++ b/src/runtime/gatedScheduler.ts
@@ -82,15 +82,13 @@ export class GatedScheduler implements Scheduler.Scheduler {
   }
 
   /**
-   * A fiber asks this before continuing its next operation. We always defer to
-   * Effect's own answer, in both modes.
+   * A fiber asks this before continuing its next operation. Effect's own answer
+   * is used in both modes: gating decides *when* a task runs, never whether a
+   * running fiber should hand control back. Overriding it would stop a released
+   * fiber from reaching its next operation at all.
    *
-   * Forcing a yield while paused looks tempting — a fiber would then stop at its
-   * next operation rather than after Effect's default of 2048. It deadlocks
-   * instead: the released fiber asks this before doing any work, is told to
-   * yield, re-queues itself, and no step ever makes progress. Pausing therefore
-   * takes effect at the runtime's own yield points, which is also where the
-   * program is in a consistent state.
+   * Pausing therefore lands on the runtime's own yield points, where the program
+   * is in a consistent state.
    */
   shouldYield(fiber: RuntimeFiber<unknown, unknown>): number | false {
     return this.#inner.shouldYield(fiber);

--- a/src/runtime/gatedScheduler.ts
+++ b/src/runtime/gatedScheduler.ts
@@ -14,6 +14,10 @@
  * While playing, every task goes straight to Effect's own scheduler, so normal
  * execution is unchanged. While paused, tasks are queued and only a step
  * releases them.
+ *
+ * Note that interruption is delivered as a task as well. A paused program
+ * therefore cannot be interrupted, so anything that tears a run down — Reset —
+ * must call `play()` first.
  */
 import { Scheduler } from "effect";
 import type { RuntimeFiber } from "effect/Fiber";

--- a/src/runtime/gatedScheduler.ts
+++ b/src/runtime/gatedScheduler.ts
@@ -1,0 +1,175 @@
+/**
+ * A `Scheduler` that can hold the Effect runtime still.
+ *
+ * The `VirtualClock` slows down the gaps that a program spends *sleeping*. It
+ * cannot touch the bursts of work between sleeps, because there is no gap there
+ * to stretch. Those bursts are where forks, races and interruptions happen, so
+ * they are exactly what a user wants to watch one event at a time.
+ *
+ * A fiber that must continue later does not continue itself. The runtime turns
+ * the continuation into a **task** and hands it to the `Scheduler`, which
+ * decides when to run it. Taking over that decision is therefore how execution
+ * is paused and stepped.
+ *
+ * While playing, every task goes straight to Effect's own scheduler, so normal
+ * execution is unchanged. While paused, tasks are queued and only a step
+ * releases them.
+ */
+import { Scheduler } from "effect";
+import type { RuntimeFiber } from "effect/Fiber";
+
+export type SchedulerMode = "playing" | "paused";
+
+export interface GatedSchedulerOptions {
+  /** Effect's scheduler, used verbatim while playing. */
+  readonly inner?: Scheduler.Scheduler;
+  /** Called whenever the number of queued tasks changes. */
+  readonly onQueueChange?: (queued: number) => void;
+}
+
+export class GatedScheduler implements Scheduler.Scheduler {
+  readonly #inner: Scheduler.Scheduler;
+  readonly #onQueueChange: ((queued: number) => void) | undefined;
+  #mode: SchedulerMode = "playing";
+  /** Reuses Effect's own priority ordering so a release picks the task the runtime would have picked. */
+  #queued = new Scheduler.PriorityBuckets<Scheduler.Task>();
+  #queuedCount = 0;
+  /** Tasks handed to the inner scheduler that have not run yet. */
+  #inFlight = 0;
+
+  constructor(options: GatedSchedulerOptions = {}) {
+    this.#inner = options.inner ?? Scheduler.defaultScheduler;
+    this.#onQueueChange = options.onQueueChange;
+  }
+
+  get mode(): SchedulerMode {
+    return this.#mode;
+  }
+
+  /** Tasks waiting for a step. Always 0 while playing. */
+  get queuedCount(): number {
+    return this.#queuedCount;
+  }
+
+  /**
+   * Whether any task could still run without help. Used to tell "busy" from
+   * "stuck": with nothing here and no pending timer, the program cannot move.
+   */
+  get pendingCount(): number {
+    return this.#queuedCount + this.#inFlight;
+  }
+
+  /**
+   * Tasks already handed to the inner scheduler still run: they are out of our
+   * hands. Anything they schedule is queued, so a pause takes hold within one
+   * scheduler turn rather than instantly.
+   */
+  pause(): void {
+    this.#mode = "paused";
+  }
+
+  /** Hand every queued task back to the runtime and resume normal execution. */
+  play(): void {
+    this.#mode = "playing";
+    const draining = this.#drainQueue();
+    for (const task of draining) {
+      this.#runViaInner(task);
+    }
+  }
+
+  /**
+   * A fiber asks this before continuing its next operation. We always defer to
+   * Effect's own answer, in both modes.
+   *
+   * Forcing a yield while paused looks tempting — a fiber would then stop at its
+   * next operation rather than after Effect's default of 2048. It deadlocks
+   * instead: the released fiber asks this before doing any work, is told to
+   * yield, re-queues itself, and no step ever makes progress. Pausing therefore
+   * takes effect at the runtime's own yield points, which is also where the
+   * program is in a consistent state.
+   */
+  shouldYield(fiber: RuntimeFiber<unknown, unknown>): number | false {
+    return this.#inner.shouldYield(fiber);
+  }
+
+  scheduleTask(task: Scheduler.Task, priority: number): void {
+    if (this.#mode === "paused") {
+      this.#queued.scheduleTask(task, priority);
+      this.#queuedCount++;
+      this.#onQueueChange?.(this.#queuedCount);
+      return;
+    }
+    this.#runViaInner(task, priority);
+  }
+
+  /**
+   * Run the highest-priority queued task, in the order the runtime would have
+   * run it. Returns false when nothing was queued.
+   *
+   * The task runs synchronously and may queue more work; that work stays queued
+   * for the next release rather than joining this one.
+   */
+  releaseOne(): boolean {
+    const task = this.#takeNext();
+    if (task === null) return false;
+    task();
+    return true;
+  }
+
+  /**
+   * Release tasks until `isSatisfied` returns true, or until nothing is left.
+   * Returns how many ran.
+   *
+   * A single task is often runtime bookkeeping — building a `Layer`, finishing a
+   * scope — rather than anything the user can see. A step button wired straight
+   * to `releaseOne` would therefore appear to do nothing at random. The caller
+   * supplies the condition that counts as visible progress, usually "one more
+   * trace event has been emitted".
+   *
+   * `maxTasks` bounds the work so a predicate that never becomes true cannot
+   * run the whole program on one click.
+   */
+  releaseUntil(isSatisfied: () => boolean, maxTasks = 1000): number {
+    let released = 0;
+    while (released < maxTasks) {
+      if (!this.releaseOne()) break;
+      released++;
+      if (isSatisfied()) break;
+    }
+    return released;
+  }
+
+  /** Drop every queued task. Used on reset. */
+  clear(): void {
+    this.#drainQueue();
+  }
+
+  #runViaInner(task: Scheduler.Task, priority = 0): void {
+    this.#inFlight++;
+    this.#inner.scheduleTask(() => {
+      this.#inFlight--;
+      task();
+    }, priority);
+  }
+
+  #takeNext(): Scheduler.Task | null {
+    for (const bucket of this.#queued.buckets) {
+      const tasks = bucket[1];
+      if (tasks.length > 0) {
+        const task = tasks.shift()!;
+        this.#queuedCount--;
+        this.#onQueueChange?.(this.#queuedCount);
+        return task;
+      }
+    }
+    return null;
+  }
+
+  #drainQueue(): Scheduler.Task[] {
+    const tasks = this.#queued.buckets.flatMap(([, bucket]) => bucket);
+    this.#queued = new Scheduler.PriorityBuckets<Scheduler.Task>();
+    this.#queuedCount = 0;
+    if (tasks.length > 0) this.#onQueueChange?.(0);
+    return tasks;
+  }
+}

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -26,3 +26,6 @@ export {
   makeVizClockLayer as _makeVizClockLayer,
 } from "./vizClock";
 export { VirtualClock as _VirtualClock } from "./virtualClock";
+
+// From dateShim (Phase 10) — WebContainer only; see the module doc
+export { installDateShim as _installDateShim } from "./dateShim";

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -27,5 +27,15 @@ export {
 } from "./vizClock";
 export { VirtualClock as _VirtualClock } from "./virtualClock";
 
+// From gatedScheduler / stepper (Phase 10) — pause and step the runtime
+export {
+  GatedScheduler as _GatedScheduler,
+  type SchedulerMode as _SchedulerMode,
+} from "./gatedScheduler";
+export {
+  Stepper as _Stepper,
+  type StepOutcome as _StepOutcome,
+} from "./stepper";
+
 // From dateShim (Phase 10) — WebContainer only; see the module doc
 export { installDateShim as _installDateShim } from "./dateShim";

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -47,5 +47,8 @@ export {
   type ControlReply as _ControlReply,
 } from "./controlChannel";
 
+// From traceOrigin (Phase 10) — mark the events the visualizer itself caused
+export { makeOriginTagger as _makeOriginTagger } from "./traceOrigin";
+
 // From dateShim (Phase 10) — WebContainer only; see the module doc
 export { installDateShim as _installDateShim } from "./dateShim";

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -37,5 +37,15 @@ export {
   type StepOutcome as _StepOutcome,
 } from "./stepper";
 
+// From controlChannel (Phase 10) — pause/resume/step over the container's stdio
+export {
+  applyCommand as _applyCommand,
+  decodeCommand as _decodeCommand,
+  encodeReply as _encodeReply,
+  makeLineReader as _makeLineReader,
+  type ControlCommand as _ControlCommand,
+  type ControlReply as _ControlReply,
+} from "./controlChannel";
+
 // From dateShim (Phase 10) — WebContainer only; see the module doc
 export { installDateShim as _installDateShim } from "./dateShim";

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -19,3 +19,10 @@ export {
 } from "./runProgram";
 
 export { makeVizTracer as _makeVizTracer } from "./vizTracer";
+
+// From vizClock (Phase 10) — Effect Clock backed by the VirtualClock
+export {
+  makeVizClock as _makeVizClock,
+  makeVizClockLayer as _makeVizClockLayer,
+} from "./vizClock";
+export { VirtualClock as _VirtualClock } from "./virtualClock";

--- a/src/runtime/runProgram.ts
+++ b/src/runtime/runProgram.ts
@@ -6,6 +6,7 @@
  */
 import { Effect, Fiber, FiberId } from "effect";
 
+import type { Now } from "@/runtime/virtualClock";
 import type { TraceEvent } from "@/types/trace";
 
 export interface RunProgramForkResult<A> {
@@ -22,6 +23,7 @@ export interface RunProgramForkResult<A> {
 export function runProgramFork<A>(
   program: Effect.Effect<A, unknown, never>,
   onEmit: (event: TraceEvent) => void,
+  now: Now,
 ): RunProgramForkResult<A> {
   const fiber = Effect.runFork(program, {
     updateRefs(refs, fiberId) {
@@ -31,7 +33,7 @@ export function runProgramFork<A>(
         fiberId: fiberIdString,
         parentId: undefined,
         label: fiberIdString,
-        timestamp: Date.now(),
+        timestamp: now(),
       });
       return refs;
     },
@@ -42,7 +44,7 @@ export function runProgramFork<A>(
       onEmit({
         type: "fiber:end",
         fiberId: FiberId.threadName(fiber.id()),
-        timestamp: Date.now(),
+        timestamp: now(),
       });
       return result;
     },
@@ -50,7 +52,7 @@ export function runProgramFork<A>(
       onEmit({
         type: "fiber:interrupt",
         fiberId: FiberId.threadName(fiber.id()),
-        timestamp: Date.now(),
+        timestamp: now(),
       });
       throw error;
     },

--- a/src/runtime/stepper.test.ts
+++ b/src/runtime/stepper.test.ts
@@ -1,0 +1,263 @@
+import { Effect, Fiber, Layer } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GatedScheduler } from "@/runtime/gatedScheduler";
+import { Stepper, type StepOutcome } from "@/runtime/stepper";
+import { makeTraceEmitterLayer } from "@/runtime/tracedRunner";
+import { VirtualClock, type VirtualClockHost } from "@/runtime/virtualClock";
+import { makeVizClockLayer } from "@/runtime/vizClock";
+import { makeVizLayers } from "@/runtime/vizSupervisor";
+import { makeVizTracer } from "@/runtime/vizTracer";
+import type { TraceEvent } from "@/types/trace";
+
+const fakeHost: VirtualClockHost = {
+  now: () => Date.now(),
+  setTimeout: (run, ms) => setTimeout(run, ms),
+  clearTimeout: (handle) =>
+    clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+/** Wires the whole runtime together the way the app does. */
+function setup() {
+  const scheduler = new GatedScheduler();
+  const clock = new VirtualClock({ rate: 1, origin: 0, host: fakeHost });
+  const events: TraceEvent[] = [];
+  let fiber: Fiber.RuntimeFiber<unknown, unknown> | null = null;
+
+  const stepper = new Stepper({
+    scheduler,
+    clock,
+    isFinished: () => fiber !== null && fiber.unsafePoll() !== null,
+  });
+
+  const now = () => clock.now();
+  const onEmit = (event: TraceEvent) => {
+    events.push(event);
+    stepper.noteEvent();
+  };
+
+  const run = (effect: Effect.Effect<unknown, unknown, never>) => {
+    const layers = Layer.mergeAll(
+      makeTraceEmitterLayer(onEmit),
+      makeVizLayers(onEmit, now),
+      Layer.setTracer(makeVizTracer(onEmit, now)),
+      makeVizClockLayer(clock),
+    );
+    fiber = Effect.runFork(
+      Effect.scoped(effect).pipe(
+        Effect.withScheduler(scheduler),
+        Effect.provide(layers),
+      ) as Effect.Effect<unknown, unknown, never>,
+    );
+    return fiber;
+  };
+
+  return { scheduler, clock, stepper, events, run };
+}
+
+const settle = () => vi.advanceTimersByTimeAsync(0);
+
+/**
+ * Steps until the program finishes or stops making progress.
+ *
+ * `settle()` between steps is required, not tidiness. Part of a fiber's
+ * completion lands outside our scheduler and needs a full turn of the event loop
+ * — a microtask alone is not enough. Without it the last step reports
+ * `noProgress` for a program that has in fact finished.
+ *
+ * In the app this is free: every click is its own turn.
+ */
+async function stepToEnd(
+  stepper: Stepper,
+  limit = 200,
+): Promise<StepOutcome[]> {
+  const outcomes: StepOutcome[] = [];
+  for (let i = 0; i < limit; i++) {
+    const outcome = stepper.step();
+    outcomes.push(outcome);
+    await settle();
+    if (outcome._tag === "finished" || outcome._tag === "noProgress") break;
+  }
+  return outcomes;
+}
+
+describe("Stepper", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("rung 1: runnable work", () => {
+    it("releases queued work and reports it", async () => {
+      const { stepper, run } = setup();
+      run(
+        Effect.gen(function* () {
+          yield* Effect.withSpan("one")(Effect.void);
+          yield* Effect.yieldNow();
+          yield* Effect.withSpan("two")(Effect.void);
+          yield* Effect.yieldNow();
+          yield* Effect.withSpan("three")(Effect.void);
+        }),
+      );
+      stepper.pause();
+      await settle();
+
+      const before = stepper.eventCount;
+      const outcome = stepper.step();
+
+      expect(outcome._tag).toBe("released");
+      expect(stepper.eventCount).toBeGreaterThan(before);
+    });
+  });
+
+  describe("rung 2: time-blocked work", () => {
+    /**
+     * The whole reason the ladder consults two sources. Nothing is runnable —
+     * the only fiber is asleep — so a step has to move virtual time before
+     * anything can be released.
+     */
+    it("advances the clock when only a sleep is pending", async () => {
+      const { stepper, clock, scheduler, run } = setup();
+      run(Effect.sleep("1 second"));
+      stepper.pause();
+      await settle();
+
+      // Drain whatever is runnable so only the sleep remains.
+      while (scheduler.queuedCount > 0) stepper.step();
+
+      expect(scheduler.queuedCount).toBe(0);
+      expect(clock.pendingCount).toBe(1);
+
+      const outcome = stepper.step();
+
+      expect(outcome._tag).toBe("advancedClock");
+      expect(clock.now()).toBe(1000);
+    });
+
+    it("steps a whole sleeping program to completion without wall time", async () => {
+      const { stepper, run } = setup();
+      const wallBefore = Date.now();
+      const fiber = run(
+        Effect.gen(function* () {
+          yield* Effect.sleep("1 second");
+          yield* Effect.sleep("2 seconds");
+        }),
+      );
+      stepper.pause();
+      await settle();
+
+      const outcomes = await stepToEnd(stepper);
+
+      expect(outcomes.at(-1)?._tag).toBe("finished");
+      expect(outcomes.some((o) => o._tag === "advancedClock")).toBe(true);
+      expect(fiber.unsafePoll()).not.toBeNull();
+      expect(Date.now() - wallBefore).toBe(0);
+    });
+  });
+
+  describe("rung 3: nothing can happen", () => {
+    it("reports no progress for a program that can never continue", async () => {
+      const { stepper, run } = setup();
+      run(Effect.never);
+      stepper.pause();
+      await settle();
+
+      const outcomes = await stepToEnd(stepper);
+      expect(outcomes.at(-1)?._tag).toBe("noProgress");
+    });
+
+    it("does not offer a step when nothing can move", async () => {
+      const { stepper, run } = setup();
+      run(Effect.never);
+      stepper.pause();
+      await settle();
+
+      await stepToEnd(stepper);
+      expect(stepper.canStep()).toBe(false);
+    });
+  });
+
+  describe("rung 4: finished", () => {
+    it("reports finished once the program is done", async () => {
+      const { stepper, run } = setup();
+      run(Effect.succeed(1));
+      stepper.pause();
+      await settle();
+
+      const outcomes = await stepToEnd(stepper);
+      expect(outcomes.at(-1)?._tag).toBe("finished");
+      expect(stepper.canStep()).toBe(false);
+    });
+
+    it("reaches finished for a program that fails", async () => {
+      const { stepper, run } = setup();
+      run(
+        Effect.gen(function* () {
+          yield* Effect.withSpan("doomed")(Effect.fail("boom"));
+        }).pipe(Effect.catchAll(() => Effect.void)),
+      );
+      stepper.pause();
+      await settle();
+
+      const outcomes = await stepToEnd(stepper);
+      expect(outcomes.at(-1)?._tag).toBe("finished");
+    });
+  });
+
+  describe("interleaving fidelity", () => {
+    /**
+     * The property that justifies "never choose a fiber, only choose when to
+     * stop": releasing in queue order reproduces the order the runtime would
+     * have chosen by itself. If this failed, the stepper would be showing an
+     * execution that never happens at full speed.
+     */
+    it("produces the same event order stepped as played", async () => {
+      const program = Effect.gen(function* () {
+        const a = yield* Effect.fork(
+          Effect.withSpan("worker-a")(Effect.sleep("10 millis")),
+        );
+        const b = yield* Effect.fork(
+          Effect.withSpan("worker-b")(Effect.sleep("20 millis")),
+        );
+        const c = yield* Effect.fork(
+          Effect.withSpan("worker-c")(Effect.sleep("5 millis")),
+        );
+        yield* Fiber.join(a);
+        yield* Fiber.join(b);
+        yield* Fiber.join(c);
+      });
+
+      const played = setup();
+      played.run(program);
+      await vi.advanceTimersByTimeAsync(100);
+      const playedOrder = played.events.map((e) => e.type);
+
+      const stepped = setup();
+      stepped.run(program);
+      stepped.stepper.pause();
+      await settle();
+      await stepToEnd(stepped.stepper);
+      const steppedOrder = stepped.events.map((e) => e.type);
+
+      expect(steppedOrder).toEqual(playedOrder);
+    });
+  });
+
+  describe("reset", () => {
+    it("drops queued tasks and pending timers", async () => {
+      const { stepper, scheduler, clock, run } = setup();
+      run(Effect.sleep("1 second"));
+      stepper.pause();
+      await settle();
+
+      stepper.reset();
+
+      expect(scheduler.queuedCount).toBe(0);
+      expect(clock.pendingCount).toBe(0);
+      expect(stepper.eventCount).toBe(0);
+    });
+  });
+});

--- a/src/runtime/stepper.test.ts
+++ b/src/runtime/stepper.test.ts
@@ -158,6 +158,46 @@ describe("Stepper", () => {
     });
   });
 
+  describe("rungs in order", () => {
+    it("falls through to the clock when the queue holds no visible work", () => {
+      const scheduler = new GatedScheduler();
+      const clock = new VirtualClock({ rate: 0, origin: 0, host: fakeHost });
+      scheduler.pause();
+      scheduler.scheduleTask(() => {}, 0);
+      clock.sleep(1000, () => {});
+
+      const stepper = new Stepper({
+        scheduler,
+        clock,
+        isFinished: () => false,
+      });
+
+      const outcome = stepper.step();
+
+      expect(outcome._tag).toBe("advancedClock");
+      expect(clock.now()).toBe(1000);
+    });
+
+    it("prefers runnable work over moving time", () => {
+      const scheduler = new GatedScheduler();
+      const clock = new VirtualClock({ rate: 0, origin: 0, host: fakeHost });
+      scheduler.pause();
+      clock.sleep(1000, () => {});
+
+      const stepper = new Stepper({
+        scheduler,
+        clock,
+        isFinished: () => false,
+      });
+      scheduler.scheduleTask(() => stepper.noteEvent(), 0);
+
+      const outcome = stepper.step();
+
+      expect(outcome._tag).toBe("released");
+      expect(clock.now()).toBe(0);
+    });
+  });
+
   describe("rung 3: nothing can happen", () => {
     it("reports no progress for a program that can never continue", async () => {
       const { stepper, run } = setup();

--- a/src/runtime/stepper.test.ts
+++ b/src/runtime/stepper.test.ts
@@ -158,6 +158,65 @@ describe("Stepper", () => {
     });
   });
 
+  describe("pause freezes time", () => {
+    /**
+     * Gating the scheduler stops fibers from running, but not the clock. If
+     * virtual time kept advancing, the program's own sense of elapsed time would
+     * include however long the user sat looking at the screen.
+     */
+    it("does not advance virtual time while paused", async () => {
+      const { stepper, clock, run } = setup();
+      run(Effect.sleep("1 second"));
+      await settle();
+
+      stepper.pause();
+      const atPause = clock.now();
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(clock.now()).toBe(atPause);
+    });
+
+    it("restores the previous rate on resume", async () => {
+      const scheduler = new GatedScheduler();
+      const clock = new VirtualClock({ rate: 0.25, origin: 0, host: fakeHost });
+      const stepper = new Stepper({
+        scheduler,
+        clock,
+        isFinished: () => false,
+      });
+
+      stepper.pause();
+      expect(clock.rate).toBe(0);
+
+      stepper.play();
+      expect(clock.rate).toBe(0.25);
+    });
+
+    it("leaves a sleep its remaining time across a long pause", async () => {
+      const { stepper, clock, run } = setup();
+      const done: string[] = [];
+      run(
+        Effect.gen(function* () {
+          yield* Effect.sleep("1 second");
+          done.push("woke");
+        }),
+      );
+      await settle();
+      await vi.advanceTimersByTimeAsync(400);
+
+      stepper.pause();
+      await vi.advanceTimersByTimeAsync(60_000); // a long look at the screen
+      stepper.play();
+
+      await vi.advanceTimersByTimeAsync(599);
+      expect(done).toEqual([]);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(done).toEqual(["woke"]);
+      expect(clock.now()).toBeCloseTo(1000, 0);
+    });
+  });
+
   describe("rungs in order", () => {
     it("falls through to the clock when the queue holds no visible work", () => {
       const scheduler = new GatedScheduler();

--- a/src/runtime/stepper.ts
+++ b/src/runtime/stepper.ts
@@ -1,0 +1,134 @@
+/**
+ * The step ladder: what happens when the user clicks step.
+ *
+ * Two separate things can move a program forward. The `GatedScheduler` holds
+ * fibers that are ready to run. The `VirtualClock` holds fibers that are waiting
+ * for a deadline. A step has to consult both, in that order, because a fiber
+ * that can run now should run before time is allowed to move.
+ *
+ * Because we supply both, we know almost everything that could happen next. The
+ * one thing we cannot see is work outstanding in the outside world — a network
+ * reply has not arrived yet, and nothing in our queues reflects that. So the
+ * bottom rung reports "no progress" rather than claiming a deadlock.
+ *
+ * A step is not fully settled the moment it returns. Part of a fiber's
+ * completion lands outside our scheduler and needs a turn of the event loop, and
+ * a microtask is not enough. Consecutive steps must therefore be separated by
+ * one; in the UI every click already is. A loop that steps without yielding will
+ * report `noProgress` for a program that has in fact finished.
+ */
+import type { GatedScheduler } from "@/runtime/gatedScheduler";
+import type { VirtualClock } from "@/runtime/virtualClock";
+
+export type StepOutcome =
+  /** Ran queued work. */
+  | { readonly _tag: "released"; readonly tasks: number }
+  /** Nothing was runnable, so virtual time moved to the next deadline. */
+  | {
+      readonly _tag: "advancedClock";
+      readonly toVirtual: number;
+      readonly tasks: number;
+    }
+  /** The program is over. */
+  | { readonly _tag: "finished" }
+  /**
+   * Nothing is runnable, no deadline is pending, and the program has not
+   * finished. Either fibers are waiting on each other, or something outside is
+   * still to answer. We cannot tell which without reading fiber status, which
+   * needs the very scheduler we are gating.
+   */
+  | { readonly _tag: "noProgress" };
+
+export interface StepperOptions {
+  readonly scheduler: GatedScheduler;
+  readonly clock: VirtualClock;
+  /** Whether the root program has completed. */
+  readonly isFinished: () => boolean;
+  /** Bound on tasks released per step, so one click cannot run everything. */
+  readonly maxTasksPerStep?: number;
+}
+
+const DEFAULT_MAX_TASKS_PER_STEP = 1000;
+
+export class Stepper {
+  readonly #scheduler: GatedScheduler;
+  readonly #clock: VirtualClock;
+  readonly #isFinished: () => boolean;
+  readonly #maxTasks: number;
+  /**
+   * Trace events seen so far. A step runs until this moves, because a single
+   * task is often runtime bookkeeping and a button that sometimes does nothing
+   * visible reads as broken.
+   */
+  #eventCount = 0;
+
+  constructor(options: StepperOptions) {
+    this.#scheduler = options.scheduler;
+    this.#clock = options.clock;
+    this.#isFinished = options.isFinished;
+    this.#maxTasks = options.maxTasksPerStep ?? DEFAULT_MAX_TASKS_PER_STEP;
+  }
+
+  /** Call from the trace emit path. */
+  noteEvent(): void {
+    this.#eventCount++;
+  }
+
+  get eventCount(): number {
+    return this.#eventCount;
+  }
+
+  pause(): void {
+    this.#scheduler.pause();
+  }
+
+  /**
+   * Resume normal execution. Also required before interrupting: interruption is
+   * delivered as a task, so a gated program cannot be torn down.
+   */
+  play(): void {
+    this.#scheduler.play();
+  }
+
+  /** True when a step would do something. Drives the step button. */
+  canStep(): boolean {
+    if (this.#isFinished()) return false;
+    return this.#scheduler.queuedCount > 0 || this.#clock.pendingCount > 0;
+  }
+
+  step(): StepOutcome {
+    if (this.#isFinished()) return { _tag: "finished" };
+
+    if (this.#scheduler.queuedCount > 0) {
+      return { _tag: "released", tasks: this.#releaseUntilVisible() };
+    }
+
+    // Nothing can run, but a fiber is due to wake. Move virtual time to that
+    // deadline; the timer then queues the work that the release below runs.
+    if (this.#clock.pendingCount > 0) {
+      this.#clock.advanceToNextDeadline();
+      return {
+        _tag: "advancedClock",
+        toVirtual: this.#clock.now(),
+        tasks: this.#releaseUntilVisible(),
+      };
+    }
+
+    return { _tag: "noProgress" };
+  }
+
+  /** Drop everything held. The caller resumes and interrupts separately. */
+  reset(): void {
+    this.#scheduler.clear();
+    this.#clock.clearAll();
+    this.#eventCount = 0;
+  }
+
+  #releaseUntilVisible(): number {
+    const before = this.#eventCount;
+    return this.#scheduler.releaseUntil(
+      () => this.#eventCount > before,
+      this.#maxTasks,
+    );
+  }
+}

--- a/src/runtime/stepper.ts
+++ b/src/runtime/stepper.ts
@@ -99,8 +99,13 @@ export class Stepper {
   step(): StepOutcome {
     if (this.#isFinished()) return { _tag: "finished" };
 
+    const before = this.#eventCount;
+    let tasks = 0;
+
     if (this.#scheduler.queuedCount > 0) {
-      return { _tag: "released", tasks: this.#releaseUntilVisible() };
+      tasks = this.#releaseUntilVisible();
+      if (this.#eventCount > before) return { _tag: "released", tasks };
+      // Only bookkeeping ran, so a deadline may still be waiting.
     }
 
     // Nothing can run, but a fiber is due to wake. Move virtual time to that
@@ -110,11 +115,12 @@ export class Stepper {
       return {
         _tag: "advancedClock",
         toVirtual: this.#clock.now(),
-        tasks: this.#releaseUntilVisible(),
+        tasks: tasks + this.#releaseUntilVisible(),
       };
     }
 
-    return { _tag: "noProgress" };
+    // Work ran but produced nothing visible; that is still progress.
+    return tasks > 0 ? { _tag: "released", tasks } : { _tag: "noProgress" };
   }
 
   /** Drop everything held. The caller resumes and interrupts separately. */

--- a/src/runtime/stepper.ts
+++ b/src/runtime/stepper.ts
@@ -61,6 +61,8 @@ export class Stepper {
    * visible reads as broken.
    */
   #eventCount = 0;
+  /** Rate to restore on resume; null while running. */
+  #rateBeforePause: number | null = null;
 
   constructor(options: StepperOptions) {
     this.#scheduler = options.scheduler;
@@ -78,7 +80,18 @@ export class Stepper {
     return this.#eventCount;
   }
 
+  /**
+   * Freeze the program: gate the scheduler *and* stop virtual time.
+   *
+   * Gating alone would leave the clock running, so a program's own sense of time
+   * would keep advancing while the user reads the screen, and the next event
+   * would be timestamped however long they spent paused.
+   */
   pause(): void {
+    if (this.#rateBeforePause === null) {
+      this.#rateBeforePause = this.#clock.rate;
+      this.#clock.setRate(0);
+    }
     this.#scheduler.pause();
   }
 
@@ -88,6 +101,11 @@ export class Stepper {
    */
   play(): void {
     this.#scheduler.play();
+    if (this.#rateBeforePause !== null) {
+      // Parked timers are re-armed with the virtual time they had left.
+      this.#clock.setRate(this.#rateBeforePause);
+      this.#rateBeforePause = null;
+    }
   }
 
   /** True when a step would do something. Drives the step button. */
@@ -128,6 +146,7 @@ export class Stepper {
     this.#scheduler.clear();
     this.#clock.clearAll();
     this.#eventCount = 0;
+    this.#rateBeforePause = null;
   }
 
   #releaseUntilVisible(): number {

--- a/src/runtime/traceEmitter.ts
+++ b/src/runtime/traceEmitter.ts
@@ -1,7 +1,13 @@
-import { Context, Effect } from "effect";
+import { Clock, Context, Effect } from "effect";
 
 import type { TraceEvent } from "@/types/trace";
 
+/**
+ * Timestamps come from `Clock.currentTimeMillis`, not `Date.now()`, so they are
+ * expressed in virtual time: a recorded trace spans the same duration whatever
+ * speed it was captured at. `Clock` is a default service, so this adds nothing
+ * to the R channel.
+ */
 export class TraceEmitter extends Context.Tag("TraceEmitter")<
   TraceEmitter,
   {
@@ -19,7 +25,7 @@ export const emitStart = (
       type: "effect:start",
       id,
       label,
-      timestamp: Date.now(),
+      timestamp: yield* Clock.currentTimeMillis,
     });
   });
 };
@@ -38,7 +44,7 @@ export const emitEnd = (
       result,
       value,
       error,
-      timestamp: Date.now(),
+      timestamp: yield* Clock.currentTimeMillis,
     });
   });
 };
@@ -57,7 +63,7 @@ export const emitRetry = (
       label,
       attempt,
       lastError,
-      timestamp: Date.now(),
+      timestamp: yield* Clock.currentTimeMillis,
     });
   });
 };
@@ -72,7 +78,7 @@ export const emitFinalizer = (
       type: "finalizer",
       id,
       label,
-      timestamp: Date.now(),
+      timestamp: yield* Clock.currentTimeMillis,
     });
   });
 };
@@ -91,7 +97,7 @@ export const emitAcquire = (
       label,
       result,
       error,
-      timestamp: Date.now(),
+      timestamp: yield* Clock.currentTimeMillis,
     });
   });
 };

--- a/src/runtime/traceEmitter.ts
+++ b/src/runtime/traceEmitter.ts
@@ -3,10 +3,13 @@ import { Clock, Context, Effect } from "effect";
 import type { TraceEvent } from "@/types/trace";
 
 /**
- * Timestamps come from `Clock.currentTimeMillis`, not `Date.now()`, so they are
- * expressed in virtual time: a recorded trace spans the same duration whatever
- * speed it was captured at. `Clock` is a default service, so this adds nothing
- * to the R channel.
+ * Timestamps do not rely on `Date.now` but on `Clock.currentTimeMillis`, so they
+ * are expressed in virtual time and a trace spans the same duration whatever
+ * speed it was recorded at.
+ *
+ * These emitters run inside an Effect, so the clock is reachable directly. Where
+ * it is not — the `Supervisor` callbacks and `runProgramFork` — virtual now is
+ * injected instead, as a `Now`.
  */
 export class TraceEmitter extends Context.Tag("TraceEmitter")<
   TraceEmitter,

--- a/src/runtime/traceOrigin.test.ts
+++ b/src/runtime/traceOrigin.test.ts
@@ -19,6 +19,13 @@ const resume = (fiberId: string): TraceEvent => ({
   fiberId,
   timestamp: 0,
 });
+const forkChild = (fiberId: string, parentId: string): TraceEvent => ({
+  type: "fiber:fork",
+  fiberId,
+  parentId,
+  label: fiberId,
+  timestamp: 0,
+});
 const effectStart = (label: string): TraceEvent => ({
   type: "effect:start",
   id: label,
@@ -94,6 +101,42 @@ describe("makeOriginTagger", () => {
         resume("#2"),
       ]),
     ).toEqual(["program", "tool", "program", "program"]);
+  });
+
+  it("gives up when a run does not open with the root's fork", () => {
+    // Every run opens with it, so anything else means this is not the run the
+    // tagger expects — and the next fork would be a child, not the root.
+    expect(
+      origins(true, [
+        effectStart("unexpected"),
+        fork("#2"),
+        suspend("#2"),
+        resume("#2"),
+      ]),
+    ).toEqual(["program", "program", "program", "program"]);
+  });
+
+  it("gives up when the root forks a child instead of yielding", () => {
+    // A fork names the fiber being created, so only its parent says who acted.
+    expect(
+      origins(true, [
+        fork("#2"),
+        forkChild("#3", "#2"),
+        suspend("#2"),
+        resume("#2"),
+      ]),
+    ).toEqual(["program", "program", "program", "program"]);
+  });
+
+  it("keeps waiting when a fiber other than the root forks", () => {
+    expect(
+      origins(true, [
+        fork("#2"),
+        forkChild("#4", "#3"),
+        suspend("#2"),
+        resume("#2"),
+      ]),
+    ).toEqual(["program", "program", "tool", "tool"]);
   });
 
   it("leaves every other field of an event untouched", () => {

--- a/src/runtime/traceOrigin.test.ts
+++ b/src/runtime/traceOrigin.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import { makeOriginTagger } from "@/runtime/traceOrigin";
+import type { TraceEvent } from "@/types/trace";
+
+const fork = (fiberId: string): TraceEvent => ({
+  type: "fiber:fork",
+  fiberId,
+  label: fiberId,
+  timestamp: 0,
+});
+const suspend = (fiberId: string): TraceEvent => ({
+  type: "fiber:suspend",
+  fiberId,
+  timestamp: 0,
+});
+const resume = (fiberId: string): TraceEvent => ({
+  type: "fiber:resume",
+  fiberId,
+  timestamp: 0,
+});
+const effectStart = (label: string): TraceEvent => ({
+  type: "effect:start",
+  id: label,
+  label,
+  timestamp: 0,
+});
+
+/** Feeds a run through a tagger and reports what each event came out as. */
+function origins(startPaused: boolean, events: TraceEvent[]) {
+  const tag = makeOriginTagger({ startPaused });
+  return events.map((event) => tag(event).origin ?? "program");
+}
+
+describe("makeOriginTagger", () => {
+  it("tags the injected yield's suspend and resume on a paused start", () => {
+    expect(
+      origins(true, [
+        fork("#2"),
+        suspend("#2"),
+        resume("#2"),
+        effectStart("initialization"),
+      ]),
+    ).toEqual(["program", "tool", "tool", "program"]);
+  });
+
+  it("tags nothing when the run was not started paused", () => {
+    expect(origins(false, [fork("#2"), suspend("#2"), resume("#2")])).toEqual([
+      "program",
+      "program",
+      "program",
+    ]);
+  });
+
+  it("leaves the program's own later suspends alone", () => {
+    expect(
+      origins(true, [
+        fork("#2"),
+        suspend("#2"),
+        resume("#2"),
+        suspend("#2"),
+        resume("#2"),
+      ]),
+    ).toEqual(["program", "tool", "tool", "program", "program"]);
+  });
+
+  it("does not mistake the root's id for another fiber's", () => {
+    // The container and the in-browser runtime number their fibers differently,
+    // so the root is whatever forked first, not a fixed id.
+    expect(
+      origins(true, [fork("#0"), suspend("#3"), suspend("#0"), resume("#0")]),
+    ).toEqual(["program", "program", "tool", "tool"]);
+  });
+
+  it("gives up when the root does something other than yield first", () => {
+    // The injected yield is no longer the explanation, so a later suspend is
+    // the program's and must not be hidden.
+    expect(
+      origins(true, [
+        fork("#2"),
+        effectStart("something"),
+        suspend("#2"),
+        resume("#2"),
+      ]),
+    ).toEqual(["program", "program", "program", "program"]);
+  });
+
+  it("does not tag a resume that is not the injected yield's", () => {
+    expect(
+      origins(true, [
+        fork("#2"),
+        suspend("#2"),
+        effectStart("x"),
+        resume("#2"),
+      ]),
+    ).toEqual(["program", "tool", "program", "program"]);
+  });
+
+  it("leaves every other field of an event untouched", () => {
+    const tag = makeOriginTagger({ startPaused: true });
+    tag(fork("#2"));
+
+    expect(tag(suspend("#2"))).toEqual({
+      type: "fiber:suspend",
+      fiberId: "#2",
+      timestamp: 0,
+      origin: "tool",
+    });
+  });
+});

--- a/src/runtime/traceOrigin.ts
+++ b/src/runtime/traceOrigin.ts
@@ -13,8 +13,32 @@
  */
 import type { TraceEvent } from "@/types/trace";
 
+/** Events with no origin are the program's, so only an explicit tag hides one. */
+export function isToolEvent(event: TraceEvent): boolean {
+  return event.origin === "tool";
+}
+
+/**
+ * The fiber that *acted*, or null for events that name no fiber.
+ *
+ * A fork names the fiber being created, not the one doing the forking, so its
+ * parent is the actor.
+ */
+function actingFiberId(event: TraceEvent): string | null {
+  if (event.type === "fiber:fork") return event.parentId ?? null;
+  return "fiberId" in event ? event.fiberId : null;
+}
+
 /** Which part of the injected yield is still to come. */
-type Phase = "awaiting-fork" | "awaiting-suspend" | "awaiting-resume" | "done";
+type Phase =
+  /** Nothing seen yet. The run opens with the root's fork, which names the fiber to watch. */
+  | "awaiting-fork"
+  /** The root is known, and its next act should be the injected yield suspending it. */
+  | "awaiting-suspend"
+  /** The yield has suspended. Its matching resume, once the first step releases it, closes the pair. */
+  | "awaiting-resume"
+  /** Nothing left to look for: both tagged, the search abandoned, or the run started with Play. */
+  | "done";
 
 export interface OriginTaggerOptions {
   /** Whether the run was started paused, which is the only source of injection. */
@@ -41,20 +65,24 @@ export function makeOriginTagger({
     if (phase === "done") return event;
 
     if (phase === "awaiting-fork") {
-      // The root's fork opens every run. Its id is what identifies the pair, and
-      // has to be read rather than hardcoded: the two runtimes number fibers
-      // differently.
-      if (event.type === "fiber:fork") {
-        rootFiberId = event.fiberId;
-        phase = "awaiting-suspend";
+      // The root's fork opens every run, and its id is what identifies the pair:
+      // it has to be read rather than hardcoded, because the two runtimes number
+      // fibers differently. Anything else first means this is not the run we
+      // expect, and the next fork would be a child rather than the root.
+      if (event.type !== "fiber:fork") {
+        phase = "done";
+        return event;
       }
+      rootFiberId = event.fiberId;
+      phase = "awaiting-suspend";
       return event;
     }
 
     // Only the root can settle this. Another fiber's events say nothing either
     // way; events naming no fiber — a span opening, a finalizer — mean the
     // program is already working, so they fall through and end the search.
-    if ("fiberId" in event && event.fiberId !== rootFiberId) return event;
+    const actor = actingFiberId(event);
+    if (actor !== null && actor !== rootFiberId) return event;
 
     if (phase === "awaiting-suspend" && event.type === "fiber:suspend") {
       phase = "awaiting-resume";

--- a/src/runtime/traceOrigin.ts
+++ b/src/runtime/traceOrigin.ts
@@ -1,0 +1,74 @@
+/**
+ * Tags each trace event with who caused it: the program, or the visualizer.
+ *
+ * Only one thing in a run is ever the visualizer's. Starting paused injects an
+ * `Effect.yieldNow()` before the program body, and the runtime yields for real,
+ * so the trace gains a `fiber:suspend` and `fiber:resume` pair that the
+ * program's author never wrote. A run started with Play has no injection, so
+ * nothing is tagged. See `workshop/phase-10.md`.
+ *
+ * That pair cannot be recognised by its contents, because an injected yield
+ * emits exactly what an earned one does. It is recognised by position: it is the
+ * first thing the root fiber does, because that is where we put it.
+ */
+import type { TraceEvent } from "@/types/trace";
+
+/** Which part of the injected yield is still to come. */
+type Phase = "awaiting-fork" | "awaiting-suspend" | "awaiting-resume" | "done";
+
+export interface OriginTaggerOptions {
+  /** Whether the run was started paused, which is the only source of injection. */
+  readonly startPaused: boolean;
+}
+
+/**
+ * Returns the tagger for one run. Call it on every event in order; it gives back
+ * the event marked as the tool's, or unchanged. It holds that run's state, so a
+ * new run needs a new tagger.
+ */
+export function makeOriginTagger({
+  startPaused,
+}: OriginTaggerOptions): (event: TraceEvent) => TraceEvent {
+  let phase: Phase = startPaused ? "awaiting-fork" : "done";
+  let rootFiberId: string | null = null;
+
+  const tool = (event: TraceEvent): TraceEvent => ({
+    ...event,
+    origin: "tool",
+  });
+
+  return (event) => {
+    if (phase === "done") return event;
+
+    if (phase === "awaiting-fork") {
+      // The root's fork opens every run. Its id is what identifies the pair, and
+      // has to be read rather than hardcoded: the two runtimes number fibers
+      // differently.
+      if (event.type === "fiber:fork") {
+        rootFiberId = event.fiberId;
+        phase = "awaiting-suspend";
+      }
+      return event;
+    }
+
+    // Only the root can settle this. Another fiber's events say nothing either
+    // way; events naming no fiber — a span opening, a finalizer — mean the
+    // program is already working, so they fall through and end the search.
+    if ("fiberId" in event && event.fiberId !== rootFiberId) return event;
+
+    if (phase === "awaiting-suspend" && event.type === "fiber:suspend") {
+      phase = "awaiting-resume";
+      return tool(event);
+    }
+    if (phase === "awaiting-resume" && event.type === "fiber:resume") {
+      phase = "done";
+      return tool(event);
+    }
+
+    // The root did something else, so the injected yield is no longer the
+    // explanation for what follows. Stop looking, rather than risk tagging a
+    // suspend the program earned.
+    phase = "done";
+    return event;
+  };
+}

--- a/src/runtime/virtualClock.test.ts
+++ b/src/runtime/virtualClock.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { VirtualClock, type VirtualClockHost } from "./virtualClock";
+
+/**
+ * Resolves the globals at call time so vitest's fake timers are picked up.
+ * The default host captures the real ones at module load, which is what we
+ * want in production but not here.
+ */
+const fakeHost: VirtualClockHost = {
+  now: () => Date.now(),
+  setTimeout: (run, ms) => setTimeout(run, ms),
+  clearTimeout: (handle) =>
+    clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+const makeClock = (rate: number) =>
+  new VirtualClock({ rate, origin: 0, host: fakeHost });
+
+describe("VirtualClock", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("now()", () => {
+    it("tracks wall time at rate 1", () => {
+      const clock = makeClock(1);
+      vi.advanceTimersByTime(500);
+      expect(clock.now()).toBe(500);
+    });
+
+    it("advances at half speed at rate 0.5", () => {
+      const clock = makeClock(0.5);
+      vi.advanceTimersByTime(1000);
+      expect(clock.now()).toBe(500);
+    });
+
+    it("freezes at rate 0", () => {
+      const clock = makeClock(0);
+      vi.advanceTimersByTime(5000);
+      expect(clock.now()).toBe(0);
+    });
+
+    it("stays continuous across a rate change", () => {
+      const clock = makeClock(1);
+      vi.advanceTimersByTime(1000);
+      expect(clock.now()).toBe(1000);
+
+      clock.setRate(0.5);
+      // No jump at the moment of the change.
+      expect(clock.now()).toBe(1000);
+
+      vi.advanceTimersByTime(1000);
+      expect(clock.now()).toBe(1500);
+    });
+  });
+
+  describe("sleep()", () => {
+    it("fires after the requested delay at rate 1", () => {
+      const clock = makeClock(1);
+      const run = vi.fn();
+      clock.sleep(1000, run);
+
+      vi.advanceTimersByTime(999);
+      expect(run).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(run).toHaveBeenCalledOnce();
+    });
+
+    it("takes twice the wall time at rate 0.5", () => {
+      const clock = makeClock(0.5);
+      const run = vi.fn();
+      clock.sleep(1000, run);
+
+      vi.advanceTimersByTime(1999);
+      expect(run).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(run).toHaveBeenCalledOnce();
+    });
+
+    it("can be cancelled", () => {
+      const clock = makeClock(1);
+      const run = vi.fn();
+      const cancel = clock.sleep(1000, run);
+
+      cancel();
+      vi.advanceTimersByTime(5000);
+      expect(run).not.toHaveBeenCalled();
+      expect(clock.pendingCount).toBe(0);
+    });
+  });
+
+  describe("pause (rate 0)", () => {
+    /**
+     * Regression test for the `setTimeout(fn, d / 0)` trap: `Infinity` overflows
+     * a 32-bit signed integer and fires after ~1ms, so a naive implementation
+     * wakes every sleeping fiber the moment you hit pause.
+     */
+    it("parks a pending timer instead of firing it immediately", () => {
+      const clock = makeClock(1);
+      const run = vi.fn();
+      clock.sleep(1000, run);
+
+      clock.setRate(0);
+      vi.advanceTimersByTime(60_000);
+
+      expect(run).not.toHaveBeenCalled();
+      expect(clock.pendingCount).toBe(1);
+    });
+
+    it("parks a timer scheduled while already paused", () => {
+      const clock = makeClock(0);
+      const run = vi.fn();
+      clock.sleep(1000, run);
+
+      vi.advanceTimersByTime(60_000);
+      expect(run).not.toHaveBeenCalled();
+    });
+
+    it("resumes with the remaining time, not the full duration", () => {
+      const clock = makeClock(1);
+      const run = vi.fn();
+      clock.sleep(1000, run);
+
+      vi.advanceTimersByTime(600); // 400 virtual ms left
+      clock.setRate(0);
+      vi.advanceTimersByTime(10_000); // paused: nothing moves
+      clock.setRate(1);
+
+      vi.advanceTimersByTime(399);
+      expect(run).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(run).toHaveBeenCalledOnce();
+    });
+
+    it("resumes at the new rate after a speed change while paused", () => {
+      const clock = makeClock(1);
+      const run = vi.fn();
+      clock.sleep(1000, run);
+
+      vi.advanceTimersByTime(600); // 400 virtual ms left
+      clock.setRate(0);
+      clock.setRate(0.5); // 400 virtual ms == 800 wall ms
+
+      vi.advanceTimersByTime(799);
+      expect(run).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(run).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("advanceToNextDeadline()", () => {
+    it("returns false when nothing is pending", () => {
+      const clock = makeClock(0);
+      expect(clock.advanceToNextDeadline()).toBe(false);
+    });
+
+    it("fires the earliest timer and moves virtual time to its deadline", () => {
+      const clock = makeClock(0);
+      const first = vi.fn();
+      const second = vi.fn();
+      clock.sleep(500, first);
+      clock.sleep(1500, second);
+
+      expect(clock.advanceToNextDeadline()).toBe(true);
+      expect(first).toHaveBeenCalledOnce();
+      expect(second).not.toHaveBeenCalled();
+      expect(clock.now()).toBe(500);
+      expect(clock.pendingCount).toBe(1);
+    });
+
+    it("fires timers sharing a deadline together", () => {
+      const clock = makeClock(0);
+      const a = vi.fn();
+      const b = vi.fn();
+      clock.sleep(500, a);
+      clock.sleep(500, b);
+
+      clock.advanceToNextDeadline();
+      expect(a).toHaveBeenCalledOnce();
+      expect(b).toHaveBeenCalledOnce();
+      expect(clock.pendingCount).toBe(0);
+    });
+
+    it("leaves a timer scheduled by the fired timer pending", () => {
+      const clock = makeClock(0);
+      const inner = vi.fn();
+      clock.sleep(500, () => clock.sleep(500, inner));
+
+      clock.advanceToNextDeadline();
+      expect(inner).not.toHaveBeenCalled();
+      expect(clock.pendingCount).toBe(1);
+
+      clock.advanceToNextDeadline();
+      expect(inner).toHaveBeenCalledOnce();
+      expect(clock.now()).toBe(1000);
+    });
+
+    it("steps a chain of sleeps without any wall time passing", () => {
+      const clock = makeClock(0);
+      const wallBefore = Date.now();
+      const order: string[] = [];
+      clock.sleep(1000, () => {
+        order.push("first");
+        clock.sleep(2000, () => order.push("second"));
+      });
+
+      clock.advanceToNextDeadline();
+      clock.advanceToNextDeadline();
+
+      expect(order).toEqual(["first", "second"]);
+      expect(clock.now()).toBe(3000);
+      expect(Date.now() - wallBefore).toBe(0); // no wall time consumed
+    });
+  });
+
+  describe("clearAll()", () => {
+    it("drops every pending timer", () => {
+      const clock = makeClock(1);
+      const run = vi.fn();
+      clock.sleep(1000, run);
+      clock.sleep(2000, run);
+
+      clock.clearAll();
+      vi.advanceTimersByTime(5000);
+
+      expect(run).not.toHaveBeenCalled();
+      expect(clock.pendingCount).toBe(0);
+    });
+  });
+
+  it("rejects a negative rate", () => {
+    const clock = makeClock(1);
+    expect(() => clock.setRate(-1)).toThrow(/rate must be >= 0/);
+  });
+});

--- a/src/runtime/virtualClock.test.ts
+++ b/src/runtime/virtualClock.test.ts
@@ -321,6 +321,74 @@ describe("VirtualClock", () => {
     });
   });
 
+  describe("at-most-once execution", () => {
+    it("runs the callback once across repeated rate changes", () => {
+      const clock = makeClock(1);
+      const run = vi.fn();
+      clock.sleep(1000, run);
+
+      for (const rate of [0.5, 0, 0.25, 1, 0, 0.75, 1]) {
+        clock.setRate(rate);
+      }
+      vi.advanceTimersByTime(10_000);
+
+      expect(run).toHaveBeenCalledOnce();
+    });
+
+    it("does not fire again from the real timer after a virtual jump", () => {
+      const clock = makeClock(1);
+      const run = vi.fn();
+      clock.sleep(500, run);
+
+      // Fires via the jump while a real timeout for the same timer is armed.
+      clock.advanceToNextDeadline();
+      expect(run).toHaveBeenCalledOnce();
+
+      vi.advanceTimersByTime(10_000);
+      expect(run).toHaveBeenCalledOnce();
+      expect(clock.pendingCount).toBe(0);
+    });
+
+    it("does not re-arm a timer that changes the rate from its own callback", () => {
+      const clock = makeClock(1);
+      const run = vi.fn(() => {
+        clock.setRate(0.5);
+      });
+      clock.sleep(500, run);
+
+      vi.advanceTimersByTime(10_000);
+      expect(run).toHaveBeenCalledOnce();
+    });
+
+    it("ignores a cancel issued after the callback ran", () => {
+      const clock = makeClock(1);
+      const run = vi.fn();
+      const cancel = clock.sleep(500, run);
+
+      vi.advanceTimersByTime(500);
+      expect(run).toHaveBeenCalledOnce();
+
+      cancel();
+      vi.advanceTimersByTime(10_000);
+      expect(run).toHaveBeenCalledOnce();
+    });
+
+    it("keeps sibling timers intact when one cancels another from its callback", () => {
+      const clock = makeClock(1);
+      const survivor = vi.fn();
+      let cancelVictim: () => void = () => {};
+      const victim = vi.fn();
+
+      clock.sleep(500, () => cancelVictim());
+      cancelVictim = clock.sleep(800, victim);
+      clock.sleep(1000, survivor);
+
+      vi.advanceTimersByTime(2000);
+      expect(victim).not.toHaveBeenCalled();
+      expect(survivor).toHaveBeenCalledOnce();
+    });
+  });
+
   describe("clearAll()", () => {
     it("drops every pending timer", () => {
       const clock = makeClock(1);

--- a/src/runtime/virtualClock.test.ts
+++ b/src/runtime/virtualClock.test.ts
@@ -204,6 +204,27 @@ describe("VirtualClock", () => {
       expect(clock.now()).toBe(1000);
     });
 
+    it("re-arms the remaining timers when the rate is not zero", () => {
+      const clock = makeClock(1);
+      const first = vi.fn();
+      const second = vi.fn();
+      clock.sleep(500, first);
+      clock.sleep(1500, second);
+
+      // Jump straight to the first deadline without wall time passing.
+      clock.advanceToNextDeadline();
+      expect(first).toHaveBeenCalledOnce();
+      expect(clock.now()).toBe(500);
+
+      // 1000 virtual ms later the second is due; its real timer was armed
+      // against the pre-jump anchor and must have been re-armed.
+      vi.advanceTimersByTime(999);
+      expect(second).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(second).toHaveBeenCalledOnce();
+    });
+
     it("steps a chain of sleeps without any wall time passing", () => {
       const clock = makeClock(0);
       const wallBefore = Date.now();
@@ -219,6 +240,84 @@ describe("VirtualClock", () => {
       expect(order).toEqual(["first", "second"]);
       expect(clock.now()).toBe(3000);
       expect(Date.now() - wallBefore).toBe(0); // no wall time consumed
+    });
+  });
+
+  describe("chained sleeps", () => {
+    it("re-bases each nested sleep on the moment it was scheduled", () => {
+      const clock = makeClock(0.5);
+      const order: string[] = [];
+      clock.sleep(1000, () => {
+        order.push("a");
+        clock.sleep(1000, () => {
+          order.push("b");
+          clock.sleep(1000, () => order.push("c"));
+        });
+      });
+
+      vi.advanceTimersByTime(2000);
+      expect(order).toEqual(["a"]);
+      vi.advanceTimersByTime(2000);
+      expect(order).toEqual(["a", "b"]);
+      vi.advanceTimersByTime(2000);
+      expect(order).toEqual(["a", "b", "c"]);
+      expect(clock.now()).toBe(3000);
+    });
+
+    it("applies a rate change to a sleep scheduled by an earlier sleep", () => {
+      const clock = makeClock(1);
+      const order: string[] = [];
+      clock.sleep(1000, () => {
+        order.push("a");
+        clock.sleep(1000, () => order.push("b"));
+      });
+
+      vi.advanceTimersByTime(1000);
+      expect(order).toEqual(["a"]);
+
+      clock.setRate(0.5);
+      vi.advanceTimersByTime(1999);
+      expect(order).toEqual(["a"]);
+
+      vi.advanceTimersByTime(1);
+      expect(order).toEqual(["a", "b"]);
+    });
+
+    it("parks an inner sleep when paused mid-chain", () => {
+      const clock = makeClock(1);
+      const inner = vi.fn();
+      clock.sleep(500, () => clock.sleep(1000, inner));
+
+      vi.advanceTimersByTime(500); // outer fired, inner scheduled
+      clock.setRate(0);
+      vi.advanceTimersByTime(60_000);
+      expect(inner).not.toHaveBeenCalled();
+
+      clock.setRate(1);
+      vi.advanceTimersByTime(999);
+      expect(inner).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(inner).toHaveBeenCalledOnce();
+    });
+
+    it("keeps a sleep started before a pause independent of one started after", () => {
+      const clock = makeClock(1);
+      const first = vi.fn();
+      const second = vi.fn();
+      clock.sleep(1000, first);
+
+      vi.advanceTimersByTime(400); // 600 left on first
+      clock.setRate(0);
+      clock.sleep(1000, second); // scheduled while frozen
+      clock.setRate(1);
+
+      vi.advanceTimersByTime(600);
+      expect(first).toHaveBeenCalledOnce();
+      expect(second).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(400);
+      expect(second).toHaveBeenCalledOnce();
     });
   });
 

--- a/src/runtime/virtualClock.ts
+++ b/src/runtime/virtualClock.ts
@@ -144,6 +144,10 @@ export class VirtualClock {
     if (deadline === null) return false;
     this.#reanchor(Math.max(deadline, this.now()));
     this.#fireDue();
+    // Survivors were armed against the previous anchor. At rate 0 they are
+    // parked and this is a no-op; above 0 they would otherwise fire late by
+    // exactly the amount of virtual time the jump skipped.
+    this.#rearmAll();
     return true;
   }
 
@@ -186,11 +190,13 @@ export class VirtualClock {
     timer.run();
   }
 
-  /** Fire every timer whose deadline has been reached, newest schedules included. */
+  /** Fire every timer already due, in deadline order. */
   #fireDue(): void {
-    // Snapshot: a firing timer may schedule another one.
+    // Snapshot against a single reading of now(), so a timer firing (and
+    // scheduling more work) cannot change which timers this pass considers.
+    const now = this.now();
     const due = [...this.#timers.values()]
-      .filter((timer) => timer.deadline <= this.now())
+      .filter((timer) => timer.deadline <= now)
       .sort((a, b) => a.deadline - b.deadline);
     for (const timer of due) {
       if (timer.handle !== null) this.#host.clearTimeout(timer.handle);

--- a/src/runtime/virtualClock.ts
+++ b/src/runtime/virtualClock.ts
@@ -3,7 +3,7 @@
  *
  * Two notions of time are kept distinct throughout this file:
  *
- * - **wall time** — real elapsed time, read from `Date.now()`. Always moves
+ * - **wall time** — real elapsed time, read from `performance`. Always moves
  *   forward at its own pace; we cannot influence it.
  * - **virtual time** — the time the running program believes it is in. It is
  *   what the Effect `Clock` reports and what `Effect.sleep` counts down in.
@@ -23,10 +23,20 @@
  */
 
 /**
- * Captured at module load, before any `Date` shim is installed. The shim reads
- * this clock, so the clock must never read the shim back.
+ * Wall time as an epoch timestamp, read from `performance` rather than `Date`.
+ *
+ * The `Date` shim reads this clock, so the clock must never read the shim back.
+ * Capturing `Date.now` at module load would achieve that only as long as this
+ * module is always evaluated before the shim is installed — a guarantee that
+ * would live in import order and be enforced by nothing, failing as unbounded
+ * recursion if it were ever broken. `performance` is never shimmed, so reading
+ * it makes the clock immune by construction instead.
+ *
+ * `performance.now()` is also monotonic, so virtual time cannot jump backwards
+ * when the system clock is corrected by NTP or changed by the user.
  */
-const realNow = Date.now.bind(Date);
+const wallNow = () => performance.timeOrigin + performance.now();
+
 const realSetTimeout = globalThis.setTimeout.bind(globalThis);
 const realClearTimeout = globalThis.clearTimeout.bind(globalThis);
 
@@ -38,7 +48,7 @@ export interface VirtualClockHost {
 }
 
 const defaultHost: VirtualClockHost = {
-  now: realNow,
+  now: wallNow,
   setTimeout: realSetTimeout,
   clearTimeout: (handle) =>
     realClearTimeout(handle as ReturnType<typeof realSetTimeout>),

--- a/src/runtime/virtualClock.ts
+++ b/src/runtime/virtualClock.ts
@@ -1,9 +1,17 @@
 /**
  * Virtual time source shared by the Effect `Clock` layer and the `Date` shim.
  *
+ * Two notions of time are kept distinct throughout this file:
+ *
+ * - **wall time** — real elapsed time, read from `Date.now()`. Always moves
+ *   forward at its own pace; we cannot influence it.
+ * - **virtual time** — the time the running program believes it is in. It is
+ *   what the Effect `Clock` reports and what `Effect.sleep` counts down in.
+ *
  * Virtual time is a piecewise-linear function of wall time: it advances at
- * `rate` milliseconds per wall millisecond. `rate = 1` is real time, `rate = 0.5`
- * is half speed, `rate = 0` freezes time (pause).
+ * `rate` virtual milliseconds per wall millisecond. `rate = 1` is real time,
+ * `rate = 0.5` is half speed, `rate = 0` freezes virtual time while wall time
+ * keeps going (pause). See `workshop/phase-10.md` for the full rationale.
  *
  * Every rate change re-anchors the mapping, so virtual time is continuous: it
  * never jumps when the user changes speed, it only changes slope.

--- a/src/runtime/virtualClock.ts
+++ b/src/runtime/virtualClock.ts
@@ -165,6 +165,10 @@ export class VirtualClock {
   }
 
   #arm(timer: Timer): void {
+    // Defensive: never leave two real timeouts outstanding for one timer. A
+    // stray one could not run the callback twice (see #fire) but would sit in
+    // the event loop until it fired and found nothing.
+    if (timer.handle !== null) this.#host.clearTimeout(timer.handle);
     if (this.#rate === 0) {
       timer.handle = null;
       return;
@@ -183,6 +187,13 @@ export class VirtualClock {
     }
   }
 
+  /**
+   * The only place a callback is ever invoked. Membership in `#timers` is the
+   * claim to run: the entry is removed *before* `run()`, so any later path
+   * reaching the same id — a stray real timeout, a cancel, a second jump —
+   * finds nothing and no-ops. Ids are monotonic, so a stale callback can never
+   * alias a newer timer.
+   */
   #fire(id: number): void {
     const timer = this.#timers.get(id);
     if (timer === undefined) return;

--- a/src/runtime/virtualClock.ts
+++ b/src/runtime/virtualClock.ts
@@ -40,6 +40,16 @@ const wallNow = () => performance.timeOrigin + performance.now();
 const realSetTimeout = globalThis.setTimeout.bind(globalThis);
 const realClearTimeout = globalThis.clearTimeout.bind(globalThis);
 
+/**
+ * Reads the current timestamp in epoch milliseconds on the virtual clock.
+ *
+ * Passed to the trace emitters that run outside an Effect context — `Supervisor`
+ * callbacks and `runProgramFork` — so their timestamps are virtual like every
+ * other event's. Code that *is* inside an Effect uses `Clock.currentTimeMillis`
+ * instead.
+ */
+export type Now = () => number;
+
 /** The wall-clock primitives the virtual clock is built on. Injectable for tests. */
 export interface VirtualClockHost {
   now: () => number;

--- a/src/runtime/virtualClock.ts
+++ b/src/runtime/virtualClock.ts
@@ -16,10 +16,10 @@
  * Every rate change re-anchors the mapping, so virtual time is continuous: it
  * never jumps when the user changes speed, it only changes slope.
  *
- * Pause is expressed by *parking* pending timers, not by dividing the delay by
- * the rate. `setTimeout(fn, d / 0)` is `setTimeout(fn, Infinity)`, which
- * overflows a 32-bit signed integer and fires after ~1ms — pause would wake
- * every sleeping fiber instead of freezing it.
+ * Pause *parks* pending timers: the real timeout is cleared, the virtual
+ * deadline is kept, and it is re-armed on resume with the time that was left.
+ * Scaling the delay by the rate cannot express a pause, because `setTimeout` has
+ * no delay meaning "never".
  */
 
 /**

--- a/src/runtime/virtualClock.ts
+++ b/src/runtime/virtualClock.ts
@@ -1,0 +1,207 @@
+/**
+ * Virtual time source shared by the Effect `Clock` layer and the `Date` shim.
+ *
+ * Virtual time is a piecewise-linear function of wall time: it advances at
+ * `rate` milliseconds per wall millisecond. `rate = 1` is real time, `rate = 0.5`
+ * is half speed, `rate = 0` freezes time (pause).
+ *
+ * Every rate change re-anchors the mapping, so virtual time is continuous: it
+ * never jumps when the user changes speed, it only changes slope.
+ *
+ * Pause is expressed by *parking* pending timers, not by dividing the delay by
+ * the rate. `setTimeout(fn, d / 0)` is `setTimeout(fn, Infinity)`, which
+ * overflows a 32-bit signed integer and fires after ~1ms — pause would wake
+ * every sleeping fiber instead of freezing it.
+ */
+
+/**
+ * Captured at module load, before any `Date` shim is installed. The shim reads
+ * this clock, so the clock must never read the shim back.
+ */
+const realNow = Date.now.bind(Date);
+const realSetTimeout = globalThis.setTimeout.bind(globalThis);
+const realClearTimeout = globalThis.clearTimeout.bind(globalThis);
+
+/** The wall-clock primitives the virtual clock is built on. Injectable for tests. */
+export interface VirtualClockHost {
+  now: () => number;
+  setTimeout: (run: () => void, ms: number) => unknown;
+  clearTimeout: (handle: unknown) => void;
+}
+
+const defaultHost: VirtualClockHost = {
+  now: realNow,
+  setTimeout: realSetTimeout,
+  clearTimeout: (handle) =>
+    realClearTimeout(handle as ReturnType<typeof realSetTimeout>),
+};
+
+interface Timer {
+  readonly id: number;
+  /** Virtual timestamp at which this timer is due. */
+  readonly deadline: number;
+  readonly run: () => void;
+  /** Real timer handle, or null while parked (rate 0). */
+  handle: unknown;
+}
+
+export interface VirtualClockOptions {
+  /** Virtual ms per wall ms. Defaults to 1 (real time). */
+  rate?: number;
+  /** Epoch-based starting point, so `new Date(clock.now())` reads sensibly. */
+  origin?: number;
+  host?: VirtualClockHost;
+}
+
+export class VirtualClock {
+  readonly #host: VirtualClockHost;
+  #rate: number;
+  /** Virtual timestamp at the last re-anchor. */
+  #virtualAnchor: number;
+  /** Wall timestamp at the last re-anchor. */
+  #wallAnchor: number;
+  #timers = new Map<number, Timer>();
+  #nextId = 1;
+
+  constructor(options: VirtualClockOptions = {}) {
+    this.#host = options.host ?? defaultHost;
+    this.#rate = options.rate ?? 1;
+    this.#virtualAnchor = options.origin ?? this.#host.now();
+    this.#wallAnchor = this.#host.now();
+  }
+
+  get rate(): number {
+    return this.#rate;
+  }
+
+  /** Whether time is frozen. Pending timers stay parked until the rate is raised. */
+  get isPaused(): boolean {
+    return this.#rate === 0;
+  }
+
+  /** Current virtual timestamp, epoch-based. */
+  now(): number {
+    return (
+      this.#virtualAnchor + (this.#host.now() - this.#wallAnchor) * this.#rate
+    );
+  }
+
+  /**
+   * Change the speed of time. Re-anchors so virtual time stays continuous, then
+   * re-arms every pending timer against the new rate.
+   */
+  setRate(rate: number): void {
+    if (rate < 0) {
+      throw new Error(`VirtualClock rate must be >= 0, received ${rate}`);
+    }
+    if (rate === this.#rate) return;
+    this.#reanchor(this.now());
+    this.#rate = rate;
+    this.#rearmAll();
+  }
+
+  /**
+   * Schedule `run` after `durationMs` of *virtual* time. Returns a cancel function.
+   */
+  sleep(durationMs: number, run: () => void): () => void {
+    const id = this.#nextId++;
+    const timer: Timer = {
+      id,
+      deadline: this.now() + Math.max(0, durationMs),
+      run,
+      handle: null,
+    };
+    this.#timers.set(id, timer);
+    this.#arm(timer);
+    return () => this.#cancel(id);
+  }
+
+  /** Number of timers waiting to fire. */
+  get pendingCount(): number {
+    return this.#timers.size;
+  }
+
+  /** Earliest pending virtual deadline, or null when nothing is scheduled. */
+  earliestDeadline(): number | null {
+    let earliest: number | null = null;
+    for (const timer of this.#timers.values()) {
+      if (earliest === null || timer.deadline < earliest) {
+        earliest = timer.deadline;
+      }
+    }
+    return earliest;
+  }
+
+  /**
+   * Jump virtual time forward to the earliest pending deadline and fire
+   * everything due. This is how a paused clock makes progress: it is the
+   * time-blocked rung of the stepper.
+   *
+   * Returns false when nothing was pending.
+   */
+  advanceToNextDeadline(): boolean {
+    const deadline = this.earliestDeadline();
+    if (deadline === null) return false;
+    this.#reanchor(Math.max(deadline, this.now()));
+    this.#fireDue();
+    return true;
+  }
+
+  /** Cancel every pending timer. Used on reset. */
+  clearAll(): void {
+    for (const timer of this.#timers.values()) {
+      if (timer.handle !== null) this.#host.clearTimeout(timer.handle);
+    }
+    this.#timers.clear();
+  }
+
+  #reanchor(virtualNow: number): void {
+    this.#virtualAnchor = virtualNow;
+    this.#wallAnchor = this.#host.now();
+  }
+
+  #arm(timer: Timer): void {
+    if (this.#rate === 0) {
+      timer.handle = null;
+      return;
+    }
+    const remainingVirtual = Math.max(0, timer.deadline - this.now());
+    timer.handle = this.#host.setTimeout(
+      () => this.#fire(timer.id),
+      remainingVirtual / this.#rate,
+    );
+  }
+
+  #rearmAll(): void {
+    for (const timer of this.#timers.values()) {
+      if (timer.handle !== null) this.#host.clearTimeout(timer.handle);
+      this.#arm(timer);
+    }
+  }
+
+  #fire(id: number): void {
+    const timer = this.#timers.get(id);
+    if (timer === undefined) return;
+    this.#timers.delete(id);
+    timer.run();
+  }
+
+  /** Fire every timer whose deadline has been reached, newest schedules included. */
+  #fireDue(): void {
+    // Snapshot: a firing timer may schedule another one.
+    const due = [...this.#timers.values()]
+      .filter((timer) => timer.deadline <= this.now())
+      .sort((a, b) => a.deadline - b.deadline);
+    for (const timer of due) {
+      if (timer.handle !== null) this.#host.clearTimeout(timer.handle);
+      this.#fire(timer.id);
+    }
+  }
+
+  #cancel(id: number): void {
+    const timer = this.#timers.get(id);
+    if (timer === undefined) return;
+    if (timer.handle !== null) this.#host.clearTimeout(timer.handle);
+    this.#timers.delete(id);
+  }
+}

--- a/src/runtime/vizClock.test.ts
+++ b/src/runtime/vizClock.test.ts
@@ -1,0 +1,150 @@
+import { Clock, Effect, Fiber, Option } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { VirtualClock, type VirtualClockHost } from "@/runtime/virtualClock";
+import { makeVizClockLayer } from "@/runtime/vizClock";
+
+/** Resolves the globals at call time so vitest's fake timers are picked up. */
+const fakeHost: VirtualClockHost = {
+  now: () => Date.now(),
+  setTimeout: (run, ms) => setTimeout(run, ms),
+  clearTimeout: (handle) =>
+    clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+function setup(rate: number) {
+  const virtual = new VirtualClock({ rate, origin: 0, host: fakeHost });
+  const layer = makeVizClockLayer(virtual);
+  const run = <A>(effect: Effect.Effect<A>) =>
+    Effect.runPromise(effect.pipe(Effect.provide(layer)));
+  const fork = <A>(effect: Effect.Effect<A>) =>
+    Effect.runFork(effect.pipe(Effect.provide(layer)));
+  return { virtual, layer, run, fork };
+}
+
+describe("vizClock", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("Effect.sleep", () => {
+    it("takes the requested wall time at rate 1", async () => {
+      const { run } = setup(1);
+      const done = vi.fn();
+      const promise = run(
+        Effect.sleep("1 second").pipe(Effect.tap(() => Effect.sync(done))),
+      );
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(done).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(done).toHaveBeenCalledOnce();
+      await promise;
+    });
+
+    it("takes twice the wall time at rate 0.5", async () => {
+      const { run } = setup(0.5);
+      const done = vi.fn();
+      const promise = run(
+        Effect.sleep("1 second").pipe(Effect.tap(() => Effect.sync(done))),
+      );
+
+      await vi.advanceTimersByTimeAsync(1999);
+      expect(done).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(done).toHaveBeenCalledOnce();
+      await promise;
+    });
+
+    it("never completes while paused, and completes after resuming", async () => {
+      const { virtual, run } = setup(0);
+      const done = vi.fn();
+      const promise = run(
+        Effect.sleep("1 second").pipe(Effect.tap(() => Effect.sync(done))),
+      );
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(done).not.toHaveBeenCalled();
+      expect(virtual.pendingCount).toBe(1);
+
+      virtual.setRate(1);
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(done).toHaveBeenCalledOnce();
+      await promise;
+    });
+  });
+
+  describe("Clock.currentTimeMillis", () => {
+    it("reports virtual time, so elapsed is the same at any rate", async () => {
+      const elapsed = Effect.gen(function* () {
+        const before = yield* Clock.currentTimeMillis;
+        yield* Effect.sleep("1 second");
+        return (yield* Clock.currentTimeMillis) - before;
+      });
+
+      const fast = setup(1);
+      const fastPromise = fast.run(elapsed);
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(await fastPromise).toBe(1000);
+
+      const slow = setup(0.25);
+      const slowPromise = slow.run(elapsed);
+      await vi.advanceTimersByTimeAsync(4000); // 4x the wall time
+      expect(await slowPromise).toBe(1000); // same virtual duration
+    });
+  });
+
+  describe("semantics are preserved", () => {
+    /**
+     * The point of scaling the clock rather than pacing the UI: relative timing
+     * still decides outcomes, so the program behaves identically at any speed.
+     */
+    it.each([1, 0.5, 0.25])(
+      "keeps the race winner at rate %s",
+      async (rate) => {
+        const { run } = setup(rate);
+        const race = Effect.race(
+          Effect.sleep("1 second").pipe(Effect.as("fast")),
+          Effect.sleep("2 seconds").pipe(Effect.as("slow")),
+        );
+
+        const promise = run(race);
+        await vi.advanceTimersByTimeAsync(2000 / rate);
+        expect(await promise).toBe("fast");
+      },
+    );
+
+    it.each([1, 0.25])("keeps a timeout firing at rate %s", async (rate) => {
+      const { run } = setup(rate);
+      const timed = Effect.sleep("2 seconds").pipe(
+        Effect.timeoutOption("1 second"),
+      );
+
+      const promise = run(timed);
+      await vi.advanceTimersByTimeAsync(3000 / rate);
+      expect(Option.isNone(await promise)).toBe(true);
+    });
+  });
+
+  describe("interruption", () => {
+    it("cancels the pending virtual timer", async () => {
+      const { virtual, fork } = setup(1);
+      const fiber = fork(Effect.sleep("10 seconds"));
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(virtual.pendingCount).toBe(1);
+
+      const interrupted = Effect.runPromise(Fiber.interrupt(fiber));
+      await vi.advanceTimersByTimeAsync(0);
+      await interrupted;
+
+      expect(virtual.pendingCount).toBe(0);
+    });
+  });
+});

--- a/src/runtime/vizClock.ts
+++ b/src/runtime/vizClock.ts
@@ -1,0 +1,41 @@
+/**
+ * An Effect `Clock` backed by the `VirtualClock`.
+ *
+ * Everything time-related in Effect goes through this service — `Effect.sleep`,
+ * `Schedule` delays, `Effect.timeout`, `Effect.race`, and even the timestamps
+ * on `Effect.log`. Replacing it scales *all* of them by the same factor, so a
+ * program's observable behaviour is unchanged: it is slow motion, not a
+ * distortion. Only the wall-clock duration changes.
+ */
+import { Clock, Duration, Effect, Layer } from "effect";
+
+import type { VirtualClock } from "@/runtime/virtualClock";
+
+const NANOS_PER_MILLI = 1_000_000;
+
+export function makeVizClock(virtual: VirtualClock): Clock.Clock {
+  const unsafeCurrentTimeMillis = () => virtual.now();
+  const unsafeCurrentTimeNanos = () =>
+    BigInt(Math.round(virtual.now() * NANOS_PER_MILLI));
+
+  return {
+    [Clock.ClockTypeId]: Clock.ClockTypeId,
+    unsafeCurrentTimeMillis,
+    unsafeCurrentTimeNanos,
+    // `Effect.sync` defers, so these read virtual time when run, not when built.
+    currentTimeMillis: Effect.sync(unsafeCurrentTimeMillis),
+    currentTimeNanos: Effect.sync(unsafeCurrentTimeNanos),
+    sleep: (duration: Duration.Duration) =>
+      Effect.async<void>((resume) => {
+        const cancel = virtual.sleep(Duration.toMillis(duration), () =>
+          resume(Effect.void),
+        );
+        // Returned canceler runs on interruption, so an interrupted fiber does
+        // not leave a timer pending on the virtual clock.
+        return Effect.sync(cancel);
+      }),
+  };
+}
+
+export const makeVizClockLayer = (virtual: VirtualClock): Layer.Layer<never> =>
+  Layer.setClock(makeVizClock(virtual));

--- a/src/runtime/vizSupervisor.ts
+++ b/src/runtime/vizSupervisor.ts
@@ -8,6 +8,7 @@ import {
   Exit,
 } from "effect";
 
+import type { Now } from "@/runtime/virtualClock";
 import type { TraceEvent } from "@/types/trace";
 
 type OnEmit = (event: TraceEvent) => void;
@@ -32,10 +33,14 @@ function shouldIgnoreFiber(
 class VizSupervisor extends Supervisor.AbstractSupervisor<void> {
   value: Effect.Effect<void, never, never>;
   onEmit: OnEmit;
-  constructor(onEmit: OnEmit) {
+  /** Supervisor callbacks are synchronous and outside any Effect, so virtual
+   * time has to be handed in rather than read from the Clock service. */
+  now: Now;
+  constructor(onEmit: OnEmit, now: Now) {
     super();
     this.value = Effect.void;
     this.onEmit = onEmit;
+    this.now = now;
   }
   onStart<A, E, R>(
     _context: Context.Context<R>,
@@ -56,7 +61,7 @@ class VizSupervisor extends Supervisor.AbstractSupervisor<void> {
       fiberId,
       parentId,
       label: fiberId,
-      timestamp: Date.now(),
+      timestamp: this.now(),
     });
   }
   onEnd<A, E>(exit: Exit.Exit<A, E>, fiber: Fiber.RuntimeFiber<A, E>): void {
@@ -67,7 +72,7 @@ class VizSupervisor extends Supervisor.AbstractSupervisor<void> {
     this.onEmit({
       type: Exit.isSuccess(exit) ? "fiber:end" : "fiber:interrupt",
       fiberId,
-      timestamp: Date.now(),
+      timestamp: this.now(),
     });
   }
   onSuspend<A, E>(fiber: Fiber.RuntimeFiber<A, E>): void {
@@ -78,7 +83,7 @@ class VizSupervisor extends Supervisor.AbstractSupervisor<void> {
     this.onEmit({
       type: "fiber:suspend",
       fiberId,
-      timestamp: Date.now(),
+      timestamp: this.now(),
     });
   }
   onResume<A, E>(fiber: Fiber.RuntimeFiber<A, E>): void {
@@ -89,11 +94,11 @@ class VizSupervisor extends Supervisor.AbstractSupervisor<void> {
     this.onEmit({
       type: "fiber:resume",
       fiberId,
-      timestamp: Date.now(),
+      timestamp: this.now(),
     });
   }
 }
 
-export function makeVizLayers(onEmit: OnEmit) {
-  return Supervisor.addSupervisor(new VizSupervisor(onEmit));
+export function makeVizLayers(onEmit: OnEmit, now: Now) {
+  return Supervisor.addSupervisor(new VizSupervisor(onEmit, now));
 }

--- a/src/runtime/vizTracer.ts
+++ b/src/runtime/vizTracer.ts
@@ -10,12 +10,17 @@ const NANOS_PER_MILLI = 1_000_000n;
 /**
  * The runtime hands span times in as nanoseconds taken from the Clock service
  * (`internal/core-effect.ts` builds them with `clock.unsafeCurrentTimeNanos()`),
- * so they are already virtual and we should use them rather than reading a clock
- * ourselves. They are `0n` when tracer timing is disabled, which is when `now`
- * is needed as a fallback.
+ * so they are already virtual and we use them rather than reading a clock again.
  *
- * Dividing as BigInt before converting keeps the value inside the safe integer
- * range; nanosecond epochs do not fit in a double.
+ * `0n` is not a timestamp, it is Effect's "no timing recorded" sentinel: when the
+ * `currentTracerTimingEnabled` FiberRef is off — it defaults to on, and
+ * `Effect.withTracerTiming(false)` turns it off — the runtime skips the clock
+ * read entirely and passes a constant zero instead. Treating that as a value
+ * would date every span to 1 January 1970 and flatten the timeline, so we fall
+ * back to `now` in that case.
+ *
+ * Dividing as BigInt before converting keeps the value exact: a nanosecond epoch
+ * is around 1.8e18, well past `Number.MAX_SAFE_INTEGER`.
  */
 function toMillis(nanos: bigint, now: Now): number {
   return nanos === 0n ? now() : Number(nanos / NANOS_PER_MILLI);

--- a/src/runtime/vizTracer.ts
+++ b/src/runtime/vizTracer.ts
@@ -2,9 +2,26 @@ import { Tracer, Exit, Cause, Option, Context } from "effect";
 import type { RuntimeFiber } from "effect/Fiber";
 
 import { randomUUID } from "@/lib/crypto";
+import type { Now } from "@/runtime/virtualClock";
 import type { TraceEvent } from "@/types/trace";
 
-export function makeVizTracer(onEmit: (event: TraceEvent) => void) {
+const NANOS_PER_MILLI = 1_000_000n;
+
+/**
+ * The runtime hands span times in as nanoseconds taken from the Clock service
+ * (`internal/core-effect.ts` builds them with `clock.unsafeCurrentTimeNanos()`),
+ * so they are already virtual and we should use them rather than reading a clock
+ * ourselves. They are `0n` when tracer timing is disabled, which is when `now`
+ * is needed as a fallback.
+ *
+ * Dividing as BigInt before converting keeps the value inside the safe integer
+ * range; nanosecond epochs do not fit in a double.
+ */
+function toMillis(nanos: bigint, now: Now): number {
+  return nanos === 0n ? now() : Number(nanos / NANOS_PER_MILLI);
+}
+
+export function makeVizTracer(onEmit: (event: TraceEvent) => void, now: Now) {
   return Tracer.make({
     span: function (
       label: string,
@@ -20,7 +37,7 @@ export function makeVizTracer(onEmit: (event: TraceEvent) => void) {
         type: "effect:start",
         label,
         id,
-        timestamp: Date.now(),
+        timestamp: toMillis(startTime, now),
       });
       return {
         _tag: "Span",
@@ -38,7 +55,7 @@ export function makeVizTracer(onEmit: (event: TraceEvent) => void) {
         sampled: false,
         kind,
         end: function (
-          _endTime: bigint,
+          endTime: bigint,
           exit: Exit.Exit<unknown, unknown>,
         ): void {
           const { result, value, error } = Exit.isSuccess(exit)
@@ -50,7 +67,7 @@ export function makeVizTracer(onEmit: (event: TraceEvent) => void) {
             result,
             value,
             error,
-            timestamp: Date.now(),
+            timestamp: toMillis(endTime, now),
           });
         },
         attribute: function (): void {},

--- a/src/services/webContainerLogs.ts
+++ b/src/services/webContainerLogs.ts
@@ -1,7 +1,12 @@
 import { Context, Effect, Layer } from "effect";
 
+import type { WebContainerLogLabel } from "@/stores/webContainerLogsStore";
+
 export interface WebContainerLogs {
-  readonly log: (label: string, message: string) => Effect.Effect<void>;
+  readonly log: (
+    label: WebContainerLogLabel,
+    message: string,
+  ) => Effect.Effect<void>;
 }
 
 export const WebContainerLogs = Context.GenericTag<WebContainerLogs>(
@@ -13,7 +18,7 @@ export const WebContainerLogs = Context.GenericTag<WebContainerLogs>(
  * This bridges Effect's world with React's world.
  */
 export const makeWebContainerLogsLayer = (
-  onLog: (label: string, message: string) => void,
+  onLog: (label: WebContainerLogLabel, message: string) => void,
 ): Layer.Layer<WebContainerLogs> =>
   Layer.succeed(WebContainerLogs, {
     log: (label, message) => Effect.sync(() => onLog(label, message)),

--- a/src/services/webcontainer.ts
+++ b/src/services/webcontainer.ts
@@ -94,13 +94,15 @@ async function main() {
 
   const onEmit = event => process.stdout.write("TRACE_EVENT:" + JSON.stringify(event) + "\\n");
 
+  const now = () => virtualClock.now();
+
   const traceLayer = _makeTraceEmitterLayer(onEmit);
-  const supervisorLayer = _makeVizLayers(onEmit);
-  const tracerLayer = Layer.setTracer(_makeVizTracer(onEmit));
+  const supervisorLayer = _makeVizLayers(onEmit, now);
+  const tracerLayer = Layer.setTracer(_makeVizTracer(onEmit, now));
   const clockLayer = _makeVizClockLayer(virtualClock);
   const allLayers = Layer.mergeAll(traceLayer, supervisorLayer, tracerLayer, clockLayer, ...requirements);
   const program = Effect.scoped(rootEffect).pipe(Effect.provide(allLayers));
-  const { promise } = _runProgramFork(program, onEmit);
+  const { promise } = _runProgramFork(program, onEmit, now);
   promise.then(
     (result) => console.log("Program completed:", result),
     (error) => console.error("Program failed:", error),
@@ -111,9 +113,10 @@ main();
 
 /** Minimal traced Effect program for pre-warm — loads effect, runtime, emits one trace event */
 const PREWARM_PROGRAM = `import { Effect } from "effect";
-import { runProgramFork } from "./runtime.js";
+import { _runProgramFork } from "./runtime.js";
 const program = Effect.succeed("prewarm");
-const { promise } = runProgramFork(program, () => {});
+// Events are discarded here, so wall time is fine — no clock is installed.
+const { promise } = _runProgramFork(program, () => {}, Date.now);
 promise.then(() => {}, (error) => console.error("Warmup program failed:", error));
 `;
 

--- a/src/services/webcontainer.ts
+++ b/src/services/webcontainer.ts
@@ -78,9 +78,9 @@ async function main() {
   const virtualClock = new _VirtualClock({ rate: readRate() });
 
   // Install before importing program.js, so the user's module sees virtual time
-  // from its first statement. runtime.js is a *static* import and has therefore
-  // already been evaluated, meaning VirtualClock captured the real Date.now
-  // before this line replaces it.
+  // from its first statement — a module evaluated earlier would capture the real
+  // Date. The clock itself is unaffected either way: it reads wall time from
+  // performance, which is never shimmed.
   _installDateShim(virtualClock);
 
   const mod = await import("./program.js");

--- a/src/services/webcontainer.ts
+++ b/src/services/webcontainer.ts
@@ -64,7 +64,7 @@ Example:
 
 /** Runner: imports program.js, injects trace layer, runs. Fixed bootstrap — no user code transformation for tracing. */
 const RUNNER_JS = `import { Effect, Layer } from "effect";
-import { _makeTraceEmitterLayer, _makeVizLayers, _makeVizTracer, _runProgramFork, _VirtualClock, _makeVizClockLayer, _installDateShim, _GatedScheduler, _Stepper, _applyCommand, _decodeCommand, _encodeReply, _makeLineReader } from "./runtime.js";
+import { _makeTraceEmitterLayer, _makeVizLayers, _makeVizTracer, _runProgramFork, _VirtualClock, _makeVizClockLayer, _installDateShim, _GatedScheduler, _Stepper, _applyCommand, _decodeCommand, _encodeReply, _makeLineReader, _makeOriginTagger } from "./runtime.js";
 
 const ROOT_EFFECT_MISSING_MSG = ${JSON.stringify(ROOT_EFFECT_MISSING_MSG)};
 
@@ -106,8 +106,11 @@ async function main() {
     isFinished: () => rootFiber !== null && rootFiber.unsafePoll() !== null,
   });
 
+  // A paused start injects a yield the program never wrote; the tagger marks the
+  // suspend and resume it produces so the log can offer to hide them.
+  const tagOrigin = _makeOriginTagger({ startPaused });
   const onEmit = event => {
-    process.stdout.write("TRACE_EVENT:" + JSON.stringify(event) + "\\n");
+    process.stdout.write("TRACE_EVENT:" + JSON.stringify(tagOrigin(event)) + "\\n");
     stepper.noteEvent(); // A step runs until this moves
   };
 

--- a/src/services/webcontainer.ts
+++ b/src/services/webcontainer.ts
@@ -64,11 +64,25 @@ Example:
 
 /** Runner: imports program.js, injects trace layer, runs. Fixed bootstrap — no user code transformation for tracing. */
 const RUNNER_JS = `import { Effect, Layer } from "effect";
-import { _makeTraceEmitterLayer, _makeVizLayers, _makeVizTracer, _runProgramFork } from "./runtime.js";
+import { _makeTraceEmitterLayer, _makeVizLayers, _makeVizTracer, _runProgramFork, _VirtualClock, _makeVizClockLayer, _installDateShim } from "./runtime.js";
 
 const ROOT_EFFECT_MISSING_MSG = ${JSON.stringify(ROOT_EFFECT_MISSING_MSG)};
 
+/** Virtual ms per wall ms. 1 is real time, 0.5 half speed, 0 frozen. */
+function readRate() {
+  const parsed = Number.parseFloat(process.env.VIZ_RATE ?? "1");
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 1;
+}
+
 async function main() {
+  const virtualClock = new _VirtualClock({ rate: readRate() });
+
+  // Install before importing program.js, so the user's module sees virtual time
+  // from its first statement. runtime.js is a *static* import and has therefore
+  // already been evaluated, meaning VirtualClock captured the real Date.now
+  // before this line replaces it.
+  _installDateShim(virtualClock);
+
   const mod = await import("./program.js");
   const rootEffect = mod.rootEffect;
   const requirements = mod.requirements ?? [];
@@ -83,7 +97,8 @@ async function main() {
   const traceLayer = _makeTraceEmitterLayer(onEmit);
   const supervisorLayer = _makeVizLayers(onEmit);
   const tracerLayer = Layer.setTracer(_makeVizTracer(onEmit));
-  const allLayers = Layer.mergeAll(traceLayer, supervisorLayer, tracerLayer, ...requirements);
+  const clockLayer = _makeVizClockLayer(virtualClock);
+  const allLayers = Layer.mergeAll(traceLayer, supervisorLayer, tracerLayer, clockLayer, ...requirements);
   const program = Effect.scoped(rootEffect).pipe(Effect.provide(allLayers));
   const { promise } = _runProgramFork(program, onEmit);
   promise.then(

--- a/src/services/webcontainer.ts
+++ b/src/services/webcontainer.ts
@@ -64,7 +64,7 @@ Example:
 
 /** Runner: imports program.js, injects trace layer, runs. Fixed bootstrap — no user code transformation for tracing. */
 const RUNNER_JS = `import { Effect, Layer } from "effect";
-import { _makeTraceEmitterLayer, _makeVizLayers, _makeVizTracer, _runProgramFork, _VirtualClock, _makeVizClockLayer, _installDateShim } from "./runtime.js";
+import { _makeTraceEmitterLayer, _makeVizLayers, _makeVizTracer, _runProgramFork, _VirtualClock, _makeVizClockLayer, _installDateShim, _GatedScheduler, _Stepper, _applyCommand, _decodeCommand, _encodeReply, _makeLineReader } from "./runtime.js";
 
 const ROOT_EFFECT_MISSING_MSG = ${JSON.stringify(ROOT_EFFECT_MISSING_MSG)};
 
@@ -72,6 +72,11 @@ const ROOT_EFFECT_MISSING_MSG = ${JSON.stringify(ROOT_EFFECT_MISSING_MSG)};
 function readRate() {
   const parsed = Number.parseFloat(process.env.VIZ_RATE ?? "1");
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : 1;
+}
+
+/** Step from idle starts a run already gated, so its first events can be stepped. */
+function readStartPaused() {
+  return process.env.VIZ_START_PAUSED === "1";
 }
 
 async function main() {
@@ -92,7 +97,31 @@ async function main() {
     process.exit(1);
   }
 
-  const onEmit = event => process.stdout.write("TRACE_EVENT:" + JSON.stringify(event) + "\\n");
+  const startPaused = readStartPaused();
+  const scheduler = new _GatedScheduler();
+  let rootFiber = null;
+  const stepper = new _Stepper({
+    scheduler,
+    clock: virtualClock,
+    isFinished: () => rootFiber !== null && rootFiber.unsafePoll() !== null,
+  });
+
+  const onEmit = event => {
+    process.stdout.write("TRACE_EVENT:" + JSON.stringify(event) + "\\n");
+    stepper.noteEvent(); // A step runs until this moves
+  };
+
+  // Commands in on stdin, replies out on stdout. The listener doubles as the
+  // process's keep-alive: a paused program has no task running and no timer
+  // armed, so nothing else would hold the event loop open.
+  const readStdin = _makeLineReader(line => {
+    const command = _decodeCommand(line);
+    if (command === null) return;
+    const reply = _applyCommand(command, { stepper, clock: virtualClock });
+    process.stdout.write(_encodeReply(reply));
+  });
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", readStdin);
 
   const now = () => virtualClock.now();
 
@@ -101,12 +130,28 @@ async function main() {
   const tracerLayer = Layer.setTracer(_makeVizTracer(onEmit, now));
   const clockLayer = _makeVizClockLayer(virtualClock);
   const allLayers = Layer.mergeAll(traceLayer, supervisorLayer, tracerLayer, clockLayer, ...requirements);
-  const program = Effect.scoped(rootEffect).pipe(Effect.provide(allLayers));
-  const { promise } = _runProgramFork(program, onEmit, now);
+
+  // Gate before the program is forked, so even its first task is held.
+  if (startPaused) stepper.pause();
+
+  // runFork runs a fiber synchronously until its first yield, and the scheduler
+  // only governs resumption. Yielding first therefore hands the very first
+  // operation to the gate, so a paused start can be stepped from event one.
+  const body = startPaused ? Effect.zipRight(Effect.yieldNow(), rootEffect) : rootEffect;
+  const program = Effect.scoped(body).pipe(Effect.withScheduler(scheduler), Effect.provide(allLayers));
+
+  process.stdout.write(_encodeReply({ reply: "ready", virtualNow: now() }));
+
+  const { fiber, promise } = _runProgramFork(program, onEmit, now);
+  rootFiber = fiber;
   promise.then(
     (result) => console.log("Program completed:", result),
     (error) => console.error("Program failed:", error),
-  );
+  ).finally(() => {
+    // Nothing left to control, so let the event loop drain and the process exit.
+    process.stdin.off("data", readStdin);
+    process.stdin.pause();
+  });
 }
 main();
 `;

--- a/src/stores/traceStore.test.tsx
+++ b/src/stores/traceStore.test.tsx
@@ -1,0 +1,52 @@
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { describe, expect, it } from "vitest";
+
+import { TraceStoreProvider, useTraceStore } from "@/stores/traceStore";
+
+const render = () =>
+  renderHook(() => useTraceStore(), { wrapper: TraceStoreProvider });
+
+describe("useTraceStore virtual now", () => {
+  /**
+   * The timeline measures its live cursor against event timestamps, which are
+   * virtual. Extrapolating from a rate cannot see a clock that the stepper has
+   * frozen or jumped, so a running clock is read directly when there is one.
+   */
+  it("reads the clock when a source is set", () => {
+    const { result } = render();
+
+    act(() => result.current.setNowSource(() => 4242));
+
+    expect(result.current.getVirtualNow()).toBe(4242);
+  });
+
+  it("follows the clock as it moves", () => {
+    const { result } = render();
+    let virtual = 1000;
+
+    act(() => result.current.setNowSource(() => virtual));
+    expect(result.current.getVirtualNow()).toBe(1000);
+
+    virtual = 2500;
+    expect(result.current.getVirtualNow()).toBe(2500);
+  });
+
+  it("falls back to wall time when there is no clock to read", () => {
+    const { result } = render();
+    const before = Date.now();
+
+    act(() => result.current.setNowSource(null));
+
+    expect(result.current.getVirtualNow()).toBeGreaterThanOrEqual(before);
+  });
+
+  it("drops the clock on clear, so a finished run cannot be read", () => {
+    const { result } = render();
+
+    act(() => result.current.setNowSource(() => 4242));
+    act(() => result.current.clear());
+
+    expect(result.current.getVirtualNow()).not.toBe(4242);
+  });
+});

--- a/src/stores/traceStore.tsx
+++ b/src/stores/traceStore.tsx
@@ -3,9 +3,11 @@ import {
   useCallback,
   useContext,
   useMemo,
+  useRef,
   useState,
 } from "react";
 
+import { type VirtualAnchor, computeVirtualNow } from "@/lib/timelineTime";
 import type { TraceEvent } from "@/types/trace";
 
 interface TraceStore {
@@ -15,6 +17,10 @@ interface TraceStore {
   addEvent: (event: TraceEvent) => void;
   /** Clear all events */
   clear: () => void;
+  /** Virtual ms per wall ms for the current run */
+  setRate: (rate: number) => void;
+  /** Current virtual timestamp, in the same units as event timestamps */
+  getVirtualNow: () => number;
 }
 
 const TraceStoreContext = createContext<TraceStore | null>(null);
@@ -25,6 +31,8 @@ interface TraceStoreProviderProps {
 
 export function TraceStoreProvider({ children }: TraceStoreProviderProps) {
   const [events, setEvents] = useState<TraceEvent[]>([]);
+  const rateRef = useRef(1);
+  const anchorRef = useRef<VirtualAnchor | null>(null);
 
   const addEvent = useCallback((event: TraceEvent) => {
     // Add timestamp if not provided
@@ -32,20 +40,38 @@ export function TraceStoreProvider({ children }: TraceStoreProviderProps) {
       ...event,
       timestamp: event.timestamp ?? Date.now(),
     };
+    // The first event of a run pins virtual time to wall time.
+    anchorRef.current ??= {
+      virtual: eventWithTimestamp.timestamp,
+      wall: performance.now(),
+    };
     setEvents((prev) => [...prev, eventWithTimestamp]);
   }, []);
 
   const clear = useCallback(() => {
+    anchorRef.current = null;
     setEvents([]);
   }, []);
+
+  const setRate = useCallback((rate: number) => {
+    rateRef.current = rate;
+  }, []);
+
+  const getVirtualNow = useCallback(
+    () =>
+      computeVirtualNow(anchorRef.current, rateRef.current, performance.now()),
+    [],
+  );
 
   const store = useMemo(
     () => ({
       events,
       addEvent,
       clear,
+      setRate,
+      getVirtualNow,
     }),
-    [events, addEvent, clear],
+    [events, addEvent, clear, setRate, getVirtualNow],
   );
 
   return (

--- a/src/stores/traceStore.tsx
+++ b/src/stores/traceStore.tsx
@@ -19,6 +19,11 @@ interface TraceStore {
   clear: () => void;
   /** Virtual ms per wall ms for the current run */
   setRate: (rate: number) => void;
+  /**
+   * Read virtual time straight from the running clock, when there is one to
+   * read. Extrapolating from a rate cannot see a paused or stepped clock.
+   */
+  setNowSource: (nowSource: (() => number) | null) => void;
   /** Current virtual timestamp, in the same units as event timestamps */
   getVirtualNow: () => number;
 }
@@ -33,6 +38,7 @@ export function TraceStoreProvider({ children }: TraceStoreProviderProps) {
   const [events, setEvents] = useState<TraceEvent[]>([]);
   const rateRef = useRef(1);
   const anchorRef = useRef<VirtualAnchor | null>(null);
+  const nowSourceRef = useRef<(() => number) | null>(null);
 
   const addEvent = useCallback((event: TraceEvent) => {
     // Add timestamp if not provided
@@ -50,6 +56,7 @@ export function TraceStoreProvider({ children }: TraceStoreProviderProps) {
 
   const clear = useCallback(() => {
     anchorRef.current = null;
+    nowSourceRef.current = null;
     setEvents([]);
   }, []);
 
@@ -57,8 +64,13 @@ export function TraceStoreProvider({ children }: TraceStoreProviderProps) {
     rateRef.current = rate;
   }, []);
 
+  const setNowSource = useCallback((nowSource: (() => number) | null) => {
+    nowSourceRef.current = nowSource;
+  }, []);
+
   const getVirtualNow = useCallback(
     () =>
+      nowSourceRef.current?.() ??
       computeVirtualNow(anchorRef.current, rateRef.current, performance.now()),
     [],
   );
@@ -69,9 +81,10 @@ export function TraceStoreProvider({ children }: TraceStoreProviderProps) {
       addEvent,
       clear,
       setRate,
+      setNowSource,
       getVirtualNow,
     }),
-    [events, addEvent, clear, setRate, getVirtualNow],
+    [events, addEvent, clear, setRate, setNowSource, getVirtualNow],
   );
 
   return (

--- a/src/stores/webContainerLogsStore.tsx
+++ b/src/stores/webContainerLogsStore.tsx
@@ -6,8 +6,19 @@ import {
   useState,
 } from "react";
 
+/**
+ * Which stream an entry came from, and how the console treats it.
+ *
+ * - `boot` — the visualizer's own progress while starting the container
+ * - `output` — anything the program wrote to stdout, rendered with ANSI colours
+ * - `error` — shown in the Errors tab rather than the Logs tab
+ * - `control` — commands the page sent the container, echoed back by its
+ *   terminal; hidden unless the user asks to see the visualizer's internals
+ */
+export type WebContainerLogLabel = "boot" | "output" | "error" | "control";
+
 export interface WebContainerLogEntry {
-  label: string;
+  label: WebContainerLogLabel;
   message: string;
   timestamp?: number;
 }
@@ -16,7 +27,7 @@ interface WebContainerLogsStore {
   /** All logged entries in order */
   logs: WebContainerLogEntry[];
   /** Add a new log entry */
-  addLog: (label: string, message: string) => void;
+  addLog: (label: WebContainerLogLabel, message: string) => void;
   /** Clear all logs */
   clear: () => void;
   /** Clear logs only (keeps errors) */
@@ -37,7 +48,7 @@ export function WebContainerLogsStoreProvider({
 }: WebContainerLogsStoreProviderProps) {
   const [logs, setLogs] = useState<WebContainerLogEntry[]>([]);
 
-  const addLog = useCallback((label: string, message: string) => {
+  const addLog = useCallback((label: WebContainerLogLabel, message: string) => {
     setLogs((prev) => [...prev, { label, message, timestamp: Date.now() }]);
   }, []);
 

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -102,10 +102,16 @@ type AcquireEvent =
     };
 
 /**
- * Union type of all possible trace events.
- * This forms the event model for the visualizer.
+ * Who caused an event: the program under observation, or the visualizer itself.
+ *
+ * Starting a run paused injects an `Effect.yieldNow()` before the program body,
+ * and the runtime yields for real — so the trace contains a suspend and resume
+ * pair that the program's author never wrote. Absent means `"program"`, which
+ * keeps the common case unannotated.
  */
-export type TraceEvent =
+export type TraceOrigin = "program" | "tool";
+
+type TraceEventBody =
   | EffectStartEvent
   | EffectEndEvent
   | FiberForkEvent
@@ -116,6 +122,17 @@ export type TraceEvent =
   | RetryAttemptEvent
   | FinalizerEvent
   | AcquireEvent;
+
+/**
+ * Union type of all possible trace events.
+ * This forms the event model for the visualizer.
+ */
+export type TraceEvent = TraceEventBody & { origin?: TraceOrigin };
+
+/** Events with no origin are the program's, so only an explicit tag hides one. */
+export function isToolEvent(event: TraceEvent): boolean {
+  return event.origin === "tool";
+}
 
 /**
  * Possible states a fiber can be in.

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -129,11 +129,6 @@ type TraceEventBody =
  */
 export type TraceEvent = TraceEventBody & { origin?: TraceOrigin };
 
-/** Events with no origin are the program's, so only an explicit tag hides one. */
-export function isToolEvent(event: TraceEvent): boolean {
-  return event.origin === "tool";
-}
-
 /**
  * Possible states a fiber can be in.
  * Used by the FiberTreeView to show fiber lifecycle.

--- a/workshop/README.md
+++ b/workshop/README.md
@@ -45,7 +45,7 @@ Refactor to use Effect's built-in observability, removing manual wrappers.
 
 Take over the runtime's clock and scheduler so execution can be slowed and stepped.
 
-- [Phase 10: Slow mode & stepper (issue #13)](./phase-10.md) 🚧
+- [Phase 10: Slow mode & stepper (issue #13)](./phase-10.md) ✅
 
 **Why two versions?**
 - **V1** teaches concepts explicitly - you see exactly what gets traced

--- a/workshop/README.md
+++ b/workshop/README.md
@@ -41,6 +41,12 @@ Refactor to use Effect's built-in observability, removing manual wrappers.
 - [Phase 8: Sleep visibility via onSuspend/onResume](./phase-8.md) ✅
 - [Phase 9: retryWithTrace with Schedule API](./phase-9.md) ✅
 
+### Version 3: Controlling Time
+
+Take over the runtime's clock and scheduler so execution can be slowed and stepped.
+
+- [Phase 10: Slow mode & stepper (issue #13)](./phase-10.md) 🚧
+
 **Why two versions?**
 - **V1** teaches concepts explicitly - you see exactly what gets traced
 - **V2** teaches Effect's production observability patterns

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -368,6 +368,25 @@ log; in the runtime model there is nothing to step until a program is live. And
 a completed run returned to `idle` rather than `finished`, so the `finished`
 state was unreachable and Reset was offered when there was nothing to reset.
 
+### Two bugs found by using it
+
+**The timeline mixed clocks.** Its live cursor read wall time while every event
+timestamp is virtual, so during a run at 0.25x the elapsed grew four times too
+fast, and the moment the run ended it switched to the last event's timestamp and
+snapped back to the true span. The host cannot see the container's clock, so it
+keeps a mirror: the rate it chose, anchored on the first event's timestamp and
+the wall time at which that event arrived.
+
+**The axis tick interval was capped at one second**, so any long span rendered a
+label per second until they overlapped into an unreadable smear. It now rounds up
+to the nearest 1, 2 or 5 times a power of ten, keeping the label count bounded at
+any magnitude. Independent of the clock bug — exponential backoff at 0.25x would
+have hit it — but the clock bug is what made it visible.
+
+Both are pure functions in `src/lib/timelineTime.ts`, unit tested. The Execution
+Log needed no change: it derives durations from event timestamps alone, so it was
+already reporting program time.
+
 ### Verification
 
 Driven in a real browser on the fallback path. At each speed the program's

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -365,6 +365,15 @@ Tasks already handed to Effect's scheduler still run — they are out of our han
 Anything *they* schedule is queued. So the program stops a moment after Pause is
 pressed, not instantly.
 
+#### A paused program cannot be interrupted
+
+Interruption reaches a fiber as a task, like everything else. So while the
+scheduler is gated, `Fiber.interrupt` never completes — it simply queues. The
+Reset button must therefore call `play()` before it interrupts, or it will hang.
+
+The same mechanism is a feature elsewhere: a promise that settles during a pause
+also queues, so external work cannot slip past the user between two steps.
+
 #### Detecting a stuck program needs no internals
 
 `fiber.status` carries `blockingOn`, which would separate a deadlock from a wait

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -492,7 +492,7 @@ editor flushes) is orthogonal and can coincide with any of them.
 | | ⏯️ | ⏭️ | ↺ | Speed |
 |---|---|---|---|---|
 | `idle` + booting | – | – | – | ✓ |
-| `idle` ready | ✓ | – | – | ✓ |
+| `idle` ready | ✓ | ✓ (starts paused) | – | ✓ |
 | `starting` | – | – | ✓ | – |
 | `running` | ✓ (pause) | – | ✓ | – |
 | `paused` | ✓ (resume) | ✓ | ✓ | ✓ |
@@ -502,6 +502,17 @@ Speed is locked while running because the WebContainer receives the rate as a
 spawn environment variable and cannot be retuned without restarting. That is a
 temporary limitation: pausing the container will require a host→container control
 channel anyway, and once it exists the rate can travel the same way.
+
+⏭️ is enabled at `idle` because there is otherwise no way *into* a paused run:
+Play starts a free-running program, and by the time the user pauses it, the
+opening events have gone. Step from `idle` starts the program already gated. It
+stays disabled while `running` — stepping remains a pause-mode operation.
+
+Gating alone does not catch the very first events, because `Effect.runFork` runs
+a fiber synchronously until its first yield and the scheduler only governs
+resumption. A paused start therefore yields before the program body, which hands
+the first operation to the gate. The cost is one extra suspend/resume pair in the
+trace, present only on a paused start.
 
 `paused` carries a reason — `user`, `deadlock` or `waiting-external` — because
 only a user pause can be stepped. The other two mean the runtime has nothing left

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -1,6 +1,6 @@
 # Phase 10: Slow Mode and Stepper (issue #13)
 
-**Status**: 🚧 IN PROGRESS — speed control shipped; stepper (steps 4 and 5b) remaining
+**Status**: 🚧 IN PROGRESS — speed control shipped; stepper runs but is not wired to the UI
 
 Issue [#13](https://github.com/topheman/effect-viz/issues/13) asks for a slow mode:
 _"It goes too fast so a slow stepper would be cool like Browser Debugger is."_
@@ -116,7 +116,7 @@ only be inferred by elimination.
 | 2 | Effect `Clock` layer built on `VirtualClock` | ✅ |
 | 3 | `Date` shim in the WebContainer runner | ✅ |
 | 3b | Virtual timestamps at every emit site | ✅ |
-| 4a | Gated `Scheduler` (fallback path) | 🚧 |
+| 4a | Gated `Scheduler` + step ladder | ✅ |
 | 4b | Control channel for the WebContainer | ⬜ |
 | 5a | UI: speed combo + playback state matrix | ✅ |
 | 5b | UI: ⏯️ ⏭️ stepper controls | ⬜ |
@@ -364,6 +364,34 @@ program on one click.
 Tasks already handed to Effect's scheduler still run — they are out of our hands.
 Anything *they* schedule is queued. So the program stops a moment after Pause is
 pressed, not instantly.
+
+#### The ladder needs both sources, in order
+
+`Stepper` owns the `GatedScheduler` and the `VirtualClock` and answers one
+question: what happens when the user clicks step.
+
+1. Queued work exists → release until one more trace event is emitted.
+2. Nothing runnable, a deadline pending → move virtual time to it, then release.
+3. Neither, and the program has not finished → no progress.
+4. The program has finished → done.
+
+A fiber that can run now must run before time is allowed to move, otherwise a
+step would skip past work that was already due.
+
+#### A step needs a turn of the event loop to settle
+
+Part of a fiber's completion lands outside our scheduler, and a microtask is not
+enough — it needs a full turn. Two steps in a row without yielding report
+`noProgress` for a program that has in fact just finished. Every click in the UI
+is its own turn, so this only bites loops, including test helpers.
+
+#### Stepping reproduces the real interleaving
+
+The design choice was to never pick which fiber advances, only when to stop
+releasing. That is only worth anything if releasing in queue order gives the same
+execution as running at full speed. A test now runs a program with three forked
+workers twice — once played, once stepped to the end — and compares the event
+order. They match.
 
 #### A paused program cannot be interrupted
 

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -1,6 +1,6 @@
 # Phase 10: Slow Mode and Stepper (issue #13)
 
-**Status**: 🚧 IN PROGRESS — speed, pause and step work on both paths; what remains is the examples and explainers (6) and tagging instrumentation events (7)
+**Status**: 🚧 IN PROGRESS — speed, pause, step and origin tagging are done; what remains is the examples and explainers (6)
 
 Issue [#13](https://github.com/topheman/effect-viz/issues/13) asks for a slow mode:
 _"It goes too fast so a slow stepper would be cool like Browser Debugger is."_
@@ -121,39 +121,7 @@ only be inferred by elimination.
 | 5a | UI: speed combo + playback state matrix | ✅ |
 | 5b | UI: ⏯️ ⏭️ stepper controls (fallback path) | ✅ |
 | 6 | Example programs + explainers | ⬜ |
-| 7 | Tag instrumentation events, with a show/hide toggle | ⬜ |
-
-## Open Decisions
-
-### Instrumentation events in the trace (step 7)
-
-A paused start injects `Effect.yieldNow()` before the program body, so that the
-very first operation is handed to the gate rather than running on the fork's own
-stack. The runtime yields for real, so the Supervisor emits a `fiber:suspend` and
-a matching `fiber:resume (after 0ms)` that the program's author never wrote. The
-same program therefore reads slightly differently depending on whether it was
-started with Play or with Step. For the Basic Example, the marked lines are the
-injected yield:
-
-```diff
-[1] ⚡fiber:forked #2 (root)
-+ [2] ⏸️fiber:suspend #2
-+ [3] ▶️fiber:resume #2 (after 0ms)
-[4] 🚀effect:started initialization
-[5] ✅effect:ended initialization
-```
-
-`[2]` is the yield handing control back, `[3]` is the same yield returning once
-the first step releases it. It reads `after 0ms` because virtual time is frozen
-while paused, however long the user takes.
-
-Rather than choose between leaving the pair visible and filtering it away, trace
-events will carry an origin — the program's own, or the tool's — and the
-Execution Log will offer a toggle. The Timeline and Fiber Tree keep consuming
-everything, since a suspend that genuinely happened still belongs on a timeline.
-
-This is deferred until after 6, and covers more than the injected yield: the
-control channel opens with a `ready` handshake of its own.
+| 7 | Tag instrumentation events, with a show/hide toggle | ✅ |
 
 ## Step 1: VirtualClock ✅
 
@@ -837,13 +805,120 @@ stopped with the scheduler. Both runs exited cleanly, which is the check that
 the stdin listener is being released.
 
 WebContainer itself could not be booted in the automation browser, which lacks
-cross-origin isolation and so has no `SharedArrayBuffer`. What that leaves
-unverified is one link: whether writes to `proc.input` arrive at the container
-process's `process.stdin`. Everything on either side of that link is covered.
+cross-origin isolation and so has no `SharedArrayBuffer`, leaving one link
+uncovered: whether writes to `proc.input` arrive at the container process's
+`process.stdin`. That was closed by hand in a real browser — Step from idle on
+the container path starts the run gated and reports the root fork and the
+injected yield's suspend, which only happens if the command arrived.
 
 ### What this unlocks
 
 Slow motion, pause and step on the path the app actually runs, which is what
-step 6's examples need to be worth writing. The `TRACE_CONTROL:` channel is also
-the handshake that step 7 anticipated: `ready` is the first message on it, and
-the first instrumentation event that will want tagging.
+step 6's examples need to be worth writing.
+
+It also settles a question step 7 had left open. The channel opens with a `ready`
+handshake, which was expected to need tagging as an instrumentation event — but
+replies are consumed where stdout is demultiplexed and never reach the trace
+store, so there is nothing to hide. What the channel did add is of a different
+kind: the terminal echoes every command back as console output.
+
+## Step 7: Origin tagging and the internals toggle ✅
+
+Two things in the visualizer are the tool talking rather than the program, and
+both were showing up as though the program had done them.
+
+A paused start injects `Effect.yieldNow()` before the program body, so that the
+very first operation is handed to the gate rather than running on the fork's own
+stack. The runtime yields for real, so the Supervisor emits a `fiber:suspend` and
+a matching `fiber:resume (after 0ms)` that the program's author never wrote. The
+same program therefore reads slightly differently depending on whether it was
+started with Play or with Step. For the Basic Example, the marked lines are the
+injected yield:
+
+```diff
+[1] ⚡fiber:forked #2 (root)
++ [2] ⏸️fiber:suspend #2
++ [3] ▶️fiber:resume #2 (after 0ms)
+[4] 🚀effect:started initialization
+[5] ✅effect:ended initialization
+```
+
+`[2]` is the yield handing control back, `[3]` is the same yield returning once
+the first step releases it. It reads `after 0ms` because virtual time is frozen
+while paused, however long the user takes.
+
+The second is in the console rather than the trace. Every WebContainer process
+has a pseudoterminal attached, and a terminal echoes what is written to it, so
+each `{"cmd":"step"}` the page sends comes straight back on the process's output
+and lands in the log as though the program had printed it.
+
+Rather than choose between leaving them visible and filtering them away, both are
+tagged and the user decides.
+
+### Created/Modified Files
+
+| File | Changes |
+|------|---------|
+| `src/types/trace.ts` | `TraceOrigin`, `TraceEvent & { origin? }`, `isToolEvent` |
+| `src/runtime/traceOrigin.ts` | `makeOriginTagger` — finds the injected yield |
+| `src/runtime/traceOrigin.test.ts` | 7 tests |
+| `src/hooks/useShowInternals.ts` | One preference, shared by both panels |
+| `src/effects/spawnAndParse.ts` | `onStdout` gains an origin; echoed commands classified |
+| `src/components/visualizer/ExecutionLog.tsx` | Filter, toggle, dimmed tool rows |
+| `src/components/editor/WebContainerLogsPanel.tsx` | Filter and toggle for control lines |
+
+### Key Learnings
+
+#### Position identifies the yield, because nothing in the event does
+
+A yield is a yield: the pair the injection produces is indistinguishable from one
+the program earned, and the Supervisor reports both the same way. What we do know
+is where it sits — it is the first thing the root fiber does, because we put it
+there.
+
+So the tagger is a small state machine over the emit path. It learns the root's
+id from the first `fiber:fork` (the two runtimes number fibers differently, so it
+cannot be hardcoded), expects a suspend from that fiber, then its resume, and
+disarms. Anything else from the root — or any event naming no fiber at all, which
+means the program is already working — disarms it too, so a suspend the program
+earned is never hidden. A run started with Play arms nothing.
+
+#### Absent means the program's
+
+`origin` is optional and only ever set to `"tool"`. Every existing emit site, test
+and fixture keeps working untouched, and the common case stays unannotated. The
+filter asks `origin === "tool"`, so anything unrecognised is shown rather than
+hidden — the safe direction for a filter whose job is to hide things.
+
+#### The echo classifies itself
+
+Nothing else writes to that process's stdin, so a console line that `decodeCommand`
+accepts is one we sent. No heuristics, and no need for a second prefix on the way
+down.
+
+#### One preference, two panels
+
+The Execution Log and the console ask independently but must agree, so the
+preference lives outside React in a module-level store read through
+`useSyncExternalStore`. From the user's side it is one question — am I looking at
+my program, or at the tool — and two checkboxes for it would have been two ways to
+ask the same thing.
+
+The Timeline and Fiber Tree still consume everything. A suspend that genuinely
+happened belongs on a timeline whoever caused it, and a fiber tree with a hole in
+it would be worse than one showing an extra yield.
+
+### Verification
+
+Running the built runner under Node against the same program, once started paused
+and once with Play, gives traces that differ only by the tagged pair: the paused
+run marks the first suspend and resume `tool` and leaves the program's own sleep
+pairs alone, and the Play run tags nothing because nothing was injected.
+
+### What this unlocks
+
+A trace that reads the same however the run was started, and a console showing the
+program's output rather than the protocol — with both available to anyone who
+wants to see how the visualizer works. That last part is worth keeping for step 6:
+turning the internals on and stepping is the clearest explanation of the control
+channel the app can give.

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -158,11 +158,20 @@ that was actually remaining.
 
 #### The clock must not read its own shim
 
-`Date.now` is captured at module load, before any shim is installed. The `Date`
-shim will read the `VirtualClock`, so if the clock read `Date.now()` dynamically
-the two would recurse. The wall-clock primitives are injectable
-(`VirtualClockHost`), which is also what makes the tests deterministic under
-vitest fake timers.
+The `Date` shim reads the `VirtualClock`, so the clock must never read `Date`
+back. Capturing `Date.now` at module load would achieve that, but only for as
+long as this module is always evaluated before the shim is installed — a
+guarantee living in import order, enforced by nothing, and failing as unbounded
+recursion if broken.
+
+Reading wall time from `performance.timeOrigin + performance.now()` instead makes
+the clock immune by construction: `performance` is never shimmed, so no ordering
+can bring the two into contact. It also makes wall time **monotonic**, so virtual
+time cannot jump backwards when the system clock is corrected by NTP or changed
+by hand.
+
+The wall-clock primitives stay injectable (`VirtualClockHost`), which is what
+makes the tests deterministic under vitest fake timers.
 
 #### `advanceToNextDeadline()` is rung 2 of the ladder
 
@@ -280,15 +289,17 @@ Only two behaviours change: `Date.now()` and the zero-argument `new Date()`.
 Every explicit form is passed straight through — which matters because Effect
 itself builds log timestamps with `new Date(clock.unsafeCurrentTimeMillis())`.
 
-#### The import order was already correct
+#### Only one ordering constraint remains
 
-The shim must be installed *after* `VirtualClock` has captured the real
-`Date.now`, or the two would read each other. `runner.js` imports `runtime.js`
-statically and loads the user's program with a *dynamic* `await import()`, so the
-sequence falls out for free: the runtime evaluates first and captures the real
-function, then `main()` installs the shim, then the program module evaluates and
-sees virtual time from its first statement. Had the program been a static import
-it would have initialised before the shim landed.
+`runner.js` imports `runtime.js` statically and loads the user's program with a
+*dynamic* `await import()`, so `main()` can install the shim in between: the
+program module then evaluates and sees virtual time from its first statement. Had
+the program been a static import it would have initialised before the shim landed
+and captured the real `Date`.
+
+That constraint is inherent — a shim only affects code evaluated after it. The
+*second* constraint this originally had, that the clock must capture `Date.now`
+before being shimmed, was removed by having the clock read `performance` instead.
 
 #### Trace timestamps became virtual for free
 

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -14,6 +14,44 @@ Two controls, driven by one mechanism:
 - **Stepper** (`⏯️ ⏭️`) — freezes the world and releases one scheduling decision
   at a time.
 
+### Two clocks: wall and virtual
+
+Everything in this phase depends on separating two notions of time, so the terms
+are used precisely throughout.
+
+**Wall time** is real elapsed time — what a stopwatch sitting next to the computer
+would measure. It comes from `Date.now()` and `performance.now()`, it always moves
+forward, and nothing we do can slow it down.
+
+**Virtual time** is the time the *program* believes it is living in. It is what
+the Effect `Clock` service reports and what `Effect.sleep` counts down in. We
+control it completely.
+
+The two are connected by a single number, the **rate**: virtual time advances by
+`rate` milliseconds for every millisecond of wall time.
+
+- At **rate 1** the two are indistinguishable — this is normal execution.
+- At **rate 0.5** an `Effect.sleep("1 second")` still measures 1 second of virtual
+  time, but 2 seconds pass on the wall while it waits.
+- At **rate 0** virtual time stops entirely while wall time keeps going. The
+  program is frozen; the browser is not.
+
+The reason this preserves the program's behaviour is that **the program only ever
+observes virtual time**. It cannot tell it is running in slow motion, because
+every duration it can measure — sleeps, timeouts, schedule delays, race outcomes,
+even `Effect.log` timestamps — is expressed in the same stretched units. Nothing
+is skewed relative to anything else.
+
+Two deliberate exceptions exist on the wall side. `performance.now()` is left
+untouched, so there is always a way to measure how much real time something took
+(useful for debugging this feature itself). And raw `setTimeout` in user code is
+not intercepted: it is already invisible to Effect's runtime, and code reaching
+for it has stepped outside the model the visualizer is showing.
+
+In the code, `VirtualClock` holds a `wallAnchor` and a `virtualAnchor` — the pair
+of readings taken the last time the rate changed. Every conversion between the
+two clocks is measured from that pair.
+
 ### Why the Clock is the lever
 
 Everything in Effect's model routes through the `Clock` service:

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -1,6 +1,6 @@
 # Phase 10: Slow Mode and Stepper (issue #13)
 
-**Status**: 🚧 IN PROGRESS — step 3 of 6 complete
+**Status**: 🚧 IN PROGRESS — speed control shipped; stepper (steps 4 and 5b) remaining
 
 Issue [#13](https://github.com/topheman/effect-viz/issues/13) asks for a slow mode:
 _"It goes too fast so a slow stepper would be cool like Browser Debugger is."_
@@ -117,7 +117,8 @@ only be inferred by elimination.
 | 3 | `Date` shim in the WebContainer runner | ✅ |
 | 3b | Virtual timestamps at every emit site | ✅ |
 | 4 | Gated `Scheduler` + the step ladder | ⬜ |
-| 5 | UI: speed combo + ⏯️ ⏭️ in `PlaybackControls` | ⬜ |
+| 5a | UI: speed combo + playback state matrix | ✅ |
+| 5b | UI: ⏯️ ⏭️ stepper controls | ⬜ |
 | 6 | Example programs + explainers | ⬜ |
 
 ## Step 1: VirtualClock ✅
@@ -317,6 +318,67 @@ whatever speed it was captured at — verified by running a program with a forke
 child, a span and a sleep at three rates: wall time scaled while the recorded
 span stayed constant. The fallback path also gains the clock layer, fixed at
 rate 1 until the speed control is wired.
+
+## Step 5a: Speed control ✅
+
+Issue #13's actual request, clickable. Selecting a speed and pressing Play runs
+the program with its clock scaled by that factor.
+
+### Created/Modified Files
+
+| File | Changes |
+|------|---------|
+| `src/hooks/useSpeed.ts` | `SPEED_OPTIONS`, `useSpeed` (localStorage-backed), `formatSpeed` |
+| `src/components/layout/PlaybackControls.tsx` | Speed `Select`, `PauseReason`, corrected enable/disable rules |
+| `src/components/layout/MainLayout.tsx` | Speed state; `finished` on completion |
+| `src/hooks/useEventHandlers.ts` | `rate` through to both paths |
+| `src/hooks/useWebContainerBoot.ts`, `src/effects/spawnAndParse.ts` | `VIZ_RATE` spawn environment variable |
+
+### The playback state model
+
+Playback has two independent dimensions, which the original single enum mixed
+together. **Lifecycle** is `idle → starting → running → paused → finished`;
+**readiness** (`isPlayDisabled` while the container boots, `isSyncing` while the
+editor flushes) is orthogonal and can coincide with any of them.
+
+| | ⏯️ | ⏭️ | ↺ | Speed |
+|---|---|---|---|---|
+| `idle` + booting | – | – | – | ✓ |
+| `idle` ready | ✓ | – | – | ✓ |
+| `starting` | – | – | ✓ | – |
+| `running` | ✓ (pause) | – | ✓ | – |
+| `paused` | ✓ (resume) | ✓ | ✓ | ✓ |
+| `finished` | ✓ (re-run) | – | ✓ | ✓ |
+
+Speed is locked while running because the WebContainer receives the rate as a
+spawn environment variable and cannot be retuned without restarting. That is a
+temporary limitation: pausing the container will require a host→container control
+channel anyway, and once it exists the rate can travel the same way.
+
+`paused` carries a reason — `user`, `deadlock` or `waiting-external` — because
+only a user pause can be stepped. The other two mean the runtime has nothing left
+to release, which is the stepper ladder's rungs 3 and 4 surfacing in the UI.
+
+### Key Learnings
+
+#### Two bugs the matrix exposed
+
+Step was enabled in `idle`, a leftover from when stepping walked a recorded event
+log; in the runtime model there is nothing to step until a program is live. And
+a completed run returned to `idle` rather than `finished`, so the `finished`
+state was unreachable and Reset was offered when there was nothing to reset.
+
+### Verification
+
+Driven in a real browser on the fallback path. At each speed the program's
+virtual duration stayed constant while wall time scaled by exactly the expected
+factor — 1×, 2× and 4× — confirming that the clock reaches the program and that
+the recorded trace is speed-invariant. Speed locks while running, unlocks after,
+and survives a reload.
+
+The WebContainer path could not be exercised in the automation browser, which is
+not cross-origin isolated and therefore cannot boot a container; its runner logic
+was verified separately against the built runtime bundle under Node.
 
 ## Step 3: Date shim in the WebContainer ✅
 

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -88,7 +88,7 @@ only be inferred by elimination.
 | File | Contents |
 |------|----------|
 | `src/runtime/virtualClock.ts` | `VirtualClock` — the single virtual time source |
-| `src/runtime/virtualClock.test.ts` | 23 tests, including the pause and re-arm regression tests |
+| `src/runtime/virtualClock.test.ts` | 28 tests: pause and re-arm regressions, chained sleeps, at-most-once |
 
 Virtual time is a piecewise-linear function of wall time, advancing at `rate`
 virtual ms per wall ms. Every rate change **re-anchors** the mapping, so virtual
@@ -138,6 +138,21 @@ against the previous anchor, so they would go off late by exactly the amount of
 virtual time the jump skipped. Everything still pending is therefore re-armed
 after the jump. While paused this is a no-op, because parked timers hold no real
 timeout at all.
+
+#### A callback can only run once
+
+Three properties together guarantee it, and they matter because step 4 will drive
+this clock from the scheduler:
+
+- **`#fire` is the only place a callback is invoked**, and it removes the timer
+  from the map *before* running it. Map membership is the claim to run.
+- **Every path that fires or cancels clears the real timeout first**, so at most
+  one is outstanding per timer.
+- **Ids are monotonic**, so a stale callback can never alias a newer timer.
+
+The first property is what actually makes it safe: even if a real timeout escaped
+cancellation, it would reach `#fire`, find no entry, and no-op. The other two stop
+strays from accumulating rather than from doing damage.
 
 #### Chained sleeps re-base themselves
 

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -1,6 +1,6 @@
 # Phase 10: Slow Mode and Stepper (issue #13)
 
-**Status**: 🚧 IN PROGRESS — speed control shipped; stepper runs but is not wired to the UI
+**Status**: 🚧 IN PROGRESS — speed and stepper both work in the browser; the WebContainer still needs a control channel (4b)
 
 Issue [#13](https://github.com/topheman/effect-viz/issues/13) asks for a slow mode:
 _"It goes too fast so a slow stepper would be cool like Browser Debugger is."_
@@ -119,7 +119,7 @@ only be inferred by elimination.
 | 4a | Gated `Scheduler` + step ladder | ✅ |
 | 4b | Control channel for the WebContainer | ⬜ |
 | 5a | UI: speed combo + playback state matrix | ✅ |
-| 5b | UI: ⏯️ ⏭️ stepper controls | ⬜ |
+| 5b | UI: ⏯️ ⏭️ stepper controls (fallback path) | ✅ |
 | 6 | Example programs + explainers | ⬜ |
 
 ## Step 1: VirtualClock ✅
@@ -414,6 +414,45 @@ in the gated queue, tasks in flight with the inner scheduler, and pending timers
 on the `VirtualClock`. With all three at zero and the root fiber still running,
 nothing can happen without help. That is reported as "no progress" rather than
 guessing between a deadlock and a slow network reply.
+
+## Step 5b: Stepper controls ✅
+
+Pause, resume and step are wired to the buttons on the in-browser path. The
+WebContainer path leaves them disabled: its program runs in another process, and
+commands cannot reach it until step 4b.
+
+### Key Learnings
+
+#### A step is at least one event, not exactly one
+
+One scheduling decision resumes a fiber, which runs to its next yield point and
+may emit several trace events on the way. In the Basic Example each click
+advances the log by about four entries. That is the intended meaning of a step —
+one decision by the runtime — rather than one line of output.
+
+#### `PauseReason` lost a value it could not produce
+
+It began as `user | deadlock | waiting-external`, but the ladder can only tell
+that nothing is runnable, not why. It is now `user | stuck`, and the tooltip says
+"deadlocked, or waiting on something outside" rather than choosing.
+
+#### An interrupted run settles like a completed one
+
+`runFallbackPlay` catches the rejection and returns a value, so a run that is
+interrupted resolves exactly as a run that finished. While both branches set the
+same state this was invisible; once completion started reporting `finished`,
+Reset began reporting `finished` too.
+
+Both this and the next entry are fixed by a run identifier: the run records its
+id when it starts, Reset increments the id, and anything settling for an id that
+is no longer current is ignored.
+
+#### Reset left the interrupt's own events in the log
+
+`clearEvents()` runs immediately, but interrupting a fiber emits trace events of
+its own, and those arrive afterwards. Reset therefore emptied the log and then
+refilled it with the interruption. The emit path now drops events belonging to a
+superseded run.
 
 ## Step 5a: Speed control ✅
 

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -1,6 +1,6 @@
 # Phase 10: Slow Mode and Stepper (issue #13)
 
-**Status**: 🚧 IN PROGRESS — speed, pause, step and origin tagging are done; what remains is the examples and explainers (6)
+**Status**: ✅ COMPLETE — all steps done. Follow-up work continues in [#18](https://github.com/topheman/effect-viz/issues/18) (Effect upgrade + trace audit)
 
 Issue [#13](https://github.com/topheman/effect-viz/issues/13) asks for a slow mode:
 _"It goes too fast so a slow stepper would be cool like Browser Debugger is."_

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -993,16 +993,19 @@ rather than one, structured interruption asserts both children's finalizers ran
 along with the parent's, and deadlock asserts the fiber is still unresolved after
 ten virtual seconds.
 
-### Known issue: the two paths run different Effect versions
+### Known issue: the two paths ran different Effect versions
 
 The Timeout example exposed a drift the other programs never revealed. The
-container's `package.json` asks for `"effect": "^3.19.15"`, so it installs
-whatever 3.x is current — 3.22.1 today — while the in-browser path bundles the
-version this repo locks, 3.19.15. The two disagree about the fiber that loses a
+container's `package.json` asked for `"effect": "^3.19.15"`, so it installed
+whatever 3.x was current — 3.22.1 at the time — while the in-browser path bundles
+the version this repo locks, 3.19.15. The two disagreed about the fiber that loses a
 timeout race: on 3.19.15 its exit is an interrupt, on 3.22.1 a success. Since the
-Supervisor labels a fiber's end from its exit, the same program traces
+Supervisor labels a fiber's end from its exit, the same program traced
 `fiber:interrupt` in the browser and `fiber:end` in the container.
 
-Left as is for now, to be settled by a separate upgrade of `effect` — at which
-point the container's dependency should be pinned to the app's own version rather
-than a caret range, so the two paths cannot drift again.
+Settled by [#17](https://github.com/topheman/effect-viz/pull/17): pinning the
+container to the app's own exact version rather than a caret range, so the two
+paths cannot drift again — both now run 3.19.15. The upgrade of `effect` itself
+to the latest 3.x remains open as separate work in
+[#18](https://github.com/topheman/effect-viz/issues/18), where the
+trace-behaviour changes between 3.19 and 3.22 will need an audit.

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -378,6 +378,18 @@ question: what happens when the user clicks step.
 A fiber that can run now must run before time is allowed to move, otherwise a
 step would skip past work that was already due.
 
+#### The timeline must read the clock, not model it
+
+The live cursor was computed by extrapolating from the run's rate: anchor the
+first event, then add wall time multiplied by the rate. That is correct only
+while the clock runs freely. A paused clock kept extrapolating, so the timeline
+grew a bar to eight seconds for a program that was frozen with two events on it,
+and a step moved virtual time in a jump the extrapolation could not see.
+
+The in-browser path holds the clock, so the store now reads it directly and only
+falls back to extrapolation for the WebContainer, where the program runs in
+another process and cannot be paused anyway.
+
 #### Pause has to stop the clock as well as the scheduler
 
 Gating the scheduler stops fibers from running, but virtual time keeps advancing

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -115,6 +115,7 @@ only be inferred by elimination.
 | 1 | `VirtualClock` — shared virtual time source | ✅ |
 | 2 | Effect `Clock` layer built on `VirtualClock` | ✅ |
 | 3 | `Date` shim in the WebContainer runner | ✅ |
+| 3b | Virtual timestamps at every emit site | ✅ |
 | 4 | Gated `Scheduler` + the step ladder | ⬜ |
 | 5 | UI: speed combo + ⏯️ ⏭️ in `PlaybackControls` | ⬜ |
 | 6 | Example programs + explainers | ⬜ |
@@ -257,6 +258,65 @@ stepper reads `pendingCount` to decide whether the world can still make progress
 Slow motion is real from here: providing this layer makes every `Effect.sleep`,
 `Schedule` delay, `timeout` and `race` in a program run at the chosen rate, and
 rate 0 genuinely freezes them.
+
+## Step 3b: Virtual timestamps at every emit site ✅
+
+The shim made container trace timestamps virtual as a *side effect* of a global
+patch, and left the fallback path on wall time. Both paths now read virtual time
+explicitly, so neither depends on the shim for correctness — the shim is back to
+doing only its real job, serving user code that reaches for `Date` directly.
+
+### Created/Modified Files
+
+| File | Changes |
+|------|---------|
+| `src/runtime/virtualClock.ts` | Export the `Now` type |
+| `src/runtime/traceEmitter.ts` | 5 sites → `Clock.currentTimeMillis` |
+| `src/runtime/vizTracer.ts` | 2 sites → the runtime-supplied span times |
+| `src/runtime/vizSupervisor.ts` | 4 sites → injected `Now` |
+| `src/runtime/runProgram.ts` | 3 sites → injected `Now` |
+| `src/hooks/useEventHandlers.ts` | Fallback builds its own clock and provides the clock layer |
+| `src/services/webcontainer.ts` | `RUNNER_JS` passes `now`; prewarm import fixed |
+
+### Key Learnings
+
+#### Only half the sites needed injecting
+
+Of the fourteen `Date.now()` calls, seven could read virtual time from something
+they already had:
+
+- **`traceEmitter.ts`** runs inside `Effect.gen`, so `Clock.currentTimeMillis` is
+  available directly. `Clock` is a default service, so this adds nothing to the R
+  channel and no signature changed.
+- **`vizTracer.ts`** was ignoring parameters the runtime already passes.
+  `internal/core-effect.ts` builds span times with `clock.unsafeCurrentTimeNanos()`
+  and hands them to `tracer.span(...)` and `span.end(...)` — already virtual. We
+  were discarding them and calling `Date.now()` instead.
+
+Only the `Supervisor` callbacks and `runProgramFork` are genuinely outside any
+Effect context, and those take the injected `Now`.
+
+#### Nanosecond epochs do not fit in a double
+
+Span times arrive as BigInt nanoseconds. An epoch in nanoseconds is around
+1.8 × 10¹⁸, well past `Number.MAX_SAFE_INTEGER`, so converting before dividing
+loses precision. Dividing as BigInt first and converting after keeps the result
+exact.
+
+#### The prewarm program had been silently broken
+
+`PREWARM_PROGRAM` imported `runProgramFork`, but the runtime bundle has exported
+it as `_runProgramFork` since the phase 9 rename. That is a link-time error, so
+the pre-warm spawn had been failing since then — invisibly, because it is forked
+and spawned with `output: false`. Found while updating the call sites.
+
+### What this unlocks
+
+Both execution paths record virtual time, so a trace spans the same duration
+whatever speed it was captured at — verified by running a program with a forked
+child, a span and a sleep at three rates: wall time scaled while the recorded
+span stayed constant. The fallback path also gains the clock layer, fixed at
+rate 1 until the speed control is wired.
 
 ## Step 3: Date shim in the WebContainer ✅
 

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -1,6 +1,6 @@
 # Phase 10: Slow Mode and Stepper (issue #13)
 
-**Status**: 🚧 IN PROGRESS — step 2 of 6 complete
+**Status**: 🚧 IN PROGRESS — step 3 of 6 complete
 
 Issue [#13](https://github.com/topheman/effect-viz/issues/13) asks for a slow mode:
 _"It goes too fast so a slow stepper would be cool like Browser Debugger is."_
@@ -114,7 +114,7 @@ only be inferred by elimination.
 |---|------|--------|
 | 1 | `VirtualClock` — shared virtual time source | ✅ |
 | 2 | Effect `Clock` layer built on `VirtualClock` | ✅ |
-| 3 | `Date` shim in the WebContainer runner | ⬜ |
+| 3 | `Date` shim in the WebContainer runner | ✅ |
 | 4 | Gated `Scheduler` + the step ladder | ⬜ |
 | 5 | UI: speed combo + ⏯️ ⏭️ in `PlaybackControls` | ⬜ |
 | 6 | Example programs + explainers | ⬜ |
@@ -248,3 +248,71 @@ stepper reads `pendingCount` to decide whether the world can still make progress
 Slow motion is real from here: providing this layer makes every `Effect.sleep`,
 `Schedule` delay, `timeout` and `race` in a program run at the chosen rate, and
 rate 0 genuinely freezes them.
+
+## Step 3: Date shim in the WebContainer ✅
+
+### Created/Modified Files
+
+| File | Changes |
+|------|---------|
+| `src/runtime/dateShim.ts` | `installDateShim(virtualClock)` → uninstall function |
+| `src/runtime/dateShim.test.ts` | 13 tests |
+| `src/runtime/index.ts` | Export `_installDateShim`, `_VirtualClock`, `_makeVizClockLayer` |
+| `src/services/webcontainer.ts` | `RUNNER_JS` creates the clock, installs the shim, provides the clock layer |
+
+Effect's own notion of time already comes from the `Clock`, but code calling
+`Date.now()` directly bypasses it and would keep reading wall time while
+everything around it ran slowly. The shim closes that gap — in the container
+only, since the in-browser fallback shares a realm with React and patching `Date`
+there would distort the UI's own animations.
+
+### Key Learnings
+
+#### A Proxy, not a subclass
+
+The obvious implementation is `class ShimmedDate extends Date`, but a class
+cannot be called without `new`, and `Date()` without `new` is legal JavaScript
+that returns a string. Proxying the real `Date` keeps that working, and gets
+`instanceof`, `Date.parse`, `Date.UTC` and the whole prototype for free because
+the target is the genuine constructor.
+
+Only two behaviours change: `Date.now()` and the zero-argument `new Date()`.
+Every explicit form is passed straight through — which matters because Effect
+itself builds log timestamps with `new Date(clock.unsafeCurrentTimeMillis())`.
+
+#### The import order was already correct
+
+The shim must be installed *after* `VirtualClock` has captured the real
+`Date.now`, or the two would read each other. `runner.js` imports `runtime.js`
+statically and loads the user's program with a *dynamic* `await import()`, so the
+sequence falls out for free: the runtime evaluates first and captures the real
+function, then `main()` installs the shim, then the program module evaluates and
+sees virtual time from its first statement. Had the program been a static import
+it would have initialised before the shim landed.
+
+#### Trace timestamps became virtual for free
+
+Every emit site hardcodes `timestamp: Date.now()` — in `traceEmitter`,
+`vizTracer`, `vizSupervisor` and `runProgram`. All of that code runs inside the
+container, so the shim converts them without a single edit: a program's recorded
+trace now spans the same virtual duration whatever the speed, and the timeline
+will not redraw itself when the user changes the combo. Verified by running the
+built bundle at three rates: wall time scaled as expected, while the trace span,
+and any `Date.now()` the program read, stayed constant.
+
+The fallback path has no shim by design, so its timestamps remain wall time.
+That asymmetry is a decision for step 5.
+
+#### `RUNNER_JS` is a string, so the logic lives in the bundle
+
+The runner cannot be typechecked or unit-tested — it is a template literal
+mounted into the container. Keeping it to a few calls into `runtime.js` means
+everything of substance is testable in `src/runtime`, and the string stays thin
+enough to read.
+
+### What this unlocks
+
+A container whose entire notion of time — Effect's and raw JavaScript's — is under
+our control, with speed-invariant trace timestamps. The rate is read from a
+`VIZ_RATE` environment variable at spawn (defaulting to 1); step 5 supplies the
+value from the UI.

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -120,7 +120,7 @@ only be inferred by elimination.
 | 4b | Control channel for the WebContainer | ✅ |
 | 5a | UI: speed combo + playback state matrix | ✅ |
 | 5b | UI: ⏯️ ⏭️ stepper controls (fallback path) | ✅ |
-| 6 | Example programs + explainers | ⬜ |
+| 6 | Example programs + explainers | ✅ |
 | 7 | Tag instrumentation events, with a show/hide toggle | ✅ |
 
 ## Step 1: VirtualClock ✅
@@ -922,3 +922,73 @@ program's output rather than the protocol — with both available to anyone who
 wants to see how the visualizer works. That last part is worth keeping for step 6:
 turning the internals on and stepping is the clearest explanation of the control
 channel the app can give.
+
+## Step 6: Example programs ✅
+
+The ten programs the visualizer shipped with were all sleep-shaped: every fork is
+followed straight away by an `Effect.sleep`, so the trace reads fork, fork,
+suspend, suspend, wait, resume, resume. That is the speed control's territory —
+those programs are already slow, and slowing them further only stretches gaps the
+reader could see anyway. The stepper earns its keep in the burst *between* the
+sleeps, and no example had one.
+
+Choosing what to add by concept rather than by what would look busy, five things
+turned out to be missing outright. `Effect.yieldNow`, `Effect.all`, its
+`concurrency` option, `Deferred` and `Effect.timeout` appeared nowhere in the set.
+Interruption did appear, but only as `Fiber.interrupt` on two flat siblings in
+Racing: a hierarchy was never cancelled, and a finalizer never unwound on anything
+but the success path.
+
+| Program | Teaches |
+|---------|---------|
+| Cooperative Interleaving | Fibers take turns at yield points; concurrency is not parallelism |
+| Bounded Concurrency | `Effect.all` with a `concurrency` limit, rather than hand-rolled forks |
+| Structured Interruption | Cancelling a parent cancels its children, and finalizers still run |
+| Timeout | A deadline read from the same clock the program sleeps on |
+| Deadlock | `Deferred`, and what a fiber deadlock is |
+
+### Created/Modified Files
+
+| File | Changes |
+|------|---------|
+| `src/lib/programs.ts` | Five effects and their registry entries, with the lesson in the code |
+| `src/lib/programs.test.ts` | 5 tests asserting each example does what its comments claim |
+| `src/lib/programCache.test.ts` | Fixture extended to the new keys |
+
+### Key Learnings
+
+#### The explanation belongs in the program, not beside it
+
+Each entry carries a `description`, and it renders nowhere — so there was no
+explainer surface to extend, only one to choose. It stays a label, a few words in
+the picker, and the teaching text lives as short comments on the lines it
+describes. Someone reading `concurrency: 2` wants to be told there that tasks 3
+and 4 wait for 1 and 2; a paragraph in a panel they are not looking at would not
+reach them.
+
+#### Every example is written twice
+
+A program exists as a real effect, which the in-browser path runs, and as a source
+string, which the editor shows and the container executes. Nothing links them, so
+the two can drift silently — and the string is invisible to `tsc`. Writing each
+`source` out to a scratch file under `src/` and running the project's own
+typecheck over it catches both a syntax slip and an API that has moved. All
+fifteen pass.
+
+#### A program that never finishes is a legitimate lesson
+
+Deadlock hangs by design, which felt wrong until it was clear that hanging is the
+concept. It is also the first program that can reach the stepper's `noProgress`
+outcome: until now the "Nothing can run" pause reason built in step 4a existed
+without a single example able to produce it.
+
+### Verification
+
+The tests drive the same layers the app does, on a `VirtualClock` the test
+advances, so a program with seconds of sleeping in it runs in milliseconds. They
+check the claims the comments make rather than the shape of the output:
+interleaving asserts the two fibers alternate step for step, bounded concurrency
+asserts the virtual times at which each task reports in fall into three batches
+rather than one, structured interruption asserts both children's finalizers ran
+along with the parent's, and deadlock asserts the fiber is still unresolved after
+ten virtual seconds.

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -1,0 +1,140 @@
+# Phase 10: Slow Mode and Stepper (issue #13)
+
+**Status**: 🚧 IN PROGRESS — step 1 of 6 complete
+
+Issue [#13](https://github.com/topheman/effect-viz/issues/13) asks for a slow mode:
+_"It goes too fast so a slow stepper would be cool like Browser Debugger is."_
+
+## Design Summary
+
+Two controls, driven by one mechanism:
+
+- **Speed combo** (`x1 / x0.75 / x0.5 / x0.25`) — scales the Effect `Clock`, so
+  time itself runs slower.
+- **Stepper** (`⏯️ ⏭️`) — freezes the world and releases one scheduling decision
+  at a time.
+
+### Why the Clock is the lever
+
+Everything in Effect's model routes through the `Clock` service:
+
+- `Effect.sleep` → `defaultServices.sleep` → `clockWith((clock) => clock.sleep(d))`
+  (`internal/defaultServices.ts:45`)
+- `Schedule` drivers read `Clock.currentTimeMillis` (`internal/schedule.ts:170`)
+- `Effect.log` timestamps come from `clockService.unsafeCurrentTimeMillis()`
+  (`internal/fiberRuntime.ts:871`)
+
+Scaling *all* of time uniformly means `race`, `timeout` and exponential backoff
+stretch together, so the program's observable semantics are unchanged — it is
+genuine slow motion, not a distortion. This is why we instrument the runtime
+rather than replaying recorded events in the UI.
+
+### Why speed alone is not enough
+
+Effect programs emit trace events in two very different rhythms. Most events
+arrive in **bursts with no measurable gap between them** — many operations running
+inside a single uninterrupted fiber run-step. The rest are separated by **hundreds
+of milliseconds**, because a fiber is parked waiting on the clock.
+
+That split is exactly the `fiber:suspend` / `fiber:resume` boundary, and it is why
+the clock is only half the answer: scaling time stretches the waiting, but the
+bursts are not clock-mediated, so they stay a flash at every speed. Making the
+sleeps longer does not make the interesting moments readable — and those bursts
+are where forks, races and interruptions actually happen.
+
+**Speed handles the sleeps, the stepper handles the bursts.** Neither covers both,
+which is why the two controls belong together.
+
+### Step is a pause-mode operation
+
+Two independent things advance the world: the clock ticking, and the scheduler
+running runnable tasks. With speed > 0 both are free-running, so pressing ⏭️ would
+be decorative — the resume arrives on its own regardless. So ⏭️ freezes first
+(rate → 0 *and* gate the scheduler), then releases exactly one thing, like a
+browser debugger where step is only available while paused.
+
+### The step ladder
+
+Frozen world, user clicks next. Because we supply both the `Scheduler` and the
+`Clock`, we know nearly everything that could happen next:
+
+1. **A runnable task is queued** → release exactly one.
+2. **Nothing runnable, timers pending** → advance virtual time to the earliest
+   deadline, making that fiber runnable, then release it. (`TestClock.adjust`
+   semantics.)
+3. **Nothing runnable, no timers, fibers waiting on each other** → deadlock, and
+   we can say so.
+4. **Nothing runnable, no timers, something out on external async** → cannot step;
+   the outside world must answer.
+
+Case 4 is the real limit: external callbacks are not in our queue, so they can
+only be inferred by elimination.
+
+## Implementation Steps
+
+| # | Step | Status |
+|---|------|--------|
+| 1 | `VirtualClock` — shared virtual time source | ✅ |
+| 2 | Effect `Clock` layer built on `VirtualClock` | ⬜ |
+| 3 | `Date` shim in the WebContainer runner | ⬜ |
+| 4 | Gated `Scheduler` + the step ladder | ⬜ |
+| 5 | UI: speed combo + ⏯️ ⏭️ in `PlaybackControls` | ⬜ |
+| 6 | Example programs + explainers | ⬜ |
+
+## Step 1: VirtualClock ✅
+
+### Created Files
+
+| File | Contents |
+|------|----------|
+| `src/runtime/virtualClock.ts` | `VirtualClock` — the single virtual time source |
+| `src/runtime/virtualClock.test.ts` | 18 tests, including the pause regression test |
+
+Virtual time is a piecewise-linear function of wall time, advancing at `rate`
+virtual ms per wall ms. Every rate change **re-anchors** the mapping, so virtual
+time is continuous — it never jumps when the user changes speed, only its slope
+changes.
+
+```ts
+now() = virtualAnchor + (wallNow - wallAnchor) * rate
+```
+
+### Key Learnings
+
+#### Pause must park, not divide
+
+The obvious implementation of a scaled sleep is `setTimeout(fn, d / rate)`. At
+rate 0 that is `setTimeout(fn, Infinity)`, and Node says:
+
+```
+TimeoutOverflowWarning: Infinity does not fit into a 32-bit signed integer.
+Timeout duration was set to 1.
+Infinity delay fired after 5 ms
+```
+
+So the naive version makes **pause wake every sleeping fiber almost immediately** —
+the exact inverse of pause, and it looks like a race condition rather than an
+arithmetic bug. Instead, `rate = 0` *parks* pending timers (clears the real
+timeout, keeps the virtual deadline) and re-arms them on resume with the time
+that was actually remaining.
+
+#### The clock must not read its own shim
+
+`Date.now` is captured at module load, before any shim is installed. The `Date`
+shim will read the `VirtualClock`, so if the clock read `Date.now()` dynamically
+the two would recurse. The wall-clock primitives are injectable
+(`VirtualClockHost`), which is also what makes the tests deterministic under
+vitest fake timers.
+
+#### `advanceToNextDeadline()` is rung 2 of the ladder
+
+Stepping a time-blocked fiber means jumping virtual time to the earliest pending
+deadline and firing what is due — with no wall time passing at all. A chain of
+sleeps can be stepped through instantly, which is exactly what `TestClock` does
+in tests.
+
+### What this unlocks
+
+A single source of truth for time that can run at any rate, freeze without
+distortion, and be stepped forward deadline by deadline — with no dependency on
+Effect yet, so it is testable in isolation.

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -116,7 +116,8 @@ only be inferred by elimination.
 | 2 | Effect `Clock` layer built on `VirtualClock` | ✅ |
 | 3 | `Date` shim in the WebContainer runner | ✅ |
 | 3b | Virtual timestamps at every emit site | ✅ |
-| 4 | Gated `Scheduler` + the step ladder | ⬜ |
+| 4a | Gated `Scheduler` (fallback path) | 🚧 |
+| 4b | Control channel for the WebContainer | ⬜ |
 | 5a | UI: speed combo + playback state matrix | ✅ |
 | 5b | UI: ⏯️ ⏭️ stepper controls | ⬜ |
 | 6 | Example programs + explainers | ⬜ |
@@ -318,6 +319,64 @@ whatever speed it was captured at — verified by running a program with a forke
 child, a span and a sleep at three rates: wall time scaled while the recorded
 span stayed constant. The fallback path also gains the clock layer, fixed at
 rate 1 until the speed control is wired.
+
+## Step 4a: Gated Scheduler 🚧
+
+The `VirtualClock` stretches the gaps a program spends sleeping. It cannot touch
+the bursts of work between sleeps, because there is no gap there to stretch — and
+those bursts are where forks, races and interruptions happen. Controlling them
+means controlling the `Scheduler`.
+
+A fiber that must continue later does not continue itself: the runtime turns the
+continuation into a **task** and hands it to the `Scheduler`, which decides when
+to run it. `GatedScheduler` takes that decision. While playing it forwards every
+task to Effect's own scheduler unchanged. While paused it queues them, and only a
+step releases one.
+
+### Key Learnings
+
+#### Forcing a yield while paused deadlocks the stepper
+
+It looked worthwhile to answer `shouldYield` with "yes" while paused, so a fiber
+would stop at its next operation rather than after Effect's default of 2048. It
+makes no progress possible at all: the released fiber asks `shouldYield` before
+doing any work, is told to yield, re-queues itself, and every step releases that
+same task forever. The queue count sits at 1 and nothing happens.
+
+`shouldYield` now defers to Effect in both modes. Pausing therefore takes effect
+at the runtime's own yield points — which is also where the program is in a
+consistent state.
+
+#### One task is not one visible step
+
+The first released task is often runtime bookkeeping — building a `Layer`,
+closing a scope — and not user code. A step button wired straight to "release one
+task" would appear to do nothing at random moments.
+
+So "release one task" stays the internal primitive, and the button uses
+`releaseUntil(predicate)`: release until something visible has happened. The
+caller supplies what counts, normally "one more trace event has been emitted". A
+`maxTasks` bound stops a predicate that never comes true from running the whole
+program on one click.
+
+#### A pause takes hold within one scheduler turn
+
+Tasks already handed to Effect's scheduler still run — they are out of our hands.
+Anything *they* schedule is queued. So the program stops a moment after Pause is
+pressed, not instantly.
+
+#### Detecting a stuck program needs no internals
+
+`fiber.status` carries `blockingOn`, which would separate a deadlock from a wait
+on the network. But it is an `Effect`, and reading it sends the fiber a message
+that the fiber must process — which needs the scheduler that we are gating. So it
+cannot be read while paused.
+
+Three counts we own are enough to detect that a program cannot move at all: tasks
+in the gated queue, tasks in flight with the inner scheduler, and pending timers
+on the `VirtualClock`. With all three at zero and the root fiber still running,
+nothing can happen without help. That is reported as "no progress" rather than
+guessing between a deadlock and a slow network reply.
 
 ## Step 5a: Speed control ✅
 

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -1,6 +1,6 @@
 # Phase 10: Slow Mode and Stepper (issue #13)
 
-**Status**: 🚧 IN PROGRESS — speed and stepper both work in the browser; the WebContainer still needs a control channel (4b)
+**Status**: 🚧 IN PROGRESS — speed, pause and step work on both paths; what remains is the examples and explainers (6) and tagging instrumentation events (7)
 
 Issue [#13](https://github.com/topheman/effect-viz/issues/13) asks for a slow mode:
 _"It goes too fast so a slow stepper would be cool like Browser Debugger is."_
@@ -117,7 +117,7 @@ only be inferred by elimination.
 | 3 | `Date` shim in the WebContainer runner | ✅ |
 | 3b | Virtual timestamps at every emit site | ✅ |
 | 4a | Gated `Scheduler` + step ladder | ✅ |
-| 4b | Control channel for the WebContainer | ⬜ |
+| 4b | Control channel for the WebContainer | ✅ |
 | 5a | UI: speed combo + playback state matrix | ✅ |
 | 5b | UI: ⏯️ ⏭️ stepper controls (fallback path) | ✅ |
 | 6 | Example programs + explainers | ⬜ |
@@ -152,8 +152,8 @@ events will carry an origin — the program's own, or the tool's — and the
 Execution Log will offer a toggle. The Timeline and Fiber Tree keep consuming
 everything, since a suspend that genuinely happened still belongs on a timeline.
 
-This is deferred until after 4b and 6, and is expected to cover more than the
-injected yield: the control channel will likely have a handshake of its own.
+This is deferred until after 6, and covers more than the injected yield: the
+control channel opens with a `ready` handshake of its own.
 
 ## Step 1: VirtualClock ✅
 
@@ -353,7 +353,7 @@ child, a span and a sleep at three rates: wall time scaled while the recorded
 span stayed constant. The fallback path also gains the clock layer, fixed at
 rate 1 until the speed control is wired.
 
-## Step 4a: Gated Scheduler 🚧
+## Step 4a: Gated Scheduler ✅
 
 The `VirtualClock` stretches the gaps a program spends sleeping. It cannot touch
 the bursts of work between sleeps, because there is no gap there to stretch — and
@@ -475,9 +475,9 @@ guessing between a deadlock and a slow network reply.
 
 ## Step 5b: Stepper controls ✅
 
-Pause, resume and step are wired to the buttons on the in-browser path. The
-WebContainer path leaves them disabled: its program runs in another process, and
-commands cannot reach it until step 4b.
+Pause, resume and step are wired to the buttons on the in-browser path, which
+holds the `Stepper` directly. The WebContainer path leaves them disabled here;
+step 4b gives it a channel to reach the same three verbs in another process.
 
 ### Key Learnings
 
@@ -672,3 +672,178 @@ A container whose entire notion of time — Effect's and raw JavaScript's — is
 our control, with speed-invariant trace timestamps. The rate is read from a
 `VIZ_RATE` environment variable at spawn (defaulting to 1); step 5 supplies the
 value from the UI.
+
+---
+
+## Step 4b: Control channel for the WebContainer ✅
+
+Pause, resume and step reached the runtime by a method call on the in-browser
+path, and by nothing at all on the WebContainer path — the program runs in
+another process, so the controls were simply disabled there. That was the wrong
+way round: the container is the path most people use.
+
+The three verbs now travel as messages. Commands go in on the process's stdin as
+one JSON object per line; replies come back on stdout behind a `TRACE_CONTROL:`
+prefix, alongside the `TRACE_EVENT:` lines that were already there.
+
+### What the wire looks like
+
+Both directions share the process's stdio, so it helps to read a run as a
+conversation. Below, ⬇️ is the page writing a command to the process's **stdin**,
+and ⬆️ is the process writing back on its **stdout**. This is a real transcript of
+a program that logs a line and then sleeps for two seconds, started paused and
+stepped through (span ids shortened).
+
+```text
+⬆️ TRACE_CONTROL:{"reply":"ready","virtualNow":1787609740816.87}
+⬆️ TRACE_EVENT:{"type":"fiber:fork","fiberId":"#0","timestamp":1787609740816.87}
+⬆️ TRACE_EVENT:{"type":"fiber:suspend","fiberId":"#0","timestamp":1787609740816.87}
+
+⬇️ {"cmd":"step"}
+⬆️ TRACE_EVENT:{"type":"fiber:resume","fiberId":"#0","timestamp":1787609740816.87}
+⬆️ TRACE_EVENT:{"type":"effect:start","label":"greet","id":"9273ed06","timestamp":1787609740816}
+⬆️ hello from the program
+⬆️ TRACE_EVENT:{"type":"effect:end","id":"9273ed06","result":"success","timestamp":1787609740816}
+⬆️ TRACE_EVENT:{"type":"fiber:suspend","fiberId":"#0","timestamp":1787609740816.87}
+⬆️ TRACE_CONTROL:{"reply":"step","virtualNow":1787609740816.87,"outcome":{"_tag":"released","tasks":1}}
+
+⬇️ {"cmd":"step"}
+⬆️ TRACE_EVENT:{"type":"fiber:resume","fiberId":"#0","timestamp":1787609742816.87}
+⬆️ TRACE_CONTROL:{"reply":"step","virtualNow":1787609742816.87,"outcome":{"_tag":"advancedClock","toVirtual":1787609742816.87,"tasks":1}}
+⬆️ TRACE_EVENT:{"type":"fiber:end","fiberId":"#0","timestamp":1787609742816.87}
+⬆️ Program completed: done
+
+⬇️ {"cmd":"step"}
+```
+
+Four things are worth reading out of it.
+
+**The upward channel is shared, the downward one is not.** Three kinds of line
+come back — trace events, control replies, and `hello from the program`, which is
+the program's own `console.log`. WebContainer merges a process's stdout and stderr
+into a single output stream, so a reader has to sort them, and only the
+machine-readable kinds are prefixed. Nothing but the page writes to stdin, so a
+command travels as bare JSON.
+
+**A step is answered after its consequences.** Every event a step produces is
+written before the reply that accounts for it, because the runner emits them
+synchronously inside the step. By the time the page snaps its clock model to a
+reply's reading, it has already received every event that reading covers — the
+correction can never arrive ahead of what it is correcting.
+
+**The clock jump is visible.** Across the second step the timestamps move from
+`…740816` to `…742816`, the full two seconds of the sleep, while the user spent a
+moment between clicks. That is the `advancedClock` rung of the ladder, and the
+reason a reply carries `virtualNow` at all: no extrapolation from the run's rate
+could have produced that jump.
+
+**The last command goes nowhere.** The program finished during the second step, so
+the process released its stdin listener and exited; the third command was written
+into a closed pipe. That is the ordinary end of every run rather than an error
+case, which is why the writer discards write failures and the scope's release
+settles any step still waiting with a null outcome.
+
+### Created/Modified Files
+
+| File | Changes |
+|------|---------|
+| `src/runtime/controlChannel.ts` | Command and reply codecs, `applyCommand`, `makeLineReader` |
+| `src/runtime/controlChannel.test.ts` | 35 tests |
+| `src/lib/mirroredClock.ts` | The page's model of the container's clock |
+| `src/lib/mirroredClock.test.ts` | 7 tests |
+| `src/lib/containerController.ts` | Turns clicks into commands, resolves a step on its reply |
+| `src/lib/containerController.test.ts` | 7 tests |
+| `src/services/webcontainer.ts` | `RUNNER_JS` builds the scheduler and stepper, reads stdin, writes replies |
+| `src/effects/spawnAndParse.ts` | `TRACE_CONTROL:` branch, writes to `proc.input`, `VIZ_START_PAUSED` |
+| `src/hooks/useEventHandlers.ts` | One pair of handlers for both paths; a step is a promise on each |
+| `src/components/layout/PlaybackControls.tsx` | `isSteppingSupported` removed — every path supports it now |
+
+### Key Learnings
+
+#### The reply is what makes a step legible, not a nicety
+
+A `StepOutcome` is what tells the user a program is stuck rather than merely
+slow, so the channel needs a return path for that alone. But every reply also
+carries the container's virtual clock reading, and that turns out to be
+load-bearing for the timeline.
+
+The page draws a cursor in the gaps between events, and on this path it can only
+model the container's clock rather than read it. Extrapolating from the run's
+rate is fine while a program runs freely. It is hopeless across a step, as the
+transcript above shows: a step over a sleep moves the container's clock by the
+whole sleep in one go, while barely any wall time passes. Without the reading in
+the reply the cursor would sit still and the next event would arrive stamped
+seconds ahead of it.
+
+#### The model is a predictor, not a second clock
+
+The container's clock stays the only clock — it is what `Effect.sleep` counts
+down in and what stamps every event. `MirroredClock` extrapolates between
+authoritative readings and snaps on each one, and it gets two kinds: the
+timestamp on every trace event, and the `virtualNow` on every control reply. Both
+sides read the same monotonic hardware source, so the two never tick at different
+speeds; the error is an offset of roughly one message latency, and snapping keeps
+it from accumulating.
+
+Two rules make the snapping safe. Corrections only ever move the cursor forward,
+because a reading is always slightly stale by the time it arrives — one that
+lands behind the prediction means the page ran ahead, not that time went
+backwards, and a playhead that rewinds reads as a bug. And the model re-anchors
+before its rate changes, or the elapsed interval gets re-read at a rate that was
+never in effect for it.
+
+That asymmetry also decides when the model follows a command. It freezes on the
+click, so the cursor stops when the user expects; it resumes on the *reply*,
+because a model resumed early would run ahead of the container for the rest of
+the run, and forward-only corrections would never pull it back.
+
+#### stdin is the keep-alive, which is why it has to be released
+
+A listener on `process.stdin` refs Node's event loop. That is a problem and a
+solution at once. Without the release the process would never exit, because
+nothing else keeps it open once a program finishes; the listener is removed when
+the root promise settles. But it also cannot simply be unref'd, because a *paused*
+program has no task running and no timer armed — while the gate is closed, that
+listener is the only thing holding the process open at all.
+
+#### Speed stayed off the wire
+
+The protocol could carry a rate, but the fallback path fixes speed for the life
+of a run, and the container reads it once from `VIZ_RATE` at spawn. Putting a live
+rate command on the channel would give one path a capability the other does not
+have, for a control the UI presents as identical on both. It stays a spawn-time
+decision.
+
+#### Step from idle had to learn to flush
+
+Step doubles as "start this program paused", and on the container path a run must
+be preceded by flushing the editor's contents. Play already did that; Step never
+had to, because it had only ever run in the browser, where there is nothing to
+sync. Without it, a stepped run would walk through whatever the container was
+last given rather than what is on screen.
+
+### Verification
+
+The runner is a template literal, so it cannot be typechecked or unit tested. It
+was exercised by extracting the real string, running it under Node against the
+built runtime bundle, and driving its stdin the way the page does.
+
+Stepping a program with a five second sleep produced the ladder in order: queued
+work released one visible chunk at a time, then the rung that moves the clock,
+reported as `advancedClock` with the jump in the reply. Pausing a free-running
+program for a second and a half left no trace in the program's own timeline —
+the run's virtual span came out the same as an unpaused one, because the clock
+stopped with the scheduler. Both runs exited cleanly, which is the check that
+the stdin listener is being released.
+
+WebContainer itself could not be booted in the automation browser, which lacks
+cross-origin isolation and so has no `SharedArrayBuffer`. What that leaves
+unverified is one link: whether writes to `proc.input` arrive at the container
+process's `process.stdin`. Everything on either side of that link is covered.
+
+### What this unlocks
+
+Slow motion, pause and step on the path the app actually runs, which is what
+step 6's examples need to be worth writing. The `TRACE_CONTROL:` channel is also
+the handshake that step 7 anticipated: `ready` is the first message on it, and
+the first instrumentation event that will want tagging.

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -88,7 +88,7 @@ only be inferred by elimination.
 | File | Contents |
 |------|----------|
 | `src/runtime/virtualClock.ts` | `VirtualClock` — the single virtual time source |
-| `src/runtime/virtualClock.test.ts` | 18 tests, including the pause regression test |
+| `src/runtime/virtualClock.test.ts` | 23 tests, including the pause and re-arm regression tests |
 
 Virtual time is a piecewise-linear function of wall time, advancing at `rate`
 virtual ms per wall ms. Every rate change **re-anchors** the mapping, so virtual
@@ -132,6 +132,20 @@ Stepping a time-blocked fiber means jumping virtual time to the earliest pending
 deadline and firing what is due — with no wall time passing at all. A chain of
 sleeps can be stepped through instantly, which is exactly what `TestClock` does
 in tests.
+
+Jumping time forward invalidates the timers that did *not* fire: they were armed
+against the previous anchor, so they would go off late by exactly the amount of
+virtual time the jump skipped. Everything still pending is therefore re-armed
+after the jump. While paused this is a no-op, because parked timers hold no real
+timeout at all.
+
+#### Chained sleeps re-base themselves
+
+A sleep scheduled from inside another sleep's callback takes its deadline from
+virtual time *at the moment it is scheduled*, so error never accumulates across a
+chain and a rate change between two links applies cleanly to the second one. The
+same holds when the chain is interrupted by a pause: the inner sleep parks like
+any other.
 
 ### What this unlocks
 

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -121,6 +121,39 @@ only be inferred by elimination.
 | 5a | UI: speed combo + playback state matrix | ✅ |
 | 5b | UI: ⏯️ ⏭️ stepper controls (fallback path) | ✅ |
 | 6 | Example programs + explainers | ⬜ |
+| 7 | Tag instrumentation events, with a show/hide toggle | ⬜ |
+
+## Open Decisions
+
+### Instrumentation events in the trace (step 7)
+
+A paused start injects `Effect.yieldNow()` before the program body, so that the
+very first operation is handed to the gate rather than running on the fork's own
+stack. The runtime yields for real, so the Supervisor emits a `fiber:suspend` and
+a matching `fiber:resume (after 0ms)` that the program's author never wrote. The
+same program therefore reads slightly differently depending on whether it was
+started with Play or with Step. For the Basic Example, the marked lines are the
+injected yield:
+
+```diff
+[1] ⚡fiber:forked #2 (root)
++ [2] ⏸️fiber:suspend #2
++ [3] ▶️fiber:resume #2 (after 0ms)
+[4] 🚀effect:started initialization
+[5] ✅effect:ended initialization
+```
+
+`[2]` is the yield handing control back, `[3]` is the same yield returning once
+the first step releases it. It reads `after 0ms` because virtual time is frozen
+while paused, however long the user takes.
+
+Rather than choose between leaving the pair visible and filtering it away, trace
+events will carry an origin — the program's own, or the tool's — and the
+Execution Log will offer a toggle. The Timeline and Fiber Tree keep consuming
+everything, since a suspend that genuinely happened still belongs on a timeline.
+
+This is deferred until after 4b and 6, and is expected to cover more than the
+injected yield: the control channel will likely have a handshake of its own.
 
 ## Step 1: VirtualClock ✅
 

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -1,6 +1,6 @@
 # Phase 10: Slow Mode and Stepper (issue #13)
 
-**Status**: 🚧 IN PROGRESS — step 1 of 6 complete
+**Status**: 🚧 IN PROGRESS — step 2 of 6 complete
 
 Issue [#13](https://github.com/topheman/effect-viz/issues/13) asks for a slow mode:
 _"It goes too fast so a slow stepper would be cool like Browser Debugger is."_
@@ -75,7 +75,7 @@ only be inferred by elimination.
 | # | Step | Status |
 |---|------|--------|
 | 1 | `VirtualClock` — shared virtual time source | ✅ |
-| 2 | Effect `Clock` layer built on `VirtualClock` | ⬜ |
+| 2 | Effect `Clock` layer built on `VirtualClock` | ✅ |
 | 3 | `Date` shim in the WebContainer runner | ⬜ |
 | 4 | Gated `Scheduler` + the step ladder | ⬜ |
 | 5 | UI: speed combo + ⏯️ ⏭️ in `PlaybackControls` | ⬜ |
@@ -167,3 +167,46 @@ any other.
 A single source of truth for time that can run at any rate, freeze without
 distortion, and be stepped forward deadline by deadline — with no dependency on
 Effect yet, so it is testable in isolation.
+
+## Step 2: Effect Clock layer ✅
+
+### Created Files
+
+| File | Contents |
+|------|----------|
+| `src/runtime/vizClock.ts` | `makeVizClock`, `makeVizClockLayer` — Effect `Clock` over the `VirtualClock` |
+| `src/runtime/vizClock.test.ts` | 10 tests driving real Effect programs |
+
+`Layer.setClock` provides it, mirroring the `Layer.setTracer` idiom from phase 7.
+The `Clock` interface is five members: `unsafeCurrentTimeMillis`,
+`unsafeCurrentTimeNanos`, `currentTimeMillis`, `currentTimeNanos` and `sleep`.
+
+### Key Learnings
+
+#### Scaling the clock preserves semantics
+
+Because relative timing still decides outcomes, a program behaves identically at
+any speed — only its wall-clock duration changes. The tests assert this directly:
+a race between a 1s and a 2s sleep picks the same winner at rate 1, 0.5 and 0.25,
+and a `timeout` still fires. This is the property a UI-level replay could never
+offer, and it is the whole argument for instrumenting the runtime.
+
+#### Elapsed virtual time is speed-invariant
+
+`Clock.currentTimeMillis` reads virtual time, so a program measuring its own
+`Effect.sleep("1 second")` sees 1000ms whether that took 1s or 4s of wall time.
+Trace timestamps taken from the clock will therefore be stable across speeds, and
+the timeline will not redraw itself when the user moves the speed combo.
+
+#### `sleep` must return its canceler
+
+`Effect.async` takes an optional canceler effect, which the runtime runs on
+interruption. Returning the `VirtualClock`'s cancel function there is what stops
+an interrupted fiber from leaving a timer pending — which matters because the
+stepper reads `pendingCount` to decide whether the world can still make progress.
+
+### What this unlocks
+
+Slow motion is real from here: providing this layer makes every `Effect.sleep`,
+`Schedule` delay, `timeout` and `race` in a program run at the chosen rate, and
+rate 0 genuinely freezes them.

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -992,3 +992,17 @@ asserts the virtual times at which each task reports in fall into three batches
 rather than one, structured interruption asserts both children's finalizers ran
 along with the parent's, and deadlock asserts the fiber is still unresolved after
 ten virtual seconds.
+
+### Known issue: the two paths run different Effect versions
+
+The Timeout example exposed a drift the other programs never revealed. The
+container's `package.json` asks for `"effect": "^3.19.15"`, so it installs
+whatever 3.x is current — 3.22.1 today — while the in-browser path bundles the
+version this repo locks, 3.19.15. The two disagree about the fiber that loses a
+timeout race: on 3.19.15 its exit is an interrupt, on 3.22.1 a success. Since the
+Supervisor labels a fiber's end from its exit, the same program traces
+`fiber:interrupt` in the browser and `fiber:end` in the container.
+
+Left as is for now, to be settled by a separate upgrade of `effect` — at which
+point the container's dependency should be pinned to the app's own version rather
+than a caret range, so the two paths cannot drift again.

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -378,6 +378,19 @@ question: what happens when the user clicks step.
 A fiber that can run now must run before time is allowed to move, otherwise a
 step would skip past work that was already due.
 
+#### Pause has to stop the clock as well as the scheduler
+
+Gating the scheduler stops fibers from running, but virtual time keeps advancing
+on its own. A program paused for seven seconds then reported `fiber:resume #104
+(after 7.83s)` for a one-second sleep, and the timeline scaled to eight seconds:
+the user's reading time had been recorded as part of the program's own elapsed
+time.
+
+So a pause sets the rate to 0 and resume restores the previous rate, which also
+re-arms parked timers with the virtual time they had left. Unit tests missed this
+because they never let wall time pass between pausing and stepping — only using
+the app surfaced it.
+
 #### A step needs a turn of the event loop to settle
 
 Part of a fiber's completion lands outside our scheduler, and a microtask is not


### PR DESCRIPTION
Closes #13

## What

Two controls over the same mechanism, driven by one idea: take over the runtime's clock and scheduler.

- **Speed combo** (`x1 / x0.75 / x0.5 / x0.25`) — scales the Effect `Clock`, so every sleep, schedule delay, timeout and race runs in stretched time while the program's own semantics stay identical.
- **Stepper** (`⏯️ ⏭️`) — freezes virtual time *and* gates the runtime's task queue, then releases one scheduling decision at a time, like a browser debugger.

Works on **both run paths**: in-browser fallback holds the clock directly; the WebContainer path reaches its runtime over a stdin/stdout control channel (`{"cmd":"step"}` → `TRACE_CONTROL:` replies).

## How it's built

| Piece | File |
|---|---|
| Virtual time source (rate-scaled, park-on-pause, step-to-deadline) | `src/runtime/virtualClock.ts` |
| Effect `Clock` layer over it | `src/runtime/vizClock.ts` |
| `Date` shim inside the WebContainer (raw JS can't bypass) | `src/runtime/dateShim.ts` |
| Gated `Scheduler` + step ladder (release / advance-clock / no-progress / done) | `src/runtime/gatedScheduler.ts`, `stepper.ts` |
| Control channel + codecs | `src/runtime/controlChannel.ts` |
| Page's model of the container's clock | `src/lib/mirroredClock.ts`, `containerController.ts` |
| Speed combo, playback state matrix | `useSpeed.ts`, `PlaybackControls.tsx` |
| Origin tagging ("tool" vs program events) + show-internals toggle | `traceOrigin.ts`, `useShowInternals.ts` |

## Also included

- Five new example programs chosen for concepts the set was missing: cooperative interleaving (`yieldNow`), bounded concurrency, structured interruption, timeout on the shared clock, and a `Deferred` deadlock — the first program able to reach the stepper's `noProgress`.
- Trace timestamps recorded in virtual time on both paths, so a trace spans the same duration at any speed.
- Container `effect` pinned to the app's exact version (settles a 3.19 vs 3.22 trace drift found by the Timeout example; upgrade tracked separately in #18).

## Verification

- ~120 new unit tests across clock, shim, scheduler, stepper, channel, mirrored clock, timeline math and examples.
- Stepping a played program reproduces full-speed event order exactly (asserted by test).
- Driven in a real browser: wall time scaled ×1/×2/×4 while the recorded trace stayed constant; paused starts tag the injected yield as tool output.
- The runner is a template literal string, so it was exercised under Node against the built bundle, driving its stdin like the page does.

Docs for this phase live in [`workshop/phase-10.md`](./workshop/phase-10.md).
