### PR TITLE
fix(#21): cache Monaco from the CDN as a CORS response

### DIFF
--- a/src/components/PwaUpdatePrompt.tsx
+++ b/src/components/PwaUpdatePrompt.tsx
@@ -6,6 +6,12 @@ import { cn } from "@/lib/utils";
 
 const COUNTDOWN_SECONDS = 5;
 
+/**
+ * Runtime caches replaced by a newer, differently named one (see vite.config.ts).
+ * The service worker never touches them again, so drop them to reclaim the storage.
+ */
+const OUTDATED_RUNTIME_CACHES = ["monaco-editor-cdn"];
+
 export function PwaUpdatePrompt() {
   const {
     offlineReady: [offlineReady],
@@ -15,6 +21,15 @@ export function PwaUpdatePrompt() {
 
   const [countdown, setCountdown] = useState(COUNTDOWN_SECONDS);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!("caches" in window)) {
+      return;
+    }
+    for (const name of OUTDATED_RUNTIME_CACHES) {
+      void caches.delete(name);
+    }
+  }, []);
 
   const handleCancel = () => {
     setNeedRefresh(false);

--- a/src/effects/typeAcquisition.ts
+++ b/src/effects/typeAcquisition.ts
@@ -101,12 +101,22 @@ function configureMonacoPaths(
 }
 
 /**
+ * Load Monaco itself. Rejects when its CDN assets can't be fetched, so this is a
+ * typed error rather than a defect - callers are expected to carry on without types.
+ * The rejection value is an unhelpful script `error` event, hence the fixed message.
+ */
+const initMonaco = Effect.tryPromise({
+  try: () => loader.init(),
+  catch: (cause) => new Error("Monaco failed to load from the CDN", { cause }),
+});
+
+/**
  * Acquire Monaco types for mobile fallback (no WebContainer).
  * Fetches fallback-types.d.ts (Effect stubs) and app libs from public/app/.
  */
 export const acquireMonacoTypesFallback: Effect.Effect<void, Error> =
   Effect.gen(function* () {
-    const monaco = yield* Effect.promise(() => loader.init());
+    const monaco = yield* initMonaco;
     configureMonacoPaths(monaco);
 
     const fallbackContent = yield* Effect.tryPromise({
@@ -124,11 +134,11 @@ export const acquireMonacoTypesFallback: Effect.Effect<void, Error> =
  */
 export const acquireMonacoTypes: Effect.Effect<
   void,
-  never,
+  Error,
   WebContainerHandle
 > = Effect.gen(function* () {
   const handle = yield* WebContainer;
-  const monaco = yield* Effect.promise(() => loader.init());
+  const monaco = yield* initMonaco;
   configureMonacoPaths(monaco, {
     effect: ["node_modules/effect/dist/dts/index.d.ts"],
     "effect/*": ["node_modules/effect/dist/dts/*"],

--- a/src/hooks/useWebContainerBoot.ts
+++ b/src/hooks/useWebContainerBoot.ts
@@ -72,10 +72,11 @@ export function useWebContainerBoot() {
           addLog("boot", "Fallback types acquired");
         })
         .catch((err) => {
+          // Stay in fallback rather than erroring out: types are an editor nicety,
+          // and the visualizer still runs the example programs in-browser without them.
           const msg = err instanceof Error ? err.message : String(err);
           addLog("boot", `Fallback types failed: ${msg}`);
-          setStatus("error");
-          setError(msg);
+          setStatus("fallback");
         });
       return () => {};
     }
@@ -93,9 +94,18 @@ export function useWebContainerBoot() {
       addLog("boot", "Boot complete, ready");
       console.log("[useWebContainerBoot] Boot complete, status=ready");
       addLog("boot", "Acquiring Monaco types...");
+      // Keep the container alive when types can't be acquired: letting the failure
+      // through would kill the boot fiber, close its scope and tear the WebContainer
+      // down. A degraded editor beats a dead app.
       yield* acquireMonacoTypes.pipe(
         Effect.tap(() => Effect.sync(() => addLog("boot", "Types acquired"))),
         Effect.tap(() => Effect.sync(() => setTypesReady(true))),
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            addLog("boot", `Types unavailable: ${err.message}`);
+            console.error("[useWebContainerBoot] Type acquisition failed", err);
+          }),
+        ),
       );
       yield* Effect.never;
     }).pipe(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,13 +52,24 @@ export default defineConfig({
             urlPattern: /^https:\/\/cdn\.jsdelivr\.net\/npm\/monaco-editor@.*/i,
             handler: "CacheFirst",
             options: {
-              cacheName: "monaco-editor-cdn",
+              // Bumped from "monaco-editor-cdn", whose entries are unreadable.
+              cacheName: "monaco-editor-cdn-v2",
+              // Refetch as CORS so the cached response stays readable. Monaco arrives
+              // through a plain <script src>, so the request is no-cors and a plain
+              // fetch yields an opaque response - which cache.match() then refuses to
+              // return under the COEP: require-corp header WebContainer needs. See #21.
+              fetchOptions: {
+                mode: "cors",
+                credentials: "omit",
+              },
               expiration: {
                 maxEntries: 100,
                 maxAgeSeconds: 60 * 60 * 24 * 30, // 30 days
               },
               cacheableResponse: {
-                statuses: [0, 200],
+                // 200 only: an opaque response reports status 0, and caching one
+                // poisons the whole cache under COEP.
+                statuses: [200],
               },
             },
           },


### PR DESCRIPTION
## Summary

Monaco stopped loading on any service-worker-controlled visit, in both WebContainer and fallback mode. The editor sat on `Loading...`; in WebContainer mode the container was torn down right after booting.

All of this lives in the generated service worker: `vite.config.ts` declares a workbox `CacheFirst` route for jsDelivr, which `vite-plugin-pwa` compiles into `dist/sw.js`. That route is what intercepts Monaco's `<script src>` and decides how to fetch and store it.

- **`fetchOptions: { mode: "cors", credentials: "omit" }`** — workbox passes this straight to its own `fetch()` inside the service worker, so it re-issues the page's `no-cors` request as a CORS one. What lands in the cache is then a readable response instead of an opaque one.
- **`cacheableResponse.statuses: [200]`**, was `[0, 200]` — an opaque response *does* expose a status, and it's always `0`. Workbox checks it before writing, so dropping `0` means an opaque response can no longer be stored. Belt and braces now that the fetch is CORS.
- **`cacheName: "monaco-editor-cdn-v2"`**, plus a one-off delete of the old cache in `PwaUpdatePrompt` — existing visitors already hold unreadable entries under the old name.
- **`Effect.tryPromise` in `typeAcquisition.ts`** — a Monaco failure now costs editor types rather than the WebContainer or the fallback path.

Fixes #21

## Why it broke

The app sends `Cross-Origin-Embedder-Policy: require-corp` on every response. That header means *"don't load anything from another site unless that site says it's OK"* — every cross-origin file must consent, either via its own `Cross-Origin-Resource-Policy` header or by being fetched with CORS. It isn't optional here: paired with COOP it makes the page cross-origin isolated, which is what unlocks `SharedArrayBuffer`, which is what WebContainer needs.

Monaco arrives through a plain `<script src>` with no `crossorigin` attribute, so it's a `no-cors` request. The request is identical on every load — what changes is who answers it:

| Load | Who answers | What happens |
|---|---|---|
| 1st | The network | The service worker installs but doesn't control the page yet. jsDelivr's `cross-origin-resource-policy` header says yes → works. Nothing cached. |
| 2nd | The service worker, cache empty | `CacheFirst` fetches the `no-cors` request as-is, gets an **opaque** response, **stores it**, returns it. Still works. |
| 3rd+ | The service worker, cache full | `cache.match()` throws `TypeError`, the handler rejects, the request becomes a network error. Dead. |

Storing an opaque response is allowed; reading one back into a `require-corp` page is not. The cache is persistent and shared, so at write time the browser doesn't know who will read it later — and an opaque response has no readable headers to check on the way out, so it refuses rather than guess. Hence the console's `Failed to execute 'match' on 'CacheStorage'`: a *match* error, not a load error.

Load 2 plants the mine, load 3 steps on it. `cmd+shift+R` bypasses the service worker entirely, which is why a force reload always worked.

The route was added in #14/#15 but its `urlPattern` never matched jsDelivr's versioned paths, so nothing was ever cached. #15 fixed the regex — which is what started filling the cache with unreadable entries.

## Notes

- jsDelivr sends `access-control-allow-origin: *`, so a CORS fetch just works — nothing was missing on the CDN side.
- The cache rename is load-bearing: keeping the old name would leave existing visitors reading their poisoned entries forever. Deleting the old cache also un-breaks anyone still on the previous service worker, since a miss beats a throw.
- `acquireMonacoTypes` used `Effect.promise`, which turns a rejection into a defect — that's what killed the boot fiber and took the container down with it. It's now `Effect.tryPromise`, so the failure is typed and the signature stops claiming `never`.
- Offline support from #15 is unaffected: `CacheFirst` still reads the cache before the network, and the entries are now readable.

## Test plan

- [ ] `npm run build && npm run preview`
- [ ] Load, reload, then open a **fresh tab** — that third load is the one that used to fail
- [ ] Same again with `?webcontainer=0` for fallback mode
- [ ] DevTools → Application → Cache storage: `monaco-editor-cdn-v2` present, `monaco-editor-cdn` gone
- [ ] Warm the cache online, cut the network, reload: still drops into readonly fallback with a working editor

Note on reproducing: repeated reloads *in the same tab* can be served from Chrome's per-renderer memory cache without ever reaching the service worker, which masks the bug — hence the "fresh tab" step.
