### PR TITLE
chore: add t3.json worktree setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ public/esbuild.wasm
 .opencode/package-lock.json
 
 src/types/editor-bundled-definitions.d.ts
+
+# Worktrees created by t3code / Claude Code
+.claude/worktrees

--- a/t3.json
+++ b/t3.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://t3.codes/schema/t3.json",
+  "scripts": [
+    {
+      "name": "Setup Worktree",
+      "command": "npm install",
+      "icon": "configure",
+      "runOnWorktreeCreate": true
+    }
+  ]
+}


### PR DESCRIPTION
Adds a `t3.json` at the repo root so t3code runs `npm install` when it creates a worktree, mirroring what `.cursor/worktrees.json` already does for Cursor.

Also ignores `.claude/worktrees`, where t3code and Claude Code create their worktrees — they were showing up as untracked.

Note: this has to be on `master` to be testable. t3's worktree-creation path branches from `origin/master`, so `runOnWorktreeCreate` can't fire for a config that only exists on a feature branch.

- `npm run lint` passes