### PR TITLE
chore(#18): upgrade effect to 3.22.1 on both run paths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,7 @@
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "always"
-  }
+  },
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true
 }

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -5,7 +5,7 @@
 ## Current Phase
 **Phase 10**: COMPLETE ✅ — slow mode & stepper (issue #13). All steps done: VirtualClock, Effect Clock layer, Date shim, virtual timestamps, GatedScheduler + step ladder, control channel for the WebContainer, speed combo + stepper controls, origin tagging with show-internals toggle, and five new example programs.
 
-**Next up (not yet a phase)**: [#18](https://github.com/topheman/effect-viz/issues/18) — upgrade `effect` to latest 3.x; the trace-behaviour changes between 3.19 and 3.22 need an audit (e.g. timeout-loser exits as success instead of interrupt).
+**Maintenance**: [#18](https://github.com/topheman/effect-viz/issues/18) — `effect` is on 3.22.1 on both run paths, and the Effect LSP is installed. Only the Timeout example traces differently: the work that overruns the deadline now ends as `fiber:end`, since Effect runs it under `Effect.exit`. See [`workshop/effect-3.22-upgrade.md`](workshop/effect-3.22-upgrade.md).
 
 **Recent**: five new examples teach what no sleep-shaped program could — `Effect.yieldNow` interleaving, bounded concurrency, structured interruption, timeout on the shared clock, and a Deferred deadlock that reaches the stepper's `noProgress`. See [`workshop/phase-10.md`](workshop/phase-10.md).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "ansi-to-react": "^6.2.6",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "effect": "^3.19.15",
+        "effect": "3.22.1",
         "esbuild-wasm": "^0.27.3",
         "lucide-react": "^0.563.0",
         "qrcode.react": "^4.2.0",
@@ -30,6 +30,7 @@
       "devDependencies": {
         "@commitlint/cli": "^20.3.1",
         "@commitlint/config-conventional": "^20.3.1",
+        "@effect/language-service": "^0.87.2",
         "@eslint/js": "^9.39.1",
         "@tailwindcss/vite": "^4.1.17",
         "@testing-library/jest-dom": "^6.9.1",
@@ -162,7 +163,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2228,7 +2228,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2272,9 +2271,18 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@effect/language-service": {
+      "version": "0.87.2",
+      "resolved": "https://registry.npmjs.org/@effect/language-service/-/language-service-0.87.2.tgz",
+      "integrity": "sha512-CfiSoaVQO8pZgaMZGw5VvMvRGybsJ2LaSDoLYaqiVGvo/YYPYVR2GzUKY0h1NtIweq/+SQ5XLrvtzPIttWQ0GQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "effect-language-service": "cli.js"
       }
     },
     "node_modules/@emnapi/core": {
@@ -4326,7 +4334,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4428,7 +4437,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4439,7 +4447,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4450,7 +4457,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4515,7 +4521,6 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -4885,7 +4890,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5327,7 +5331,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5726,7 +5729,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -6044,13 +6046,15 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -6091,9 +6095,9 @@
       "license": "MIT"
     },
     "node_modules/effect": {
-      "version": "3.19.15",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.19.15.tgz",
-      "integrity": "sha512-vzMmgfZKLcojmUjBdlQx+uaKryO7yULlRxjpDnHdnvcp1NPHxJyoM6IOXBLlzz2I/uPtZpGKavt5hBv7IvGZkA==",
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.22.1.tgz",
+      "integrity": "sha512-TNoXushmPOBAjJlthF5d2QwnX2xBPEtcNJr5XKNKbRLbDvBcOYkXlYDfvGfSA0zriwLFuCll5MDtNMAdZL17PQ==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -6393,7 +6397,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6454,7 +6457,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8207,7 +8209,6 @@
       "integrity": "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.23",
         "@asamuzakjp/dom-selector": "^6.7.4",
@@ -8852,6 +8853,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8871,6 +8873,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -9419,7 +9422,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9470,7 +9472,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9513,6 +9514,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9528,6 +9530,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9606,7 +9609,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9616,7 +9618,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9629,7 +9630,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -9978,7 +9980,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -10818,8 +10819,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
       "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -10965,7 +10965,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11212,7 +11211,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11459,7 +11457,6 @@
       "integrity": "sha512-u09tdk/huMiN8xwoiBbig197jKdCamQTtOruSalOzbqGje3jdHiV0njQlAW0YvzoahkirFePNQ4RYlfnRQpXZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.97.0",
         "fdir": "^6.5.0",
@@ -11585,7 +11582,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11974,7 +11970,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12418,7 +12413,6 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ansi-to-react": "^6.2.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "effect": "^3.19.15",
+    "effect": "3.22.1",
     "esbuild-wasm": "^0.27.3",
     "lucide-react": "^0.563.0",
     "qrcode.react": "^4.2.0",
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@commitlint/cli": "^20.3.1",
     "@commitlint/config-conventional": "^20.3.1",
+    "@effect/language-service": "^0.87.2",
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.1.17",
     "@testing-library/jest-dom": "^6.9.1",

--- a/src/lib/programs.test.ts
+++ b/src/lib/programs.test.ts
@@ -5,6 +5,8 @@ import { makeTraceEmitterLayer } from "@/runtime/tracedRunner";
 import type { TraceEmitter } from "@/runtime/traceEmitter";
 import { VirtualClock, type VirtualClockHost } from "@/runtime/virtualClock";
 import { makeVizClockLayer } from "@/runtime/vizClock";
+import { makeVizLayers } from "@/runtime/vizSupervisor";
+import { makeVizTracer } from "@/runtime/vizTracer";
 import type { TraceEvent } from "@/types/trace";
 
 import {
@@ -26,11 +28,14 @@ const fakeHost: VirtualClockHost = {
 function start(effect: Effect.Effect<unknown, unknown, TraceEmitter>) {
   const events: TraceEvent[] = [];
   const clock = new VirtualClock({ rate: 1, origin: 0, host: fakeHost });
+  const onEmit = (event: TraceEvent) => events.push(event);
   const fiber = Effect.runFork(
     Effect.scoped(effect).pipe(
       Effect.provide(
         Layer.mergeAll(
-          makeTraceEmitterLayer((event) => events.push(event)),
+          makeTraceEmitterLayer(onEmit),
+          makeVizLayers(onEmit, () => clock.now()),
+          Layer.setTracer(makeVizTracer(onEmit, () => clock.now())),
           makeVizClockLayer(clock),
         ),
       ),
@@ -110,6 +115,65 @@ describe("example programs", () => {
       quick: "quick-task finished",
       slow: "slow-task timed out",
     });
+  });
+
+  it("timeout: the work that overruns the deadline reports its interruption as a span failure", async () => {
+    const { events, fiber } = start(timeoutExample);
+    await settle(fiber);
+
+    // Spans carry their label on effect:start only, so pair the two by id.
+    const labels = new Map(
+      events
+        .filter((event) => event.type === "effect:start")
+        .map((event) => [event.id, event.label]),
+    );
+    const spans = events
+      .filter((event) => event.type === "effect:end")
+      .map((event) => ({
+        label: labels.get(event.id),
+        result: event.result,
+        error: event.result === "failure" ? String(event.error) : "",
+      }));
+
+    expect(spans).toEqual([
+      { label: "quick-task", result: "success", error: "" },
+      {
+        label: "slow-task",
+        result: "failure",
+        error: expect.stringContaining("Interrupted"),
+      },
+    ]);
+  });
+
+  it("timeout: of the two fibers each deadline races, only a losing deadline exits interrupted", async () => {
+    const { events, fiber } = start(timeoutExample);
+    await settle(fiber);
+
+    // Each withDeadline forks a pair: the work first, then the sleep that is the
+    // deadline. Order the fibers by fork so the assertion does not name FiberIds.
+    const forked = events
+      .filter((event) => event.type === "fiber:fork")
+      .filter((event) => event.parentId !== undefined)
+      .map((event) => event.fiberId);
+    const exits = forked.map(
+      (fiberId) =>
+        events.find(
+          (event) =>
+            (event.type === "fiber:end" || event.type === "fiber:interrupt") &&
+            event.fiberId === fiberId,
+        )?.type,
+    );
+
+    expect(exits).toEqual([
+      // quick-task: the work wins, so its deadline is interrupted.
+      "fiber:end",
+      "fiber:interrupt",
+      // slow-task: the work loses and is interrupted, yet Effect >= 3.22 runs it
+      // under Effect.exit, so its own exit is a success and the Supervisor can
+      // only report an end. The interruption shows on its span instead.
+      "fiber:end",
+      "fiber:end",
+    ]);
   });
 
   it("deadlock: the program never finishes", async () => {

--- a/src/services/webcontainer.test.ts
+++ b/src/services/webcontainer.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Both run paths take their `effect` version from one source: `__EFFECT_VERSION__`,
+ * which Vite fills in at build time with the version the app resolves. These tests
+ * keep it that way — the container template must name the constant rather than a
+ * version of its own, and the dependency must stay exact so a build cannot resolve
+ * a newer 3.x than the traces were checked against.
+ */
+import { version as resolvedEffectVersion } from "effect/package.json";
+import { describe, expect, it } from "vitest";
+
+import appPackageJson from "../../package.json?raw";
+
+// Read as text: importing the service initialises esbuild-wasm, which throws under jsdom.
+import webcontainerSource from "./webcontainer.ts?raw";
+
+function declaredEffectVersion(): string {
+  const pkg = JSON.parse(appPackageJson) as {
+    dependencies: Record<string, string>;
+  };
+  return pkg.dependencies.effect;
+}
+
+describe("the effect version the container installs", () => {
+  it("comes from the build rather than a second declaration", () => {
+    expect(webcontainerSource).toContain('"effect": "${__EFFECT_VERSION__}"');
+  });
+
+  it("is the version this build resolves", () => {
+    expect(__EFFECT_VERSION__).toBe(resolvedEffectVersion);
+  });
+
+  it("is declared exactly, so a build cannot resolve a newer 3.x than it was tested on", () => {
+    expect(declaredEffectVersion()).toBe(resolvedEffectVersion);
+    expect(declaredEffectVersion()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});

--- a/src/services/webcontainer.ts
+++ b/src/services/webcontainer.ts
@@ -27,7 +27,7 @@ const PACKAGE_JSON = `{
     "run": "pnpm exec tsx program.ts"
   },
   "dependencies": {
-    "effect": "3.19.15",
+    "effect": "${__EFFECT_VERSION__}",
     "tsx": "^4.19.0",
     "typescript": "~5.9.3"
   }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="vite/client" />
+
+/** The `effect` version this build resolves, injected by Vite. See vite.config.ts. */
+declare const __EFFECT_VERSION__: string;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -30,6 +30,13 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    /* Effect LSP: Effect-aware diagnostics, refactors and completions.
+       Requires the editor to use the workspace TypeScript (see .vscode/settings.json). */
+    "plugins": [
+      {
+        "name": "@effect/language-service"
+      }
+    ],
     /* Import alias */
     "baseUrl": ".",
     "paths": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 /// <reference types="vitest/config" />
+import { createRequire } from "node:module";
 import path from "path";
 
 import tailwindcss from "@tailwindcss/vite";
@@ -8,8 +9,20 @@ import { VitePWA } from "vite-plugin-pwa";
 
 import { runtimeWatchPlugin } from "./vite-plugin-runtime-watch";
 
+/**
+ * The version of `effect` this build resolves, injected into the WebContainer's
+ * package.json (`PACKAGE_JSON` in src/services/webcontainer.ts). The container
+ * installs effect itself, so without this the two run paths could install
+ * different versions and trace the same program differently — see #17 and #18.
+ */
+const effectVersion = createRequire(import.meta.url)("effect/package.json")
+  .version as string;
+
 // https://vite.dev/config/
 export default defineConfig({
+  define: {
+    __EFFECT_VERSION__: JSON.stringify(effectVersion),
+  },
   plugins: [
     runtimeWatchPlugin(),
     react({

--- a/workshop/README.md
+++ b/workshop/README.md
@@ -47,6 +47,10 @@ Take over the runtime's clock and scheduler so execution can be slowed and stepp
 
 - [Phase 10: Slow mode & stepper (issue #13)](./phase-10.md) ✅
 
+### Maintenance
+
+- [Upgrading Effect to 3.22 (issue #18)](./effect-3.22-upgrade.md) ✅ — what three minor versions changed for the traces, and the one example that traces differently.
+
 **Why two versions?**
 - **V1** teaches concepts explicitly - you see exactly what gets traced
 - **V2** teaches Effect's production observability patterns

--- a/workshop/effect-3.22-upgrade.md
+++ b/workshop/effect-3.22-upgrade.md
@@ -1,0 +1,97 @@
+# Upgrading Effect to 3.22 (issue #18)
+
+The app ran `effect` 3.19.15 on both execution paths. This upgrade moves both to
+3.22.1, the latest 3.x, and records what the three intervening minor versions
+changed for a program that is *watched* rather than merely run.
+
+## One version, on both paths
+
+The in-browser path bundles the `effect` this repo depends on. The WebContainer
+path installs its own copy from npm, from the `package.json` the container mounts
+(`PACKAGE_JSON` in `src/services/webcontainer.ts`). Two declarations of the same
+dependency is how the Timeout example came to trace differently on the two paths
+before [#17](https://github.com/topheman/effect-viz/pull/17), so there is only
+one. The container's `package.json` names a constant that Vite fills in at build
+time with the version the build itself resolves:
+
+```ts
+// vite.config.ts
+const effectVersion = createRequire(import.meta.url)("effect/package.json").version
+// define: { __EFFECT_VERSION__: JSON.stringify(effectVersion) }
+```
+
+The mounted `package.json` therefore asks for the very version the bundle was
+built against — the resolved one, not a declared range — so no upgrade can move
+one path without the other.
+
+The dependency is also declared as an exact version rather than a caret range.
+That is not what holds the two paths together any more — the injected constant
+does — but it keeps a build from quietly resolving a newer 3.x than the traces
+were checked against, which for a visualizer is a behaviour change rather than a
+patch. `src/services/webcontainer.test.ts` holds both properties in place.
+
+## Auditing the trace surfaces
+
+Three minor versions is a lot of runtime to take on faith, so the audit compared
+the two versions on the evidence that matters here: the trace each example
+program emits.
+
+`Supervisor` and `Tracer` are untouched between 3.19.15 and 3.22.1 — both the
+types and their implementations are byte-identical, so the two surfaces the
+visualizer hooks into behave the same. What did change is deeper: the fiber
+runtime, the scheduler, and `Effect.timeout`.
+
+Rather than read those diffs and guess, every example was run through the app's
+own runtime bundle (`dist/runtime/runtime.js`, the file the container loads) under
+each version, with span ids and timestamps stripped so the two traces could be
+compared line by line. Fourteen of the fifteen examples traced identically, down
+to the FiberId numbering.
+
+## The one difference: a timeout's loser now exits as a success
+
+The Timeout example is the exception, and it is the behaviour the issue was
+opened for.
+
+`Effect.timeout` races the work against a sleep. When the work wins, the sleep
+loses and is interrupted; when the work overruns, the work loses and is
+interrupted. Under 3.19.15 both losers ended as interrupted fibers, so the
+Supervisor — which reads a fiber's exit to label its end — emitted
+`fiber:interrupt` for both.
+
+3.22.1 runs the work side under `Effect.exit` ([#6507](https://github.com/Effect-TS/effect/pull/6507),
+released as "disable unhandled error logging for fibers spawned by
+`Effect.timeout`"). Interruption of that fiber is now captured as a value, so the
+fiber's exit is a *success* and the Supervisor can only report `fiber:end`. The
+sleep side is unwrapped and still ends as an interrupt.
+
+The interruption is not lost from the trace: the `slow-task` span still ends as a
+failure carrying an `InterruptedException`, which is what the Execution Log shows.
+Only the fiber's own end event changed. Both facts are pinned by tests in
+`src/lib/programs.test.ts`, so a future version that moves this again will say so
+rather than drift quietly.
+
+This is Effect's own account of the run, so the visualizer reports it as given
+rather than second-guessing the exit.
+
+## Scheduler: a signature the GatedScheduler does not implement
+
+3.20.0 isolated `AsyncLocalStorage` across fibers by giving `MixedScheduler` a
+runner per fiber, which added an optional third argument to `scheduleTask`:
+
+```ts
+scheduleTask(task: Task, priority: number, fiber?: RuntimeFiber<unknown, unknown>): void
+```
+
+`GatedScheduler` takes two parameters and forwards two, so tasks it passes on
+while playing all land on the shared fallback runner — the 3.19 arrangement.
+Nothing in the app breaks, because one queue in fork order is exactly what
+stepping wants: `gatedScheduler.test.ts` and `stepper.test.ts` drive real
+programs through the gate, and both pass unchanged. Worth knowing rather than
+fixing, unless a future Effect makes the fiber argument load-bearing.
+
+## Effect LSP
+
+The upgrade also brought in `@effect/language-service`, registered as a
+TypeScript plugin in `tsconfig.app.json`. It only runs on the TypeScript
+installed in the project, so `.vscode/settings.json` points the editor at the
+workspace version; VS Code and Cursor prompt for it on first open.

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -1005,7 +1005,7 @@ Supervisor labels a fiber's end from its exit, the same program traced
 
 Settled by [#17](https://github.com/topheman/effect-viz/pull/17): pinning the
 container to the app's own exact version rather than a caret range, so the two
-paths cannot drift again — both now run 3.19.15. The upgrade of `effect` itself
-to the latest 3.x remains open as separate work in
-[#18](https://github.com/topheman/effect-viz/issues/18), where the
-trace-behaviour changes between 3.19 and 3.22 will need an audit.
+paths cannot drift again. Both then ran 3.19.15, and
+[#18](https://github.com/topheman/effect-viz/issues/18) has since moved both to
+3.22.1 — where the timeout loser's exit is now a success on either path. See
+[effect-3.22-upgrade.md](./effect-3.22-upgrade.md).


### PR DESCRIPTION
Closes #18

## What

Moves both execution paths from `effect` 3.19.15 to 3.22.1 (latest 3.x), and records what the three intervening minor versions changed for a program that is *watched* rather than merely run.

## One version, on both paths

The container installs `effect` itself, so the version was declared twice — the drift #17 had to fix by hand. There is now a single source:

- `vite.config.ts` resolves `effect/package.json` at config load and injects the version as `__EFFECT_VERSION__` through Vite's `define`.
- `PACKAGE_JSON` in `src/services/webcontainer.ts` — the file mounted into the container and installed by `pnpm install` at boot — interpolates that constant, so the container asks for the version the bundle was built against.
- `package.json` declares `effect` exactly rather than with a caret: for a visualizer, a newer 3.x is a behaviour change, not a patch.
- `src/services/webcontainer.test.ts` fails if the template names a version of its own, or if the declaration stops being exact.

## The audit

`Supervisor` and `Tracer` are byte-identical between the two versions, types and implementation — the two surfaces the visualizer hooks into. `fiberRuntime`, `Scheduler` and `Effect.timeout` are not.

Rather than read those diffs and guess, all 15 example programs were run through the app's own runtime bundle (`dist/runtime/runtime.js`, the file the container loads) under each version, span ids and timestamps stripped, and the traces diffed. **Fourteen matched exactly**, down to the FiberId numbering.

The fifteenth is Timeout, and it is what the issue was opened for:

| | 3.19.15 | 3.22.1 |
|---|---|---|
| deadline loses (work wins) | `fiber:interrupt` | `fiber:interrupt` |
| work loses (deadline fires) | `fiber:interrupt` | `fiber:end` |

3.22.1 runs the work side of the race under `Effect.exit` ([#6507](https://github.com/Effect-TS/effect/pull/6507), shipped as "disable unhandled error logging for fibers spawned by `Effect.timeout`"), so interruption is captured as a value and the fiber's exit is a success. `VizSupervisor.onEnd` labels from the exit, hence `fiber:end`. The interruption still shows on the span, which ends as a failure carrying an `InterruptedException` — that is what the Execution Log displays. Both facts are pinned by tests in `src/lib/programs.test.ts`.

Also noted, not changed: 3.20.0 added an optional third `fiber` argument to `Scheduler.scheduleTask` (per-fiber runners, for `AsyncLocalStorage` isolation). `GatedScheduler` neither takes nor forwards it, so gated tasks share one queue — which is what stepping wants; `gatedScheduler.test.ts` and `stepper.test.ts` drive real programs through the gate and pass unchanged.

## Bonus: Effect LSP

`@effect/language-service` registered as a TypeScript plugin in `tsconfig.app.json`. It runs on the project's TypeScript, so `.vscode/settings.json` points the editor at the workspace version (`js/ts.tsdk.path`) and prompts for it on first open.

## Verification

- 188 tests pass, including 5 new ones: two Timeout trace assertions, and three on the version wiring. `start()` in `programs.test.ts` now provides the Supervisor and Tracer, so example tests see the same trace the app does.
- Typecheck, lint and build clean.
- **Both paths driven in a real browser**, Timeout at 1x. In-browser and WebContainer produce the same trace: `fiber:interrupt` for the deadline that loses to `quick-task`, then `effect:end (failure)` for `slow-task` followed by `fiber:end` for the work the deadline cuts off. Racing spot-checked too — its losers still report as interrupts.
- The container's `RUNNER_JS` was also run verbatim under Node against `dist/runtime/runtime.js` with `effect@3.22.1`, reproducing that trace event-for-event.
- Version wiring checked live: `__EFFECT_VERSION__` resolves to `"3.22.1"` in dev, and the production bundle inlines `"effect": "3.22.1"` into the mounted `package.json`.

Details in [`workshop/effect-3.22-upgrade.md`](./workshop/effect-3.22-upgrade.md).
