### PR TITLE
feat(demo): script and record the README demo video

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ src/types/editor-bundled-definitions.d.ts
 
 # Worktrees created by t3code / Claude Code
 .claude/worktrees
+
+# Demo recordings produced by `npm run demo:record`
+recordings

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -69,6 +69,21 @@ export default defineConfig([
     }
   },
   {
+    // Playwright locators (`page.getByRole`, ...) read like Testing Library
+    // queries destructured from `render`, which those rules flag.
+    files: ['scripts/demo/**/*.ts'],
+    languageOptions: {
+      globals: globals.node,
+    },
+    rules: {
+      ...Object.fromEntries(
+        Object.keys(eslintPluginTestingLibrary.configs['flat/react'].rules).map(
+          (rule) => [rule, 'off']
+        )
+      ),
+    }
+  },
+  {
     files: ['public/app/**/*'],
     rules: {
       "prettier/prettier": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "husky": "^9.1.7",
         "jsdom": "^27.2.0",
         "lint-staged": "^16.2.7",
+        "playwright": "^1.62.1",
         "prettier": "3.6.2",
         "tailwindcss": "^4.1.17",
         "tw-animate-css": "^1.4.0",
@@ -9390,6 +9391,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -31,15 +31,16 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",
-    "demo:record": "node scripts/demo/record.ts",
     "test": "vitest run",
     "test:watch": "vitest",
+    "demo:prepare": "playwright install chromium",
+    "demo:record": "node scripts/demo/record.ts",
     "typecheck:app": "tsc --noEmit -p ./tsconfig.app.json",
     "typecheck:node": "tsc --noEmit -p ./tsconfig.node.json",
+    "typecheck:demo": "tsc --noEmit -p ./tsconfig.demo.json",
     "typecheck": "npm run typecheck:app && npm run typecheck:node && npm run typecheck:demo",
     "prepare": "husky",
-    "bootstrap": "./scripts/bootstrap.ts",
-    "typecheck:demo": "tsc --noEmit -p ./tsconfig.demo.json"
+    "bootstrap": "./scripts/bootstrap.ts"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -31,13 +31,15 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",
+    "demo:record": "node scripts/demo/record.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck:app": "tsc --noEmit -p ./tsconfig.app.json",
     "typecheck:node": "tsc --noEmit -p ./tsconfig.node.json",
-    "typecheck": "npm run typecheck:app && npm run typecheck:node",
+    "typecheck": "npm run typecheck:app && npm run typecheck:node && npm run typecheck:demo",
     "prepare": "husky",
-    "bootstrap": "./scripts/bootstrap.ts"
+    "bootstrap": "./scripts/bootstrap.ts",
+    "typecheck:demo": "tsc --noEmit -p ./tsconfig.demo.json"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
@@ -84,6 +86,7 @@
     "husky": "^9.1.7",
     "jsdom": "^27.2.0",
     "lint-staged": "^16.2.7",
+    "playwright": "^1.62.1",
     "prettier": "3.6.2",
     "tailwindcss": "^4.1.17",
     "tw-animate-css": "^1.4.0",

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -4,15 +4,18 @@ Replays a scripted tour of the app in a real browser and records it as an mp4
 for the README.
 
 ```sh
-npm run dev        # in one terminal
+npm run build && npm run preview   # in one terminal
 npm run demo:record
 ```
 
 The result lands in `recordings/demo.mp4` (gitignored).
 
-The dev server is required rather than `vite preview`: the WebContainer needs
-the `Cross-Origin-Embedder-Policy` and `Cross-Origin-Opener-Policy` headers that
-`vite.config.ts` only sets on `server`.
+Record against a build rather than the dev server: a built app gives the
+WebContainer less to do before it is ready, and that boot is dead time at the
+head of the video. The dev server works too, via `--url=http://localhost:5173`.
+Both send the `Cross-Origin-Embedder-Policy` and `Cross-Origin-Opener-Policy`
+headers the WebContainer needs, because Vite applies the `server.headers` from
+`vite.config.ts` to the preview server as well.
 
 ## Files
 
@@ -40,6 +43,22 @@ between takes.
 - `--url=<url>` — record a different origin, e.g. the deployed app
 - `--headed` — watch the browser while it plays
 - `--keep-webm` — keep Playwright's raw capture next to the mp4
+
+## Length
+
+The recorder prints where each act falls, measured from the moment the app is
+ready:
+
+```
+    0.0s  ready
+   16.1s  act 1 — run and inspect
+   ...
+```
+
+Use those numbers to trim rather than guessing. The WebContainer boot ahead of
+`ready` swings from about five seconds to fifteen on a cold start, so the
+recorder keeps a short glimpse of it and cuts the rest, which leaves the running
+time decided by the scenario alone.
 
 ## Writing a scenario
 

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -66,3 +66,10 @@ Wait on the app, never on the clock. `untilStatus("finished")` survives a slow
 machine; a `pause(6000)` guessed from one run does not. Beats after a click are
 for the viewer, so they can be generous — the panel tour deliberately happens
 while execution is paused, because a frozen frame is the one a viewer can read.
+
+The same goes for the editor. Monaco's first type hover of a session waits about
+two seconds on the TypeScript worker to load the program, and shows an empty
+`Loading...` box meanwhile, so `hoverType` holds until the tooltip has real text
+in it. Beats that cost seconds are worth hiding inside a run: the tour asks for
+that first type while the program is executing, which pays for the wait twice
+over.

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -4,11 +4,18 @@ Replays a scripted tour of the app in a real browser and records it as an mp4
 for the README.
 
 ```sh
+npm run demo:prepare               # once per machine
 npm run build && npm run preview   # in one terminal
 npm run demo:record
 ```
 
 The result lands in `recordings/demo.mp4` (gitignored).
+
+`npm install` brings in the Playwright package but not the browser it drives,
+which is a separate few hundred megabytes. `demo:prepare` downloads it, and is
+kept out of `postinstall` on purpose: nothing but this script needs a browser,
+least of all CI. Encoding needs `ffmpeg` on the `PATH` as well; without it the
+raw `.webm` is kept instead of an mp4.
 
 Record against a build rather than the dev server: a built app gives the
 WebContainer less to do before it is ready, and that boot is dead time at the

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -1,0 +1,49 @@
+# Demo recording
+
+Replays a scripted tour of the app in a real browser and records it as an mp4
+for the README.
+
+```sh
+npm run dev        # in one terminal
+npm run demo:record
+```
+
+The result lands in `recordings/demo.mp4` (gitignored).
+
+The dev server is required rather than `vite preview`: the WebContainer needs
+the `Cross-Origin-Embedder-Policy` and `Cross-Origin-Opener-Policy` headers that
+`vite.config.ts` only sets on `server`.
+
+## Files
+
+| File          | Role                                            |
+| ------------- | ----------------------------------------------- |
+| `scenario.ts` | What the video shows. This is the file to edit. |
+| `cursor.ts`   | The visible pointer and its easing.             |
+| `record.ts`   | Browser setup, video capture, ffmpeg encode.    |
+
+## The pointer
+
+Playwright sends input through the Chrome DevTools Protocol, which never moves
+the operating system pointer, so a capture would otherwise show clicks landing
+with nothing on screen to explain them. `cursor.ts` injects an SVG arrow into
+the page and slaves it to `mousemove`, which puts the pointer inside the
+recorded frame. The Playwright mouse still drives everything, so hover, focus
+and click targeting behave exactly as they do for a person.
+
+Movement is tweened over wall-clock time along a slight arc. A counted loop
+would be at the mercy of CDP round-trip latency and the pacing would drift
+between takes.
+
+## Flags
+
+- `--url=<url>` — record a different origin, e.g. the deployed app
+- `--headed` — watch the browser while it plays
+- `--keep-webm` — keep Playwright's raw capture next to the mp4
+
+## Writing a scenario
+
+Wait on the app, never on the clock. `untilStatus("finished")` survives a slow
+machine; a `pause(6000)` guessed from one run does not. Beats after a click are
+for the viewer, so they can be generous — the panel tour deliberately happens
+while execution is paused, because a frozen frame is the one a viewer can read.

--- a/scripts/demo/cursor.ts
+++ b/scripts/demo/cursor.ts
@@ -271,6 +271,27 @@ const paceFor = (distance: number) =>
   Math.min(MAX_MOVE_MS, Math.max(MIN_MOVE_MS, distance / SPEED_PX_PER_MS));
 
 /**
+ * Blocks until a target will accept a press.
+ *
+ * `mouse.down()` fires wherever the pointer happens to be and runs none of the
+ * checks `locator.click()` does. That is deliberate — the play button animates
+ * on mount, and Playwright refuses to click an element it considers unstable —
+ * but it means nothing notices a press that lands on a disabled control. Run is
+ * disabled while an edit syncs into the WebContainer, and a press swallowed
+ * there would leave every beat after it describing a run that never started.
+ */
+async function untilEnabled(target: Locator, timeout = 15_000): Promise<void> {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    if (await target.isEnabled()) return;
+    if (Date.now() > deadline) {
+      throw new Error(`Target still disabled after ${timeout}ms: ${target}`);
+    }
+    await target.page().waitForTimeout(100);
+  }
+}
+
+/**
  * Drives the pointer for one page. Holds the last position, because Playwright's
  * mouse is stateless from the script's point of view and a glide needs to know
  * where it is starting from.
@@ -341,6 +362,7 @@ export class Cursor {
     { duration }: { duration?: number } = {},
   ): Promise<void> {
     await this.moveToLocator(target, duration);
+    await untilEnabled(target);
     await this.page.waitForTimeout(220);
     await this.page.mouse.down();
     // Long enough for the pressed state to land on a frame: the capture runs at
@@ -400,22 +422,6 @@ export class Cursor {
   }
 
   /**
-   * Rests on a target long enough for a hover affordance to appear.
-   *
-   * Monaco's type tooltip is on a delay, and the pointer has to stay inside the
-   * word for the whole of it, so the dwell is the point of this rather than an
-   * afterthought.
-   */
-  async hover(target: Locator | Point, dwell = 1100): Promise<void> {
-    if ("x" in target) {
-      await this.moveTo(target);
-    } else {
-      await this.moveToLocator(target);
-    }
-    await this.page.waitForTimeout(dwell);
-  }
-
-  /**
    * Scrolls the wheel under the pointer, in increments.
    *
    * One large delta jumps the content in a single frame; several smaller ones
@@ -445,10 +451,14 @@ export class Cursor {
     await this.page.waitForTimeout(220);
 
     const { x, y } = this.position;
+    // Dispatched on the control rather than on the document. The pointer
+    // overlay listens on the document either way, because the event bubbles,
+    // but anything else watching for a press outside itself — a popover, a
+    // tooltip — sees a press that truthfully happened inside the picker.
     const flash = (type: string) =>
-      this.page.evaluate(
-        ({ type, x, y }: { type: string; x: number; y: number }) => {
-          document.dispatchEvent(
+      target.evaluate(
+        (el, { type, x, y }: { type: string; x: number; y: number }) => {
+          el.dispatchEvent(
             new PointerEvent(type, { clientX: x, clientY: y, bubbles: true }),
           );
         },

--- a/scripts/demo/cursor.ts
+++ b/scripts/demo/cursor.ts
@@ -1,0 +1,240 @@
+/**
+ * A scripted mouse pointer for demo recordings.
+ *
+ * Playwright drives input through CDP, which never moves the operating system
+ * pointer, so a recording made with `recordVideo` shows no cursor at all. The
+ * pointer below is a DOM node injected into the page and slaved to `mousemove`,
+ * which puts it inside the captured frame. Real Playwright mouse events still do
+ * the work, so `:hover`, focus and click targeting behave normally.
+ */
+
+import type { BrowserContext, Locator, Page } from "playwright";
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+const CURSOR_ID = "__demo-cursor";
+
+/**
+ * Injects the pointer into every document of the context. Must be called before
+ * the first navigation, because init scripts only run on document creation.
+ */
+export async function installCursor(context: BrowserContext): Promise<void> {
+  await context.addInitScript(
+    ({ id }: { id: string }) => {
+      const mount = () => {
+        if (document.getElementById(id)) return;
+
+        const el = document.createElement("div");
+        el.id = id;
+        el.setAttribute("aria-hidden", "true");
+        el.style.cssText = [
+          "position:fixed",
+          "top:0",
+          "left:0",
+          "width:26px",
+          "height:26px",
+          "z-index:2147483647",
+          "pointer-events:none",
+          "will-change:transform",
+          // Pivot the press scale on the arrow's tip rather than its box
+          // centre, so pressing does not nudge the point it is aiming at.
+          "transform-origin:0 0",
+          // The pointer starts off-screen so it does not sit in the top-left
+          // corner of the first frames before the scenario moves it.
+          "transform:translate(-100px,-100px)",
+        ].join(";");
+        el.innerHTML = `
+          <svg viewBox="0 0 26 26" width="26" height="26"
+               style="filter:drop-shadow(0 2px 3px rgba(0,0,0,.45))">
+            <path d="M5 2 L5 19 L9.8 14.6 L12.6 21.5 L15.9 20.1 L13.1 13.4 L19.6 13.1 Z"
+                  fill="#101828" stroke="#ffffff" stroke-width="1.6"
+                  stroke-linejoin="round"/>
+          </svg>`;
+        document.body.appendChild(el);
+
+        // The ring is a click flash: it expands and fades on mousedown so a
+        // viewer can tell a click happened from the video alone.
+        const ring = document.createElement("div");
+        ring.setAttribute("aria-hidden", "true");
+        ring.style.cssText = [
+          "position:fixed",
+          "top:0",
+          "left:0",
+          "width:34px",
+          "height:34px",
+          "margin:-17px 0 0 -17px",
+          "border-radius:9999px",
+          "border:2px solid rgba(56,189,248,.9)",
+          "background:rgba(56,189,248,.18)",
+          "z-index:2147483646",
+          "pointer-events:none",
+          "opacity:0",
+          "will-change:transform,opacity",
+        ].join(";");
+        document.body.appendChild(ring);
+
+        let x = -100;
+        let y = -100;
+        let press = 1;
+
+        /**
+         * Position and press scale have to travel in one `transform`. The
+         * standalone `scale` property is composed *after* `transform`, so it
+         * would scale the translation itself and fling the arrow a fifth of the
+         * way back towards the top-left corner on every press.
+         */
+        const render = () => {
+          el.style.transform = `translate(${x}px, ${y}px) scale(${press})`;
+        };
+
+        document.addEventListener(
+          "mousemove",
+          (event) => {
+            x = event.clientX;
+            y = event.clientY;
+            render();
+          },
+          true,
+        );
+
+        document.addEventListener(
+          "mousedown",
+          () => {
+            press = 0.82;
+            render();
+            // Animated through the Web Animations API rather than a CSS
+            // transition: a transition interpolates from the last *committed*
+            // style, which is still the previous click's position, so the ring
+            // would streak across the screen from wherever it last fired.
+            ring.animate(
+              [
+                {
+                  transform: `translate(${x}px, ${y}px) scale(.35)`,
+                  opacity: 0.9,
+                },
+                {
+                  transform: `translate(${x}px, ${y}px) scale(1.3)`,
+                  opacity: 0,
+                },
+              ],
+              { duration: 420, easing: "cubic-bezier(.22,.61,.36,1)" },
+            );
+          },
+          true,
+        );
+
+        document.addEventListener(
+          "mouseup",
+          () => {
+            press = 1;
+            render();
+          },
+          true,
+        );
+      };
+
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", mount);
+      } else {
+        mount();
+      }
+    },
+    { id: CURSOR_ID },
+  );
+}
+
+const easeInOutCubic = (t: number) =>
+  t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+
+/**
+ * Drives the pointer for one page. Holds the last position, because Playwright's
+ * mouse is stateless from the script's point of view and a glide needs to know
+ * where it is starting from.
+ */
+export class Cursor {
+  readonly page: Page;
+
+  position: Point = { x: -100, y: -100 };
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  /**
+   * Moves to a point over `duration` milliseconds along a slightly curved path.
+   *
+   * The loop is driven by elapsed wall-clock time rather than a fixed step
+   * count: every `mouse.move` is a CDP round-trip of a few milliseconds, so a
+   * counted loop would overshoot the intended duration by an amount that varies
+   * with machine load, and the recording's pacing would drift between takes.
+   */
+  async moveTo(to: Point, duration = 700): Promise<void> {
+    const from = this.position;
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+
+    // Quadratic control point pushed perpendicular to the straight line, so the
+    // path arcs the way a hand does instead of sliding along a ruler.
+    const cx = (from.x + to.x) / 2 + dy * 0.12;
+    const cy = (from.y + to.y) / 2 - dx * 0.12;
+
+    const start = Date.now();
+    for (;;) {
+      const elapsed = Date.now() - start;
+      const t = easeInOutCubic(Math.min(1, elapsed / duration));
+      const u = 1 - t;
+      await this.page.mouse.move(
+        u * u * from.x + 2 * u * t * cx + t * t * to.x,
+        u * u * from.y + 2 * u * t * cy + t * t * to.y,
+      );
+      if (t === 1) break;
+    }
+
+    this.position = to;
+  }
+
+  /** Moves to the centre of an element, scrolling it into view first. */
+  async moveToLocator(target: Locator, duration?: number): Promise<void> {
+    await target.waitFor({ state: "visible" });
+    await target.scrollIntoViewIfNeeded();
+    const box = await target.boundingBox();
+    if (!box) {
+      throw new Error("Cannot move to a target with no bounding box");
+    }
+    await this.moveTo(
+      { x: box.x + box.width / 2, y: box.y + box.height / 2 },
+      duration,
+    );
+  }
+
+  /** Glides to an element, pauses so the viewer can register it, then clicks. */
+  async click(
+    target: Locator,
+    { duration }: { duration?: number } = {},
+  ): Promise<void> {
+    await this.moveToLocator(target, duration);
+    await this.page.waitForTimeout(220);
+    await this.page.mouse.down();
+    // Long enough for the pressed state to land on a frame: the capture runs at
+    // 25fps, so a 90ms press could fall entirely between two frames.
+    await this.page.waitForTimeout(160);
+    await this.page.mouse.up();
+    await this.page.waitForTimeout(260);
+  }
+
+  /** Selects a value in a native `<select>`, flashing the pointer over it first. */
+  async select(target: Locator, value: string): Promise<void> {
+    await this.moveToLocator(target);
+    await this.page.waitForTimeout(220);
+    await target.selectOption(value);
+    await this.page.waitForTimeout(320);
+  }
+
+  /** A beat: holds the frame still so the viewer can read what just changed. */
+  async pause(ms: number): Promise<void> {
+    await this.page.waitForTimeout(ms);
+  }
+}

--- a/scripts/demo/cursor.ts
+++ b/scripts/demo/cursor.ts
@@ -430,12 +430,39 @@ export class Cursor {
     await this.page.waitForTimeout(280);
   }
 
-  /** Selects a value in a native `<select>`, flashing the pointer over it first. */
+  /**
+   * Selects a value in a native `<select>`.
+   *
+   * The open popup cannot be filmed. The browser draws it as an OS menu outside
+   * the page, so it is absent from a page capture even though it is on screen
+   * for a real viewer. What the beat can show is the press and the result: an
+   * untrusted `pointerdown` flashes the pointer exactly as a real click does,
+   * without the browser acting on it, and then the new value is held long
+   * enough to read.
+   */
   async select(target: Locator, value: string): Promise<void> {
     await this.moveToLocator(target);
     await this.page.waitForTimeout(220);
+
+    const { x, y } = this.position;
+    const flash = (type: string) =>
+      this.page.evaluate(
+        ({ type, x, y }: { type: string; x: number; y: number }) => {
+          document.dispatchEvent(
+            new PointerEvent(type, { clientX: x, clientY: y, bubbles: true }),
+          );
+        },
+        { type, x, y },
+      );
+
+    await flash("pointerdown");
+    await this.page.waitForTimeout(160);
+    await flash("pointerup");
+    // Stand still for about as long as picking from an open menu would take.
+    await this.page.waitForTimeout(450);
+
     await target.selectOption(value);
-    await this.page.waitForTimeout(320);
+    await this.page.waitForTimeout(350);
   }
 
   /** A beat: holds the frame still so the viewer can read what just changed. */

--- a/scripts/demo/cursor.ts
+++ b/scripts/demo/cursor.ts
@@ -3,9 +3,13 @@
  *
  * Playwright drives input through CDP, which never moves the operating system
  * pointer, so a recording made with `recordVideo` shows no cursor at all. The
- * pointer below is a DOM node injected into the page and slaved to `mousemove`,
- * which puts it inside the captured frame. Real Playwright mouse events still do
- * the work, so `:hover`, focus and click targeting behave normally.
+ * pointer below is a DOM node injected into the page and slaved to the pointer
+ * event stream, which puts it inside the captured frame. Real Playwright input
+ * still does the work, so `:hover`, focus and click targeting behave normally.
+ *
+ * The glyph follows the CSS `cursor` of whatever is under the point, so the
+ * recording shows an I-beam over the editor and a resize cursor over a handle,
+ * the way a viewer's own machine would.
  */
 
 import type { BrowserContext, Locator, Page } from "playwright";
@@ -24,6 +28,82 @@ const CURSOR_ID = "__demo-cursor";
 export async function installCursor(context: BrowserContext): Promise<void> {
   await context.addInitScript(
     ({ id }: { id: string }) => {
+      /**
+       * One entry per cursor shape the app can ask for.
+       *
+       * `hotspot` is the point inside the 26x26 box that sits on the actual
+       * coordinate — the tip for an arrow, the centre for an I-beam. Getting it
+       * wrong shifts the whole glyph off the thing it is pointing at.
+       */
+      const skin = "#101828";
+      const edge = "#ffffff";
+      const filled = `fill="${skin}" stroke="${edge}" stroke-width="1.6" stroke-linejoin="round"`;
+      const line = `fill="none" stroke-linecap="round" stroke-linejoin="round"`;
+
+      const glyphs: Record<string, { hotspot: [number, number]; svg: string }> =
+        {
+          default: {
+            hotspot: [5, 2],
+            svg: `<path d="M5 2 L5 19 L9.8 14.6 L12.6 21.5 L15.9 20.1 L13.1 13.4 L19.6 13.1 Z" ${filled}/>`,
+          },
+          pointer: {
+            hotspot: [9, 2],
+            svg: `<path d="M9 2.8 a1.9 1.9 0 0 1 3.8 0 V12 h.9 v-1.6 a1.7 1.7 0 0 1 3.4 0 V12 h.9 v-1.1 a1.7 1.7 0 0 1 3.4 0 V17 a5.4 5.4 0 0 1 -5.4 5.4 h-2.7 a4.8 4.8 0 0 1 -3.9 -2 l-3 -4.2 a1.8 1.8 0 0 1 2.7 -2.3 L9 15.2 Z" ${filled}/>`,
+          },
+          text: {
+            hotspot: [13, 13],
+            svg:
+              `<path d="M9.5 4.5 H16.5 M13 4.5 V21.5 M9.5 21.5 H16.5" ${line} stroke="${skin}" stroke-width="4.2"/>` +
+              `<path d="M9.5 4.5 H16.5 M13 4.5 V21.5 M9.5 21.5 H16.5" ${line} stroke="${edge}" stroke-width="1.8"/>`,
+          },
+          "row-resize": {
+            hotspot: [13, 13],
+            svg: `<path d="M13 3 L17.5 8.5 H14.8 V17.5 H17.5 L13 23 L8.5 17.5 H11.2 V8.5 H8.5 Z" ${filled}/>`,
+          },
+          "col-resize": {
+            hotspot: [13, 13],
+            svg: `<path d="M3 13 L8.5 8.5 V11.2 H17.5 V8.5 L23 13 L17.5 17.5 V14.8 H8.5 V17.5 Z" ${filled}/>`,
+          },
+          move: {
+            hotspot: [13, 13],
+            svg: `<path d="M13 2.5 L16 6 H14.2 V11.2 H19.4 V9.4 L23 13 L19.4 16.6 V14.8 H14.2 V20 H16 L13 23.5 L10 20 H11.8 V14.8 H6.6 V16.6 L3 13 L6.6 9.4 V11.2 H11.8 V6 H10 Z" ${filled}/>`,
+          },
+          "not-allowed": {
+            hotspot: [13, 13],
+            svg:
+              `<circle cx="13" cy="13" r="8.2" fill="none" stroke="${edge}" stroke-width="4.6"/>` +
+              `<path d="M7.4 7.4 L18.6 18.6" ${line} stroke="${edge}" stroke-width="4.6"/>` +
+              `<circle cx="13" cy="13" r="8.2" fill="none" stroke="#dc2626" stroke-width="2.6"/>` +
+              `<path d="M7.4 7.4 L18.6 18.6" ${line} stroke="#dc2626" stroke-width="2.6"/>`,
+          },
+        };
+
+      /** Cursor keywords that should reuse another glyph. */
+      const aliases: Record<string, string> = {
+        auto: "default",
+        "context-menu": "default",
+        help: "default",
+        progress: "default",
+        wait: "default",
+        cell: "default",
+        crosshair: "default",
+        "vertical-text": "text",
+        alias: "default",
+        copy: "default",
+        "all-scroll": "move",
+        grab: "pointer",
+        grabbing: "pointer",
+        "ns-resize": "row-resize",
+        "n-resize": "row-resize",
+        "s-resize": "row-resize",
+        "ew-resize": "col-resize",
+        "e-resize": "col-resize",
+        "w-resize": "col-resize",
+        "nesw-resize": "move",
+        "nwse-resize": "move",
+        "no-drop": "not-allowed",
+      };
+
       const mount = () => {
         if (document.getElementById(id)) return;
 
@@ -39,24 +119,14 @@ export async function installCursor(context: BrowserContext): Promise<void> {
           "z-index:2147483647",
           "pointer-events:none",
           "will-change:transform",
-          // Pivot the press scale on the arrow's tip rather than its box
-          // centre, so pressing does not nudge the point it is aiming at.
-          "transform-origin:0 0",
           // The pointer starts off-screen so it does not sit in the top-left
           // corner of the first frames before the scenario moves it.
           "transform:translate(-100px,-100px)",
         ].join(";");
-        el.innerHTML = `
-          <svg viewBox="0 0 26 26" width="26" height="26"
-               style="filter:drop-shadow(0 2px 3px rgba(0,0,0,.45))">
-            <path d="M5 2 L5 19 L9.8 14.6 L12.6 21.5 L15.9 20.1 L13.1 13.4 L19.6 13.1 Z"
-                  fill="#101828" stroke="#ffffff" stroke-width="1.6"
-                  stroke-linejoin="round"/>
-          </svg>`;
         document.body.appendChild(el);
 
-        // The ring is a click flash: it expands and fades on mousedown so a
-        // viewer can tell a click happened from the video alone.
+        // The ring is a click flash: it expands and fades on press so a viewer
+        // can tell a click happened from the video alone.
         const ring = document.createElement("div");
         ring.setAttribute("aria-hidden", "true");
         ring.style.cssText = [
@@ -79,29 +149,61 @@ export async function installCursor(context: BrowserContext): Promise<void> {
         let x = -100;
         let y = -100;
         let press = 1;
+        let kind = "";
 
         /**
          * Position and press scale have to travel in one `transform`. The
          * standalone `scale` property is composed *after* `transform`, so it
-         * would scale the translation itself and fling the arrow a fifth of the
+         * would scale the translation itself and fling the glyph a fifth of the
          * way back towards the top-left corner on every press.
+         *
+         * `transform-origin` tracks the hotspot so the press pivots on the
+         * point being clicked rather than on the corner of the box.
          */
         const render = () => {
-          el.style.transform = `translate(${x}px, ${y}px) scale(${press})`;
+          const [hx, hy] = glyphs[kind].hotspot;
+          el.style.transformOrigin = `${hx}px ${hy}px`;
+          el.style.transform = `translate(${x - hx}px, ${y - hy}px) scale(${press})`;
         };
 
+        const setKind = (next: string) => {
+          if (next === kind) return;
+          kind = next;
+          el.innerHTML = `<svg viewBox="0 0 26 26" width="26" height="26"
+             style="filter:drop-shadow(0 2px 3px rgba(0,0,0,.45))">${glyphs[kind].svg}</svg>`;
+        };
+
+        /**
+         * Resolves the shape from whatever sits under the point. The overlay is
+         * `pointer-events:none`, so `elementFromPoint` reports the page's own
+         * element rather than the glyph itself.
+         */
+        const syncKind = () => {
+          const under = document.elementFromPoint(x, y);
+          const css = under ? getComputedStyle(under).cursor : "default";
+          const name = aliases[css] ?? css;
+          setKind(name in glyphs ? name : "default");
+        };
+
+        setKind("default");
+
+        // Pointer events, not mouse events. A drag target that calls
+        // `preventDefault()` on the pointer stream — react-resizable-panels
+        // does — suppresses the compatibility mouse events for the rest of that
+        // gesture, and the glyph would sit frozen for the whole drag.
         document.addEventListener(
-          "mousemove",
+          "pointermove",
           (event) => {
             x = event.clientX;
             y = event.clientY;
+            syncKind();
             render();
           },
           true,
         );
 
         document.addEventListener(
-          "mousedown",
+          "pointerdown",
           () => {
             press = 0.82;
             render();
@@ -127,9 +229,12 @@ export async function installCursor(context: BrowserContext): Promise<void> {
         );
 
         document.addEventListener(
-          "mouseup",
+          "pointerup",
           () => {
             press = 1;
+            // A drag usually changes what is under the point — releasing a
+            // resize handle hands the cursor back to the panel beneath it.
+            syncKind();
             render();
           },
           true,
@@ -150,6 +255,22 @@ const easeInOutCubic = (t: number) =>
   t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
 
 /**
+ * How long a move of a given distance should take, when the caller does not say.
+ *
+ * A single fixed duration cannot serve both ends of the range: it makes a nudge
+ * between two adjacent buttons crawl, and it turns a corner-to-corner traverse
+ * into a jump. At 25fps a 450px move given 300ms advances some 60px per frame,
+ * which the eye reads as a teleport rather than as motion. Holding the speed
+ * roughly constant instead keeps every move legible.
+ */
+const SPEED_PX_PER_MS = 0.5;
+const MIN_MOVE_MS = 300;
+const MAX_MOVE_MS = 1200;
+
+const paceFor = (distance: number) =>
+  Math.min(MAX_MOVE_MS, Math.max(MIN_MOVE_MS, distance / SPEED_PX_PER_MS));
+
+/**
  * Drives the pointer for one page. Holds the last position, because Playwright's
  * mouse is stateless from the script's point of view and a glide needs to know
  * where it is starting from.
@@ -164,27 +285,31 @@ export class Cursor {
   }
 
   /**
-   * Moves to a point over `duration` milliseconds along a slightly curved path.
+   * Moves to a point along a slightly curved path, taking `duration`
+   * milliseconds. Omit `duration` to travel at a constant speed, which is what
+   * a scenario usually wants — see `paceFor`.
    *
    * The loop is driven by elapsed wall-clock time rather than a fixed step
    * count: every `mouse.move` is a CDP round-trip of a few milliseconds, so a
    * counted loop would overshoot the intended duration by an amount that varies
    * with machine load, and the recording's pacing would drift between takes.
    */
-  async moveTo(to: Point, duration = 700): Promise<void> {
+  async moveTo(to: Point, duration?: number, arc = 0.12): Promise<void> {
     const from = this.position;
     const dx = to.x - from.x;
     const dy = to.y - from.y;
+    const ms = duration ?? paceFor(Math.hypot(dx, dy));
 
     // Quadratic control point pushed perpendicular to the straight line, so the
-    // path arcs the way a hand does instead of sliding along a ruler.
-    const cx = (from.x + to.x) / 2 + dy * 0.12;
-    const cy = (from.y + to.y) / 2 - dx * 0.12;
+    // path arcs the way a hand does instead of sliding along a ruler. Drags pass
+    // `arc: 0`, because a curved drag would wobble whatever it is dragging.
+    const cx = (from.x + to.x) / 2 + dy * arc;
+    const cy = (from.y + to.y) / 2 - dx * arc;
 
     const start = Date.now();
     for (;;) {
       const elapsed = Date.now() - start;
-      const t = easeInOutCubic(Math.min(1, elapsed / duration));
+      const t = easeInOutCubic(Math.min(1, elapsed / ms));
       const u = 1 - t;
       await this.page.mouse.move(
         u * u * from.x + 2 * u * t * cx + t * t * to.x,
@@ -223,6 +348,40 @@ export class Cursor {
     await this.page.waitForTimeout(160);
     await this.page.mouse.up();
     await this.page.waitForTimeout(260);
+  }
+
+  /**
+   * Presses on a target, drags by `delta`, and releases.
+   *
+   * The move is broken into many small steps by `moveTo`, which matters here:
+   * a drag target reads the pointer's path, and a single jump to the end
+   * position would either be ignored or snap without any visible motion.
+   *
+   * A bare point is accepted as well as a locator, because not every drag
+   * target is an element Playwright will call visible — see the Timeline
+   * separator in `scenario.ts`.
+   */
+  async drag(
+    target: Locator | Point,
+    delta: Point,
+    { duration = 800 }: { duration?: number } = {},
+  ): Promise<void> {
+    if ("x" in target) {
+      await this.moveTo(target);
+    } else {
+      await this.moveToLocator(target);
+    }
+    await this.page.waitForTimeout(260);
+    await this.page.mouse.down();
+    await this.page.waitForTimeout(200);
+    await this.moveTo(
+      { x: this.position.x + delta.x, y: this.position.y + delta.y },
+      duration,
+      0,
+    );
+    await this.page.waitForTimeout(300);
+    await this.page.mouse.up();
+    await this.page.waitForTimeout(320);
   }
 
   /** Selects a value in a native `<select>`, flashing the pointer over it first. */

--- a/scripts/demo/cursor.ts
+++ b/scripts/demo/cursor.ts
@@ -384,6 +384,52 @@ export class Cursor {
     await this.page.waitForTimeout(320);
   }
 
+  /**
+   * Glides to a point and double-clicks, which in a text editor selects the
+   * word under the pointer.
+   */
+  async doubleClick(target: Locator | Point): Promise<void> {
+    if ("x" in target) {
+      await this.moveTo(target);
+    } else {
+      await this.moveToLocator(target);
+    }
+    await this.page.waitForTimeout(220);
+    await this.page.mouse.dblclick(this.position.x, this.position.y);
+    await this.page.waitForTimeout(320);
+  }
+
+  /**
+   * Rests on a target long enough for a hover affordance to appear.
+   *
+   * Monaco's type tooltip is on a delay, and the pointer has to stay inside the
+   * word for the whole of it, so the dwell is the point of this rather than an
+   * afterthought.
+   */
+  async hover(target: Locator | Point, dwell = 1100): Promise<void> {
+    if ("x" in target) {
+      await this.moveTo(target);
+    } else {
+      await this.moveToLocator(target);
+    }
+    await this.page.waitForTimeout(dwell);
+  }
+
+  /**
+   * Scrolls the wheel under the pointer, in increments.
+   *
+   * One large delta jumps the content in a single frame; several smaller ones
+   * read as scrolling. The pointer stays put, as a real one would.
+   */
+  async scroll(deltaY: number, { steps = 5 }: { steps?: number } = {}) {
+    const per = deltaY / steps;
+    for (let i = 0; i < steps; i++) {
+      await this.page.mouse.wheel(0, per);
+      await this.page.waitForTimeout(70);
+    }
+    await this.page.waitForTimeout(280);
+  }
+
   /** Selects a value in a native `<select>`, flashing the pointer over it first. */
   async select(target: Locator, value: string): Promise<void> {
     await this.moveToLocator(target);

--- a/scripts/demo/original-demo.md
+++ b/scripts/demo/original-demo.md
@@ -108,7 +108,9 @@ log rows — is pacing, giving the viewer somewhere to look while a program runs
 
 - **The open dropdown** (13.0, 25.5, 33.5) is not reproduced. It is a native
   `<select>`, so macOS draws the popup outside the page and a browser capture
-  cannot see it. The switch still reads, through the picker label and the code.
+  cannot see it — not even in a headed run. The switch still reads: the pointer
+  presses the picker, holds for as long as picking from a menu takes, and the
+  label and the code change together.
 - **The multi-caret rename targets two spans, not three.** The original suffixes
   all three Multi-Step Worker spans at once, reaching the extra carets with
   "add cursor below". The script stays in the Basic Example, which is already on

--- a/scripts/demo/original-demo.md
+++ b/scripts/demo/original-demo.md
@@ -109,10 +109,10 @@ log rows — is pacing, giving the viewer somewhere to look while a program runs
 - **The open dropdown** (13.0, 25.5, 33.5) is not reproduced. It is a native
   `<select>`, so macOS draws the popup outside the page and a browser capture
   cannot see it. The switch still reads, through the picker label and the code.
-- **The rename targets one span, not three.** The original suffixes all three
-  Multi-Step Worker spans at once with a multi-caret edit. The script renames
-  `worker-1-task` to `worker-1-job` in the Basic Example instead, which makes the
-  same point in one program and leaves the untouched `worker-2-task` on screen
-  as a control.
+- **The multi-caret rename targets two spans, not three.** The original suffixes
+  all three Multi-Step Worker spans at once, reaching the extra carets with
+  "add cursor below". The script stays in the Basic Example, which is already on
+  screen, and renames `worker-1-task` and `worker-2-task` to `-job` by selecting
+  every occurrence of `task` instead. Same edit, one program fewer.
 - **The emoji edit is dropped**, for time. `Schedule.recurs(5)` →
   `recurs(3)` and the failing run it causes are reproduced in full.

--- a/scripts/demo/original-demo.md
+++ b/scripts/demo/original-demo.md
@@ -1,0 +1,115 @@
+# The original hand-made demo, step by step
+
+A frame-by-frame reconstruction of the 53s screen recording linked from the root
+README, extracted at 0.5s granularity. It is the reference the scripted scenario
+in `scenario.ts` is built against.
+
+Source: `https://github.com/user-attachments/assets/c6073f78-d18e-4573-805b-65b1c2a71df8`
+(3024x1964, 60fps, 53.15s, recorded against `effect-viz.vercel.app`).
+
+## Steps
+
+| Time       | Who  | Step                                                                                                                                                                                   |
+| ---------- | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.0–2.0    | user | Pointer drifts from the Fiber Tree down into the console panel and parks on the last boot line.                                                                                        |
+| 0.0–6.5    | app  | WebContainer boots. Log runs `3/6 runtime.js fetched` → `4/6 Files mounted` → `5/6 Running pnpm install...` → `pnpm install finished {"exitCode":0}` → `6/6 Boot complete` → `ready`.  |
+| 2.0–6.5    | user | Pointer held still for ~4.5s. The presenter simply waits and lets the boot log be read.                                                                                                |
+| 6.5        | app  | Run button enables. The red type-error squiggle under `"effect"` on line 1 clears as Monaco acquires types (`Types acquired` at 7.0).                                                  |
+| 7.0–7.5    | user | Move to the Run button; its `Run` tooltip appears.                                                                                                                                     |
+| 7.5–8.0    | user | **Click Run.** Idle → `Starting...`                                                                                                                                                    |
+| 9.0–10.5   | app  | Basic Example runs. `#0` forks `#6` and `#7`; log streams rows `[4]`→`[30]`; three Timeline lanes fill to ~1.5s. Console prints `All workers done!` then `Program completed: { … }`.   |
+| 10.5–11.5  | user | Move up to the horizontal splitter between the cards row and the Timeline; the cursor becomes `↕` and the splitter highlights.                                                        |
+| 11.5–13.0  | user | **Drag the splitter up ~58px** (y 628 → 570), enlarging the Timeline so all three fiber lanes fit at once. The Execution Log is clipped as a result.                                   |
+| 13.0–13.5  | user | **Open the program dropdown** (native macOS popup, 10 options, `Basic Example` ticked).                                                                                                |
+| 14.0–14.5  | user | **Select `Multi-Step Worker`.** Editor swaps to its template; all three visualizer cards reset.                                                                                        |
+| 15.0–15.5  | user | **Click Run.**                                                                                                                                                                         |
+| 16.5–17.0  | user | **Click into the editor**, line 6, placing the caret just inside the closing quote of `"step-1-prepare"`.                                                                              |
+| 17.5–18.0  | app  | Run finishes. The log still shows the original span names.                                                                                                                             |
+| 18.0–19.0  | user | **Add a caret below, twice** (keyboard — the pointer is not drawn). Carets land at the same column on lines 6, 7 and 8; all three span names are 14 characters, so the columns align.  |
+| 19.5–20.0  | user | **Type `!!`** at all three carets at once. See [Code edits](#code-edits).                                                                                                              |
+| 20.5–21.0  | user | **Click Run.**                                                                                                                                                                         |
+| 22.0–24.0  | app  | The run streams the edited names: `effect:started step-1-prepare!!`, `effect:ended step-2-process!!`, `effect:started step-3-cleanup!!`.                                               |
+| 24.0–25.0  | user | Pointer sweeps across the Execution Log rows, reading the renamed spans. No click — this beat exists purely to point at the payoff of the edit.                                        |
+| 25.5–26.0  | user | **Open the dropdown** again.                                                                                                                                                           |
+| 26.0–27.5  | user | Highlight walks down to `Nested Forks`; **selected** between 27.0 and 27.5.                                                                                                            |
+| 27.5–28.0  | user | **Click Run.**                                                                                                                                                                         |
+| 29.0–30.0  | app  | Nested Forks runs. Fiber Tree nests four deep: `#0` → `#6` → `#7` → `#8`. Console prints `Program completed: parent done`.                                                             |
+| 30.0–32.0  | user | **Hover identifiers for their types.** `parent` → `const parent: Fiber.RuntimeFiber<string, never>`, then `child` → `const child: Fiber.RuntimeFiber<string, never>`.                  |
+| 33.5–34.0  | user | **Open the dropdown** a third time.                                                                                                                                                    |
+| 34.0–35.0  | user | Highlight walks `Nested Forks` → `Failure & Recovery` → `Retry (Exponential Backoff)`.                                                                                                 |
+| 35.0–35.5  | user | **Select `Retry (Exponential Backoff)`.**                                                                                                                                              |
+| 36.5–37.0  | user | **Click Run.**                                                                                                                                                                         |
+| 38.0–39.5  | app  | The retry run succeeds. Four `retry:attempt` rows, with resumes after 101ms, 209ms, 410ms and 812ms — the backoff doubling is visible both in the log and as widening Timeline gaps.   |
+| 38.5–39.0  | user | **Hover `flakyEffect`** → `const flakyEffect: Effect.Effect<string, Error, never>`.                                                                                                    |
+| 40.0–40.5  | user | **Click into the editor**, line 13, caret just after the word `failed`.                                                                                                                |
+| 41.0–41.5  | user | **Type ` 💣💥💨`** into the error message.                                                                                                                                             |
+| 42.0–43.0  | user | **Scroll the editor** down ~4.5 lines to bring `Schedule.recurs(5)` into view. Monaco's sticky scroll pins line 5.                                                                     |
+| 43.5–44.0  | user | **Double-click the `5`** in `Schedule.recurs(5)` to select it.                                                                                                                         |
+| 44.5–45.5  | user | **Type `3`** over the selection.                                                                                                                                                       |
+| 46.0–46.5  | user | **Click Run.**                                                                                                                                                                         |
+| 47.5–48.5  | app  | **The program now fails.** `[interrupted] #0` in red, a red segment closing the Timeline bar, `[12] ❌ effect:ended flaky-task` and `[13] ⛔ fiber:interrupted #0`, and a stack trace. |
+| 49.5–50.5  | user | Move to the ⓘ icon; `About` tooltip appears.                                                                                                                                           |
+| 50.5–51.0  | user | **Click ⓘ.** The info modal opens.                                                                                                                                                     |
+| 51.0–53.15 | —    | The video ends with the modal open.                                                                                                                                                    |
+
+## Code edits
+
+Three edits across two programs. Each is followed by a re-run, and in every case
+the point is that the change shows up in the runtime output.
+
+**Multi-Step Worker, t=20.0** — one multi-caret edit across three lines:
+
+```diff
+-      yield* Effect.withSpan("step-1-prepare")(Effect.sleep("500 millis"));
+-      yield* Effect.withSpan("step-2-process")(Effect.sleep("500 millis"));
+-      yield* Effect.withSpan("step-3-cleanup")(Effect.sleep("500 millis"));
++      yield* Effect.withSpan("step-1-prepare!!")(Effect.sleep("500 millis"));
++      yield* Effect.withSpan("step-2-process!!")(Effect.sleep("500 millis"));
++      yield* Effect.withSpan("step-3-cleanup!!")(Effect.sleep("500 millis"));
+```
+
+**Retry (Exponential Backoff), t=41.5** — decorate the failure message:
+
+```diff
+-      return yield* Effect.fail(new Error(`Attempt ${n} failed`));
++      return yield* Effect.fail(new Error(`Attempt ${n} failed 💣💥💨`));
+```
+
+**Retry (Exponential Backoff), t=45.5** — the edit that breaks the program:
+
+```diff
+-    Schedule.recurs(5),
++    Schedule.recurs(3),
+```
+
+`flakyEffect` only succeeds once `n >= 5`, and `if (n < 5)` is left untouched, so
+cutting the schedule to three retries means four attempts and a guaranteed
+failure. That is the whole point of the last act: an edit to the retry policy
+flips a green run red, and the visualizer shows exactly where.
+
+## What the demo is actually arguing
+
+Three claims, in order, each proven by running something:
+
+1. **The runtime is observable.** One click on Run and the fiber tree, event log
+   and timeline all fill in together.
+2. **The programs are live, not screenshots.** Edit a span name, re-run, and the
+   new name comes back out of the runtime in the event log.
+3. **You can break things and see why.** Change a retry policy, re-run, and the
+   failure is legible across all three views at once.
+
+Everything else — the panel drag, the type-hover tooltips, the walk across the
+log rows — is pacing, giving the viewer somewhere to look while a program runs.
+
+## Coverage by the scripted scenario
+
+`scenario.ts` reproduces beats 1–3, plus controls that did not exist when this
+was recorded (speed, pause, step, reset). Deliberately not reproduced:
+
+- **The open dropdown** (13.0, 25.5, 33.5). It is a native `<select>`, so macOS
+  draws the popup outside the page and a browser capture cannot see it. The
+  program switch itself still reads, through the picker label and the code.
+- **Type-hover tooltips** (30.0, 38.5). Reproducible with a hover and a dwell;
+  left out only for time.
+- **The second edit and the failing run** (41.5–48.5). The strongest act in the
+  original. It is out of the current cut for length, not for difficulty.

--- a/scripts/demo/original-demo.md
+++ b/scripts/demo/original-demo.md
@@ -103,13 +103,16 @@ log rows — is pacing, giving the viewer somewhere to look while a program runs
 
 ## Coverage by the scripted scenario
 
-`scenario.ts` reproduces beats 1–3, plus controls that did not exist when this
-was recorded (speed, pause, step, reset). Deliberately not reproduced:
+`scenario.ts` reproduces every act of this demo, plus controls that postdate it
+(speed, pause, step, reset). Three deliberate departures:
 
-- **The open dropdown** (13.0, 25.5, 33.5). It is a native `<select>`, so macOS
-  draws the popup outside the page and a browser capture cannot see it. The
-  program switch itself still reads, through the picker label and the code.
-- **Type-hover tooltips** (30.0, 38.5). Reproducible with a hover and a dwell;
-  left out only for time.
-- **The second edit and the failing run** (41.5–48.5). The strongest act in the
-  original. It is out of the current cut for length, not for difficulty.
+- **The open dropdown** (13.0, 25.5, 33.5) is not reproduced. It is a native
+  `<select>`, so macOS draws the popup outside the page and a browser capture
+  cannot see it. The switch still reads, through the picker label and the code.
+- **The rename targets one span, not three.** The original suffixes all three
+  Multi-Step Worker spans at once with a multi-caret edit. The script renames
+  `worker-1-task` to `worker-1-job` in the Basic Example instead, which makes the
+  same point in one program and leaves the untouched `worker-2-task` on screen
+  as a control.
+- **The emoji edit is dropped**, for time. `Schedule.recurs(5)` →
+  `recurs(3)` and the failing run it causes are reproduced in full.

--- a/scripts/demo/record.ts
+++ b/scripts/demo/record.ts
@@ -1,0 +1,143 @@
+/**
+ * Records the README demo video by replaying `scenario.ts` in a real browser.
+ *
+ * Run the dev server first: the app needs the `Cross-Origin-Embedder-Policy`
+ * and `Cross-Origin-Opener-Policy` headers that `vite.config.ts` sets on
+ * `server`, and `vite preview` does not send them, so the WebContainer would
+ * refuse to boot against a preview build.
+ *
+ *   npm run dev
+ *   npm run demo:record
+ *
+ * Flags:
+ *   --url=<url>     app to record (default http://localhost:5173)
+ *   --headed        show the browser while it plays
+ *   --keep-webm     keep the raw Playwright capture next to the mp4
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdir, readdir, rm, rename } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { chromium } from "playwright";
+
+import { Cursor, installCursor } from "./cursor.ts";
+import { runScenario, VIEWPORT } from "./scenario.ts";
+
+const ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+const OUT_DIR = path.join(ROOT, "recordings");
+
+function flag(name: string): string | undefined {
+  const match = process.argv
+    .slice(2)
+    .find((a) => a === `--${name}` || a.startsWith(`--${name}=`));
+  if (!match) return undefined;
+  const [, value] = match.split("=");
+  return value ?? "";
+}
+
+async function main() {
+  const url = flag("url") || "http://localhost:5173";
+  const headed = flag("headed") !== undefined;
+  const keepWebm = flag("keep-webm") !== undefined;
+
+  await rm(OUT_DIR, { recursive: true, force: true });
+  await mkdir(OUT_DIR, { recursive: true });
+
+  const browser = await chromium.launch({ headless: !headed });
+  const context = await browser.newContext({
+    viewport: VIEWPORT,
+    deviceScaleFactor: 1,
+    recordVideo: { dir: OUT_DIR, size: VIEWPORT },
+    colorScheme: "dark",
+    reducedMotion: "no-preference",
+  });
+
+  // A fresh profile would start the onboarding tour, whose pulsing highlights
+  // fight with the scripted pointer for the viewer's attention.
+  await context.addInitScript(() => {
+    localStorage.setItem(
+      "effect-flow-onboarding",
+      JSON.stringify({
+        completed: "info",
+        version: 1,
+        date: new Date().toISOString(),
+      }),
+    );
+  });
+
+  await installCursor(context);
+
+  const page = await context.newPage();
+  page.on("console", (msg) => {
+    if (msg.type() === "error") console.error("[page]", msg.text());
+  });
+
+  try {
+    await page.goto(url, { waitUntil: "domcontentloaded" });
+  } catch (cause) {
+    throw new Error(
+      `Cannot reach ${url}. Start the dev server with \`npm run dev\` first.`,
+      { cause },
+    );
+  }
+
+  const cursor = new Cursor(page);
+  await runScenario({ page, cursor });
+
+  // The video file is only flushed once the context closes, and it is named
+  // after an internal id, so it can only be located afterwards.
+  await context.close();
+  await browser.close();
+
+  const webm = (await readdir(OUT_DIR)).find((f) => f.endsWith(".webm"));
+  if (!webm) throw new Error("Playwright produced no video file");
+
+  const rawPath = path.join(OUT_DIR, "demo.webm");
+  await rename(path.join(OUT_DIR, webm), rawPath);
+
+  const mp4Path = path.join(OUT_DIR, "demo.mp4");
+  const ffmpeg = spawnSync(
+    "ffmpeg",
+    [
+      "-y",
+      "-i",
+      rawPath,
+      // GitHub only plays H.264 in an MP4 container, and yuv420p is the pixel
+      // format Safari needs; the even-dimension filter keeps H.264 happy if the
+      // viewport is ever set to an odd size.
+      "-vf",
+      "scale=trunc(iw/2)*2:trunc(ih/2)*2",
+      "-c:v",
+      "libx264",
+      "-pix_fmt",
+      "yuv420p",
+      "-crf",
+      "20",
+      "-preset",
+      "slow",
+      "-movflags",
+      "+faststart",
+      "-an",
+      mp4Path,
+    ],
+    { stdio: "inherit" },
+  );
+
+  if (ffmpeg.error || ffmpeg.status !== 0) {
+    console.warn(`\nffmpeg unavailable or failed; keeping ${rawPath}`);
+    return;
+  }
+
+  if (!keepWebm) await rm(rawPath);
+  console.log(`\nRecorded ${path.relative(ROOT, mp4Path)}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/demo/record.ts
+++ b/scripts/demo/record.ts
@@ -31,6 +31,9 @@ const ROOT = path.resolve(
 );
 const OUT_DIR = path.join(ROOT, "recordings");
 
+/** How much of the WebContainer boot to keep at the head of the video. */
+const BOOT_LEAD_IN_SECONDS = 1.8;
+
 function flag(name: string): string | undefined {
   const match = process.argv
     .slice(2)
@@ -73,6 +76,8 @@ async function main() {
   await installCursor(context);
 
   const page = await context.newPage();
+  // Video capture starts with the page, so this is frame zero.
+  const videoStartedAt = Date.now();
   page.on("console", (msg) => {
     if (msg.type() === "error") console.error("[page]", msg.text());
   });
@@ -87,7 +92,23 @@ async function main() {
   }
 
   const cursor = new Cursor(page);
-  await runScenario({ page, cursor });
+
+  // Act timings, so the length can be trimmed against measurements. The clock
+  // starts when the app is ready, because the WebContainer boot happens before
+  // the recording has anything worth showing and varies run to run.
+  let clockStart = Date.now();
+  let readyAt = Date.now();
+  const mark = (label: string) => {
+    if (label === "ready") {
+      clockStart = Date.now();
+      readyAt = clockStart;
+    }
+    const elapsed = (Date.now() - clockStart) / 1000;
+    console.log(`  ${elapsed.toFixed(1).padStart(5)}s  ${label}`);
+  };
+
+  console.log("\nScenario:");
+  await runScenario({ page, cursor, mark });
 
   // The video file is only flushed once the context closes, and it is named
   // after an internal id, so it can only be located afterwards.
@@ -100,11 +121,20 @@ async function main() {
   const rawPath = path.join(OUT_DIR, "demo.webm");
   await rename(path.join(OUT_DIR, webm), rawPath);
 
+  // Everything before the app is usable is WebContainer boot, whose length
+  // swings by seconds between machines and would otherwise decide whether the
+  // video comes in under a minute. Keep a glimpse of it for context and cut the
+  // rest, so the running time is set by the scenario alone.
+  const bootSeconds = (readyAt - videoStartedAt) / 1000;
+  const trim = Math.max(0, bootSeconds - BOOT_LEAD_IN_SECONDS);
+
   const mp4Path = path.join(OUT_DIR, "demo.mp4");
   const ffmpeg = spawnSync(
     "ffmpeg",
     [
       "-y",
+      "-ss",
+      trim.toFixed(2),
       "-i",
       rawPath,
       // GitHub only plays H.264 in an MP4 container, and yuv420p is the pixel
@@ -134,7 +164,10 @@ async function main() {
   }
 
   if (!keepWebm) await rm(rawPath);
-  console.log(`\nRecorded ${path.relative(ROOT, mp4Path)}`);
+  console.log(
+    `\nRecorded ${path.relative(ROOT, mp4Path)} ` +
+      `(trimmed ${trim.toFixed(1)}s of boot from the head)`,
+  );
 }
 
 main().catch((error) => {

--- a/scripts/demo/record.ts
+++ b/scripts/demo/record.ts
@@ -1,16 +1,20 @@
 /**
  * Records the README demo video by replaying `scenario.ts` in a real browser.
  *
- * Run the dev server first: the app needs the `Cross-Origin-Embedder-Policy`
- * and `Cross-Origin-Opener-Policy` headers that `vite.config.ts` sets on
- * `server`, and `vite preview` does not send them, so the WebContainer would
- * refuse to boot against a preview build.
+ * Record against a production build. The WebContainer boots much faster there
+ * than under the dev server, and that boot is dead time at the head of the
+ * video.
  *
- *   npm run dev
+ *   npm run build && npm run preview
  *   npm run demo:record
  *
+ * The dev server works too, via `--url`. Both send the
+ * `Cross-Origin-Embedder-Policy` and `Cross-Origin-Opener-Policy` headers the
+ * WebContainer needs: Vite applies the `server.headers` from `vite.config.ts`
+ * to the preview server as well.
+ *
  * Flags:
- *   --url=<url>     app to record (default http://localhost:5173)
+ *   --url=<url>     app to record (default http://localhost:4173)
  *   --headed        show the browser while it plays
  *   --keep-webm     keep the raw Playwright capture next to the mp4
  */
@@ -44,7 +48,7 @@ function flag(name: string): string | undefined {
 }
 
 async function main() {
-  const url = flag("url") || "http://localhost:5173";
+  const url = flag("url") || "http://localhost:4173";
   const headed = flag("headed") !== undefined;
   const keepWebm = flag("keep-webm") !== undefined;
 
@@ -86,7 +90,8 @@ async function main() {
     await page.goto(url, { waitUntil: "domcontentloaded" });
   } catch (cause) {
     throw new Error(
-      `Cannot reach ${url}. Start the dev server with \`npm run dev\` first.`,
+      `Cannot reach ${url}. Serve a build with ` +
+        "`npm run build && npm run preview` first, or point --url at a dev server.",
       { cause },
     );
   }

--- a/scripts/demo/record.ts
+++ b/scripts/demo/record.ts
@@ -36,7 +36,7 @@ const ROOT = path.resolve(
 const OUT_DIR = path.join(ROOT, "recordings");
 
 /** How much of the WebContainer boot to keep at the head of the video. */
-const BOOT_LEAD_IN_SECONDS = 1.8;
+const BOOT_LEAD_IN_SECONDS = 0.8;
 
 function flag(name: string): string | undefined {
   const match = process.argv

--- a/scripts/demo/record.ts
+++ b/scripts/demo/record.ts
@@ -55,7 +55,16 @@ async function main() {
   await rm(OUT_DIR, { recursive: true, force: true });
   await mkdir(OUT_DIR, { recursive: true });
 
-  const browser = await chromium.launch({ headless: !headed });
+  // `npm install` fetches the Playwright package but not the browser it drives,
+  // deliberately: only this script needs it, and CI never does.
+  const browser = await chromium
+    .launch({ headless: !headed })
+    .catch((cause) => {
+      throw new Error(
+        "Cannot launch Chromium. Run `npm run demo:prepare` once to download it.",
+        { cause },
+      );
+    });
   const context = await browser.newContext({
     viewport: VIEWPORT,
     deviceScaleFactor: 1,
@@ -113,7 +122,16 @@ async function main() {
   };
 
   console.log("\nScenario:");
-  await runScenario({ page, cursor, mark });
+  // A scenario that fails halfway is exactly when the video is worth having:
+  // it shows what the app was doing when the beat went wrong. Encode it first
+  // and rethrow afterwards, rather than losing the take to the error.
+  let failure: unknown;
+  try {
+    await runScenario({ page, cursor, mark });
+  } catch (error) {
+    failure = error;
+    console.error("\nScenario failed. Encoding the partial take anyway.");
+  }
 
   // The video file is only flushed once the context closes, and it is named
   // after an internal id, so it can only be located afterwards.
@@ -164,15 +182,22 @@ async function main() {
   );
 
   if (ffmpeg.error || ffmpeg.status !== 0) {
-    console.warn(`\nffmpeg unavailable or failed; keeping ${rawPath}`);
+    console.warn(
+      `\nffmpeg unavailable or failed; keeping ${rawPath}. ` +
+        "Install ffmpeg to get an mp4 the README can play.",
+    );
+    if (failure) throw failure;
     return;
   }
 
   if (!keepWebm) await rm(rawPath);
   console.log(
-    `\nRecorded ${path.relative(ROOT, mp4Path)} ` +
+    `\n${failure ? "Partial recording in" : "Recorded"} ` +
+      `${path.relative(ROOT, mp4Path)} ` +
       `(trimmed ${trim.toFixed(1)}s of boot from the head)`,
   );
+
+  if (failure) throw failure;
 }
 
 main().catch((error) => {

--- a/scripts/demo/scenario.ts
+++ b/scripts/demo/scenario.ts
@@ -248,11 +248,13 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   await cursor.moveToLocator(timeline);
   await cursor.pause(430);
 
-  // Panels are resizable: give the timeline lanes more room.
+  // Panels are resizable, and the Basic Example needs the room: at the default
+  // split the third fiber lane is cut off by the time axis. Fifty pixels puts
+  // all three on screen at once.
   await cursor.drag(
     await timelineHandlePoint(page),
-    { x: 0, y: -25 },
-    { duration: 600 },
+    { x: 0, y: -50 },
+    { duration: 700 },
   );
   await cursor.pause(350);
   mark("act 1 — run and inspect");
@@ -261,7 +263,6 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   // The speed change lands between two runs of the same program on purpose:
   // the only thing that differs is how long it takes, which is the point.
   await cursor.select(speedSelect, "0.5");
-  await cursor.pause(300);
 
   await cursor.click(runButton);
   await untilStatus("running");
@@ -285,7 +286,6 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   await cursor.click(resetButton);
   await cursor.pause(400);
   await cursor.select(speedSelect, "1");
-  await cursor.pause(300);
 
   // Renaming a span keeps the run the same length, and the new names come back
   // out of the runtime in the execution log — which is the point being made.
@@ -311,7 +311,7 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   await cursor.pause(250);
 
   await cursor.select(programSelect, "retryExponentialBackoff");
-  await cursor.pause(700);
+  await cursor.pause(350);
 
   await cursor.click(runButton);
   await untilStatus("finished");

--- a/scripts/demo/scenario.ts
+++ b/scripts/demo/scenario.ts
@@ -4,6 +4,10 @@
  * Edit this file to change what the video shows; `record.ts` only drives it.
  * Beats are deliberate: every click is followed by a hold long enough for a
  * viewer to read what changed before the pointer moves on.
+ *
+ * The tour is budgeted to stay under a minute, so each act earns its place by
+ * showing something the others do not. `mark()` prints where the acts fall, to
+ * make trimming a matter of measurement rather than guesswork.
  */
 
 import type { Page } from "playwright";
@@ -15,17 +19,17 @@ export const VIEWPORT = { width: 1440, height: 810 };
 interface ScenarioContext {
   page: Page;
   cursor: Cursor;
+  /** Records the elapsed time at an act boundary. */
+  mark: (label: string) => void;
 }
 
 /**
  * The grab point of the resize separator above the Timeline panel.
  *
- * Returns a point rather than a locator for two reasons. The separator is a
- * zero-height element, which Playwright does not count as visible, and
- * react-resizable-panels hit-tests pointers against a margin around it rather
- * than against the element itself. The layout holds several separators under
- * library-generated ids, so this one is found structurally: it is the sibling
- * immediately before the panel that holds the Timeline.
+ * Returns a point rather than a locator because the separator is a zero-height
+ * element, which Playwright does not count as visible. The layout holds several
+ * separators under library-generated ids, so this one is found structurally: it
+ * is the sibling immediately before the panel that holds the Timeline.
  */
 async function timelineHandlePoint(page: Page): Promise<Point> {
   const point = await page.evaluate(() => {
@@ -81,12 +85,13 @@ async function locateText(page: Page, needle: string): Promise<Point> {
   return box;
 }
 
-export async function runScenario({ page, cursor }: ScenarioContext) {
+export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   const runButton = page.getByRole("button", { name: "Run", exact: true });
   const pauseButton = page.getByRole("button", { name: "Pause", exact: true });
   const stepButton = page.getByRole("button", { name: "Step", exact: true });
   const resetButton = page.getByRole("button", { name: "Reset", exact: true });
   const speedSelect = page.getByLabel("Playback speed");
+  const infoButton = page.locator('[data-onboarding-step="info"]');
   // The program picker is rendered twice, for the desktop and mobile layouts.
   const programSelect = page
     .locator('select[data-onboarding-step="programSelect"]')
@@ -114,86 +119,88 @@ export async function runScenario({ page, cursor }: ScenarioContext) {
     undefined,
     { timeout: 120_000 },
   );
-  await cursor.pause(1200);
+  mark("ready");
+  await cursor.pause(900);
 
-  // --- Act 1: slow the clock down, run, and pause mid-flight ---------------
-  await cursor.moveTo({ x: 320, y: 300 });
-  await cursor.pause(800);
-
+  // --- Act 1: slow the clock, run, and read the three views ----------------
   await cursor.select(speedSelect, "0.25");
-  await cursor.pause(600);
+  await cursor.pause(400);
 
   await cursor.click(runButton);
   await untilStatus("running");
-  await cursor.pause(900);
+  await cursor.pause(600);
 
-  // Pause early rather than after the panel tour below: the tour takes longer
-  // than this program runs, and pausing a finished program is not a thing.
+  // Paused first: the panel tour takes longer than this program runs, and a
+  // still frame is the one a viewer can actually read.
   await cursor.click(pauseButton);
   await untilStatus("paused");
+  await cursor.pause(600);
+
+  await cursor.moveToLocator(fiberTree);
+  await cursor.pause(900);
+  await cursor.moveToLocator(executionLog);
+  await cursor.pause(900);
+  await cursor.moveToLocator(timeline);
   await cursor.pause(900);
 
-  // Walk the three panels. Holding the runtime still while the pointer moves
-  // also gives the viewer a frame stable enough to actually read.
-  await cursor.moveToLocator(fiberTree);
-  await cursor.pause(1300);
-  await cursor.moveToLocator(executionLog);
-  await cursor.pause(1300);
-  await cursor.moveToLocator(timeline);
-  await cursor.pause(1300);
-
-  // Drag the separator above the Timeline up, to give the lanes more room and
-  // to show that the panels are resizable.
+  // Panels are resizable: give the timeline lanes more room.
   await cursor.drag(await timelineHandlePoint(page), { x: 0, y: -25 });
-  await cursor.pause(1200);
+  await cursor.pause(700);
+  mark("act 1 — run and inspect");
 
   // --- Act 2: step the runtime forward one event at a time -----------------
-  for (let i = 0; i < 4; i++) {
+  for (let i = 0; i < 3; i++) {
     await cursor.click(stepButton);
-    await cursor.pause(700);
+    await cursor.pause(550);
   }
 
   await cursor.click(runButton);
   await untilStatus("finished");
-  await cursor.pause(2000);
+  await cursor.pause(1200);
+  mark("act 2 — pause and step");
 
   // --- Act 3: edit the program and re-run it -------------------------------
   await cursor.click(resetButton);
-  await cursor.pause(800);
+  await cursor.pause(500);
 
   await cursor.select(speedSelect, "1");
-  await cursor.pause(400);
+  await cursor.pause(300);
 
   const delay = await locateText(page, "1.5");
   await cursor.moveTo({ x: delay.x + 2, y: delay.y });
-  await cursor.pause(300);
+  await cursor.pause(250);
   await page.mouse.down();
   await page.mouse.up();
-  await cursor.pause(500);
+  await cursor.pause(400);
   // Select the three characters of "1.5" and retype the duration, so the video
   // shows a live editor rather than a syntax-highlighted screenshot.
   for (let i = 0; i < 3; i++) await page.keyboard.press("Shift+ArrowRight");
-  await cursor.pause(400);
-  await page.keyboard.type("4", { delay: 120 });
-  await cursor.pause(1400);
+  await cursor.pause(300);
+  await page.keyboard.type("4", { delay: 110 });
+  await cursor.pause(900);
 
   await cursor.click(runButton);
   await untilStatus("finished");
-  await cursor.pause(2000);
+  await cursor.pause(1400);
+  mark("act 3 — edit and re-run");
 
-  // --- Act 4: a second program, to show the catalogue ----------------------
+  // --- Act 4: a second program, ending on its interrupted fibers -----------
   await cursor.click(resetButton);
-  await cursor.pause(600);
+  await cursor.pause(400);
 
   await cursor.select(programSelect, "structuredInterruption");
-  await cursor.pause(1600);
+  await cursor.pause(1100);
 
   await cursor.click(runButton);
   await untilStatus("finished");
-  await cursor.pause(1200);
+  await cursor.pause(800);
 
-  // Ends on the fiber tree, where the interrupted children are the point of
-  // this program.
   await cursor.moveToLocator(fiberTree);
-  await cursor.pause(2500);
+  await cursor.pause(1800);
+  mark("act 4 — second program");
+
+  // --- Close on the about box, the way the hand-made video did -------------
+  await cursor.click(infoButton);
+  await cursor.pause(2600);
+  mark("act 5 — about");
 }

--- a/scripts/demo/scenario.ts
+++ b/scripts/demo/scenario.ts
@@ -58,31 +58,100 @@ async function timelineHandlePoint(page: Page): Promise<Point> {
 /**
  * Finds where a piece of text sits on screen inside Monaco.
  *
- * Monaco splits a line across many spans and re-renders them on scroll, so a
- * CSS selector cannot address a token. Walking the text nodes and measuring a
- * `Range` finds the token wherever the editor happened to put it.
+ * Three things make this harder than a CSS selector. Monaco splits a line
+ * across a span per token, so the text being searched for is rarely inside a
+ * single node; it renders only the lines near the viewport, so anything below
+ * the fold is absent from the DOM entirely; and the page holds a second,
+ * zero-sized editor whose content would otherwise match first.
+ *
+ * `within` disambiguates: pass a longer string that contains `needle` when the
+ * needle alone would match somewhere else on screen. Searching for "5" in the
+ * retry program finds `if (n < 5)` long before `Schedule.recurs(5)`.
  */
-async function locateText(page: Page, needle: string): Promise<Point> {
-  const box = await page.evaluate((text: string) => {
-    const lines = document.querySelector(".view-lines");
-    if (!lines) return null;
+async function locateText(
+  page: Page,
+  needle: string,
+  { within }: { within?: string } = {},
+): Promise<Point | null> {
+  return page.evaluate(
+    ({ needle, within }: { needle: string; within?: string }) => {
+      const editor = [...document.querySelectorAll(".view-lines")].find(
+        (el) => el.getBoundingClientRect().height > 0,
+      );
+      if (!editor) return null;
 
-    const walker = document.createTreeWalker(lines, NodeFilter.SHOW_TEXT);
-    for (let node = walker.nextNode(); node; node = walker.nextNode()) {
-      const index = node.textContent?.indexOf(text) ?? -1;
-      if (index < 0) continue;
+      // Monaco renders indentation and gaps as non-breaking spaces, so a needle
+      // typed with ordinary spaces never matches the DOM text. Substituting one
+      // character for another keeps every offset below valid.
+      const normalise = (value: string) => value.replace(/\u00A0/g, " ");
 
-      const range = document.createRange();
-      range.setStart(node, index);
-      range.setEnd(node, index + text.length);
-      const rect = range.getBoundingClientRect();
-      return { x: rect.left, y: rect.top + rect.height / 2 };
-    }
-    return null;
-  }, needle);
+      const context = normalise(within ?? needle);
+      const offsetInContext = within ? context.indexOf(normalise(needle)) : 0;
+      if (offsetInContext < 0) return null;
 
-  if (!box) throw new Error(`Cannot find "${needle}" in the editor`);
-  return box;
+      for (const line of editor.querySelectorAll(".view-line")) {
+        const text = normalise(line.textContent ?? "");
+        const at = text.indexOf(context);
+        if (at < 0) continue;
+
+        // Map a character offset in the line onto the text node that holds it.
+        const target = at + offsetInContext;
+        const walker = document.createTreeWalker(line, NodeFilter.SHOW_TEXT);
+        let seen = 0;
+        for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+          const length = node.textContent?.length ?? 0;
+          if (seen + length > target) {
+            const range = document.createRange();
+            range.setStart(node, target - seen);
+            // The needle can spill into the next span; clamping to this node is
+            // enough, because only the left edge of the rect is used.
+            range.setEnd(node, Math.min(length, target - seen + needle.length));
+            const rect = range.getBoundingClientRect();
+            return { x: rect.left, y: rect.top + rect.height / 2 };
+          }
+          seen += length;
+        }
+      }
+      return null;
+    },
+    { needle, within },
+  );
+}
+
+/**
+ * Scrolls the editor until a piece of text is rendered, then returns its
+ * position. Monaco virtualises, so a target below the fold has to be brought
+ * into the DOM before it can be pointed at.
+ */
+async function revealText(
+  page: Page,
+  cursor: Cursor,
+  needle: string,
+  options: { within?: string } = {},
+): Promise<Point> {
+  const found = await locateText(page, needle, options);
+  if (found) return found;
+
+  // The wheel acts on whatever is under the pointer, so it has to be over the
+  // editor before scrolling, not wherever the last beat left it.
+  const editorBox = await page
+    .locator(".view-lines")
+    .filter({ visible: true })
+    .first()
+    .boundingBox();
+  if (editorBox) {
+    await cursor.moveTo({
+      x: editorBox.x + editorBox.width / 2,
+      y: editorBox.y + editorBox.height / 3,
+    });
+  }
+
+  for (let attempt = 0; attempt < 6; attempt++) {
+    await cursor.scroll(300, { steps: 4 });
+    const point = await locateText(page, needle, options);
+    if (point) return point;
+  }
+  throw new Error(`Cannot reach "${needle}" in the editor`);
 }
 
 export async function runScenario({ page, cursor, mark }: ScenarioContext) {
@@ -122,85 +191,108 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   mark("ready");
   await cursor.pause(900);
 
-  // --- Act 1: slow the clock, run, and read the three views ----------------
-  await cursor.select(speedSelect, "0.25");
-  await cursor.pause(400);
+  // --- Act 1: run it once at full speed and read the three views -----------
+  await cursor.click(runButton);
+  await untilStatus("finished");
+  await cursor.pause(500);
+
+  await cursor.moveToLocator(fiberTree);
+  await cursor.pause(520);
+  await cursor.moveToLocator(executionLog);
+  await cursor.pause(520);
+  await cursor.moveToLocator(timeline);
+  await cursor.pause(430);
+
+  // Panels are resizable: give the timeline lanes more room.
+  await cursor.drag(
+    await timelineHandlePoint(page),
+    { x: 0, y: -25 },
+    { duration: 600 },
+  );
+  await cursor.pause(350);
+  mark("act 1 — run and inspect");
+
+  // --- Act 2: same program, slower clock, then step through it -------------
+  // The speed change lands between two runs of the same program on purpose:
+  // the only thing that differs is how long it takes, which is the point.
+  await cursor.select(speedSelect, "0.5");
+  await cursor.pause(300);
 
   await cursor.click(runButton);
   await untilStatus("running");
   await cursor.pause(600);
 
-  // Paused first: the panel tour takes longer than this program runs, and a
-  // still frame is the one a viewer can actually read.
   await cursor.click(pauseButton);
   await untilStatus("paused");
-  await cursor.pause(600);
+  await cursor.pause(500);
 
-  await cursor.moveToLocator(fiberTree);
-  await cursor.pause(900);
-  await cursor.moveToLocator(executionLog);
-  await cursor.pause(900);
-  await cursor.moveToLocator(timeline);
-  await cursor.pause(900);
-
-  // Panels are resizable: give the timeline lanes more room.
-  await cursor.drag(await timelineHandlePoint(page), { x: 0, y: -25 });
-  await cursor.pause(700);
-  mark("act 1 — run and inspect");
-
-  // --- Act 2: step the runtime forward one event at a time -----------------
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 2; i++) {
     await cursor.click(stepButton);
-    await cursor.pause(550);
+    await cursor.pause(380);
   }
 
   await cursor.click(runButton);
   await untilStatus("finished");
-  await cursor.pause(1200);
-  mark("act 2 — pause and step");
+  await cursor.pause(700);
+  mark("act 2 — slow down and step");
 
-  // --- Act 3: edit the program and re-run it -------------------------------
+  // --- Act 3: the editor is live, and it knows the types -------------------
   await cursor.click(resetButton);
-  await cursor.pause(500);
-
+  await cursor.pause(400);
   await cursor.select(speedSelect, "1");
   await cursor.pause(300);
 
-  const delay = await locateText(page, "1.5");
-  await cursor.moveTo({ x: delay.x + 2, y: delay.y });
+  const worker = await revealText(page, cursor, "worker1", {
+    within: "const worker1",
+  });
+  await cursor.hover(worker, 850);
+
+  // Renaming a span keeps the run the same length, and the new name comes back
+  // out of the runtime in the execution log — which is the point being made.
+  const span = await revealText(page, cursor, "task", {
+    within: "worker-1-task",
+  });
+  await cursor.doubleClick({ x: span.x + 3, y: span.y });
   await cursor.pause(250);
-  await page.mouse.down();
-  await page.mouse.up();
-  await cursor.pause(400);
-  // Select the three characters of "1.5" and retype the duration, so the video
-  // shows a live editor rather than a syntax-highlighted screenshot.
-  for (let i = 0; i < 3; i++) await page.keyboard.press("Shift+ArrowRight");
-  await cursor.pause(300);
-  await page.keyboard.type("4", { delay: 110 });
-  await cursor.pause(900);
+  await page.keyboard.type("job", { delay: 110 });
+  await cursor.pause(600);
 
   await cursor.click(runButton);
   await untilStatus("finished");
-  await cursor.pause(1400);
+  await cursor.pause(650);
   mark("act 3 — edit and re-run");
 
-  // --- Act 4: a second program, ending on its interrupted fibers -----------
+  // --- Act 4: break the retry policy and watch the run go red --------------
   await cursor.click(resetButton);
-  await cursor.pause(400);
+  await cursor.pause(250);
 
-  await cursor.select(programSelect, "structuredInterruption");
-  await cursor.pause(1100);
+  await cursor.select(programSelect, "retryExponentialBackoff");
+  await cursor.pause(700);
 
   await cursor.click(runButton);
   await untilStatus("finished");
-  await cursor.pause(800);
+  await cursor.pause(450);
+
+  // `flakyEffect` only succeeds once n >= 5, and the `if (n < 5)` guard is left
+  // alone, so cutting the schedule to three retries makes failure certain.
+  const recurs = await revealText(page, cursor, "5", {
+    within: "Schedule.recurs(5)",
+  });
+  await cursor.doubleClick({ x: recurs.x + 3, y: recurs.y });
+  await cursor.pause(300);
+  await page.keyboard.type("3", { delay: 110 });
+  await cursor.pause(450);
+
+  await cursor.click(runButton);
+  await untilStatus("finished");
+  await cursor.pause(700);
 
   await cursor.moveToLocator(fiberTree);
-  await cursor.pause(1800);
-  mark("act 4 — second program");
+  await cursor.pause(950);
+  mark("act 4 — break the retry policy");
 
   // --- Close on the about box, the way the hand-made video did -------------
   await cursor.click(infoButton);
-  await cursor.pause(2600);
+  await cursor.pause(1500);
   mark("act 5 — about");
 }

--- a/scripts/demo/scenario.ts
+++ b/scripts/demo/scenario.ts
@@ -18,6 +18,40 @@ interface ScenarioContext {
 }
 
 /**
+ * The grab point of the resize separator above the Timeline panel.
+ *
+ * Returns a point rather than a locator for two reasons. The separator is a
+ * zero-height element, which Playwright does not count as visible, and
+ * react-resizable-panels hit-tests pointers against a margin around it rather
+ * than against the element itself. The layout holds several separators under
+ * library-generated ids, so this one is found structurally: it is the sibling
+ * immediately before the panel that holds the Timeline.
+ */
+async function timelineHandlePoint(page: Page): Promise<Point> {
+  const point = await page.evaluate(() => {
+    // Panels nest, and every ancestor of the Timeline contains its text too.
+    // Document order puts ancestors first, so the innermost match is the last.
+    const timelinePanels = [
+      ...document.querySelectorAll('[data-slot="resizable-panel"]'),
+    ].filter((panel) => {
+      const rect = panel.getBoundingClientRect();
+      // The mobile layout is rendered too, collapsed to zero size.
+      if (rect.width === 0 || rect.height === 0) return false;
+      return panel.textContent?.includes("Visualize concurrency, delays");
+    });
+
+    const handle = timelinePanels.at(-1)?.previousElementSibling;
+    if (handle?.getAttribute("role") !== "separator") return null;
+
+    const rect = handle.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top };
+  });
+
+  if (!point) throw new Error("Cannot find the Timeline resize handle");
+  return point;
+}
+
+/**
  * Finds where a piece of text sits on screen inside Monaco.
  *
  * Monaco splits a line across many spans and re-renders them on scroll, so a
@@ -83,7 +117,7 @@ export async function runScenario({ page, cursor }: ScenarioContext) {
   await cursor.pause(1200);
 
   // --- Act 1: slow the clock down, run, and pause mid-flight ---------------
-  await cursor.moveTo({ x: 320, y: 300 }, 900);
+  await cursor.moveTo({ x: 320, y: 300 });
   await cursor.pause(800);
 
   await cursor.select(speedSelect, "0.25");
@@ -101,16 +135,21 @@ export async function runScenario({ page, cursor }: ScenarioContext) {
 
   // Walk the three panels. Holding the runtime still while the pointer moves
   // also gives the viewer a frame stable enough to actually read.
-  await cursor.moveToLocator(fiberTree, 900);
+  await cursor.moveToLocator(fiberTree);
   await cursor.pause(1300);
-  await cursor.moveToLocator(executionLog, 800);
+  await cursor.moveToLocator(executionLog);
   await cursor.pause(1300);
-  await cursor.moveToLocator(timeline, 800);
+  await cursor.moveToLocator(timeline);
   await cursor.pause(1300);
+
+  // Drag the separator above the Timeline up, to give the lanes more room and
+  // to show that the panels are resizable.
+  await cursor.drag(await timelineHandlePoint(page), { x: 0, y: -25 });
+  await cursor.pause(1200);
 
   // --- Act 2: step the runtime forward one event at a time -----------------
   for (let i = 0; i < 4; i++) {
-    await cursor.click(stepButton, { duration: 300 });
+    await cursor.click(stepButton);
     await cursor.pause(700);
   }
 
@@ -126,7 +165,7 @@ export async function runScenario({ page, cursor }: ScenarioContext) {
   await cursor.pause(400);
 
   const delay = await locateText(page, "1.5");
-  await cursor.moveTo({ x: delay.x + 2, y: delay.y }, 800);
+  await cursor.moveTo({ x: delay.x + 2, y: delay.y });
   await cursor.pause(300);
   await page.mouse.down();
   await page.mouse.up();
@@ -155,6 +194,6 @@ export async function runScenario({ page, cursor }: ScenarioContext) {
 
   // Ends on the fiber tree, where the interrupted children are the point of
   // this program.
-  await cursor.moveToLocator(fiberTree, 900);
+  await cursor.moveToLocator(fiberTree);
   await cursor.pause(2500);
 }

--- a/scripts/demo/scenario.ts
+++ b/scripts/demo/scenario.ts
@@ -151,7 +151,10 @@ async function revealText(
     const point = await locateText(page, needle, options);
     if (point) return point;
   }
-  throw new Error(`Cannot reach "${needle}" in the editor`);
+  throw new Error(
+    `Cannot reach "${needle}" in the editor. Scrolling only goes down from ` +
+      "where the editor already is, so a target above the fold is out of reach.",
+  );
 }
 
 /**
@@ -211,6 +214,27 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   /** Blocks until the playback bar reports a state, so beats never race the run. */
   const untilStatus = (state: string, timeout = 60_000) =>
     status.filter({ hasText: new RegExp(`^${state}$`) }).waitFor({ timeout });
+
+  const untilNotStatus = (state: string, timeout = 30_000) =>
+    status
+      .filter({ hasNotText: new RegExp(`^${state}$`) })
+      .waitFor({ timeout });
+
+  /**
+   * Runs the program and waits for *this* run to end.
+   *
+   * Waiting for `finished` on its own is only safe from a standing start. Press
+   * Run on a program that has already finished and the status still reads
+   * `finished` at the moment of the press, so the wait would return before the
+   * new run had produced anything, and the beat after it would describe the
+   * previous run's results. Watching the status leave that state first anchors
+   * the wait to this press; from `idle` or `paused` it passes straight through.
+   */
+  const runToCompletion = async () => {
+    await cursor.click(runButton);
+    await untilNotStatus("finished");
+    await untilStatus("finished");
+  };
 
   // The WebContainer boots before anything can run, and Run stays disabled
   // until it is ready, which makes it the readiness signal.
@@ -276,8 +300,7 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
     await cursor.pause(380);
   }
 
-  await cursor.click(runButton);
-  await untilStatus("finished");
+  await runToCompletion();
   await cursor.pause(700);
   mark("act 2 — slow down and step");
 
@@ -300,8 +323,7 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   await page.keyboard.type("job", { delay: 110 });
   await cursor.pause(550);
 
-  await cursor.click(runButton);
-  await untilStatus("finished");
+  await runToCompletion();
   await cursor.pause(650);
   mark("act 3 — edit and re-run");
 
@@ -312,8 +334,7 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   await cursor.select(programSelect, "retryExponentialBackoff");
   await cursor.pause(350);
 
-  await cursor.click(runButton);
-  await untilStatus("finished");
+  await runToCompletion();
   await cursor.pause(450);
 
   // `flakyEffect` only succeeds once n >= 5, and the `if (n < 5)` guard is left
@@ -326,8 +347,7 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   await page.keyboard.type("3", { delay: 110 });
   await cursor.pause(450);
 
-  await cursor.click(runButton);
-  await untilStatus("finished");
+  await runToCompletion();
   await cursor.pause(700);
 
   await cursor.moveToLocator(fiberTree);

--- a/scripts/demo/scenario.ts
+++ b/scripts/demo/scenario.ts
@@ -1,0 +1,160 @@
+/**
+ * The scripted feature tour recorded for the README.
+ *
+ * Edit this file to change what the video shows; `record.ts` only drives it.
+ * Beats are deliberate: every click is followed by a hold long enough for a
+ * viewer to read what changed before the pointer moves on.
+ */
+
+import type { Page } from "playwright";
+
+import type { Cursor, Point } from "./cursor.ts";
+
+export const VIEWPORT = { width: 1440, height: 810 };
+
+interface ScenarioContext {
+  page: Page;
+  cursor: Cursor;
+}
+
+/**
+ * Finds where a piece of text sits on screen inside Monaco.
+ *
+ * Monaco splits a line across many spans and re-renders them on scroll, so a
+ * CSS selector cannot address a token. Walking the text nodes and measuring a
+ * `Range` finds the token wherever the editor happened to put it.
+ */
+async function locateText(page: Page, needle: string): Promise<Point> {
+  const box = await page.evaluate((text: string) => {
+    const lines = document.querySelector(".view-lines");
+    if (!lines) return null;
+
+    const walker = document.createTreeWalker(lines, NodeFilter.SHOW_TEXT);
+    for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+      const index = node.textContent?.indexOf(text) ?? -1;
+      if (index < 0) continue;
+
+      const range = document.createRange();
+      range.setStart(node, index);
+      range.setEnd(node, index + text.length);
+      const rect = range.getBoundingClientRect();
+      return { x: rect.left, y: rect.top + rect.height / 2 };
+    }
+    return null;
+  }, needle);
+
+  if (!box) throw new Error(`Cannot find "${needle}" in the editor`);
+  return box;
+}
+
+export async function runScenario({ page, cursor }: ScenarioContext) {
+  const runButton = page.getByRole("button", { name: "Run", exact: true });
+  const pauseButton = page.getByRole("button", { name: "Pause", exact: true });
+  const stepButton = page.getByRole("button", { name: "Step", exact: true });
+  const resetButton = page.getByRole("button", { name: "Reset", exact: true });
+  const speedSelect = page.getByLabel("Playback speed");
+  // The program picker is rendered twice, for the desktop and mobile layouts.
+  const programSelect = page
+    .locator('select[data-onboarding-step="programSelect"]')
+    .first();
+  const status = page.getByTestId("playback-status");
+  // Each panel title exists several times over: the desktop and mobile layouts
+  // are both rendered, and only one of them is on screen.
+  const panelTitle = (name: string) =>
+    page.getByText(name, { exact: true }).filter({ visible: true }).first();
+  const fiberTree = panelTitle("Fiber Tree");
+  const executionLog = panelTitle("Execution Log");
+  const timeline = panelTitle("Timeline");
+
+  /** Blocks until the playback bar reports a state, so beats never race the run. */
+  const untilStatus = (state: string, timeout = 60_000) =>
+    status.filter({ hasText: new RegExp(`^${state}$`) }).waitFor({ timeout });
+
+  // The WebContainer boots before anything can run, and Run stays disabled
+  // until it is ready, which makes it the readiness signal.
+  await runButton.waitFor({ state: "visible" });
+  await page.waitForFunction(
+    () =>
+      !document.querySelector<HTMLButtonElement>('button[aria-label="Run"]')
+        ?.disabled,
+    undefined,
+    { timeout: 120_000 },
+  );
+  await cursor.pause(1200);
+
+  // --- Act 1: slow the clock down, run, and pause mid-flight ---------------
+  await cursor.moveTo({ x: 320, y: 300 }, 900);
+  await cursor.pause(800);
+
+  await cursor.select(speedSelect, "0.25");
+  await cursor.pause(600);
+
+  await cursor.click(runButton);
+  await untilStatus("running");
+  await cursor.pause(900);
+
+  // Pause early rather than after the panel tour below: the tour takes longer
+  // than this program runs, and pausing a finished program is not a thing.
+  await cursor.click(pauseButton);
+  await untilStatus("paused");
+  await cursor.pause(900);
+
+  // Walk the three panels. Holding the runtime still while the pointer moves
+  // also gives the viewer a frame stable enough to actually read.
+  await cursor.moveToLocator(fiberTree, 900);
+  await cursor.pause(1300);
+  await cursor.moveToLocator(executionLog, 800);
+  await cursor.pause(1300);
+  await cursor.moveToLocator(timeline, 800);
+  await cursor.pause(1300);
+
+  // --- Act 2: step the runtime forward one event at a time -----------------
+  for (let i = 0; i < 4; i++) {
+    await cursor.click(stepButton, { duration: 300 });
+    await cursor.pause(700);
+  }
+
+  await cursor.click(runButton);
+  await untilStatus("finished");
+  await cursor.pause(2000);
+
+  // --- Act 3: edit the program and re-run it -------------------------------
+  await cursor.click(resetButton);
+  await cursor.pause(800);
+
+  await cursor.select(speedSelect, "1");
+  await cursor.pause(400);
+
+  const delay = await locateText(page, "1.5");
+  await cursor.moveTo({ x: delay.x + 2, y: delay.y }, 800);
+  await cursor.pause(300);
+  await page.mouse.down();
+  await page.mouse.up();
+  await cursor.pause(500);
+  // Select the three characters of "1.5" and retype the duration, so the video
+  // shows a live editor rather than a syntax-highlighted screenshot.
+  for (let i = 0; i < 3; i++) await page.keyboard.press("Shift+ArrowRight");
+  await cursor.pause(400);
+  await page.keyboard.type("4", { delay: 120 });
+  await cursor.pause(1400);
+
+  await cursor.click(runButton);
+  await untilStatus("finished");
+  await cursor.pause(2000);
+
+  // --- Act 4: a second program, to show the catalogue ----------------------
+  await cursor.click(resetButton);
+  await cursor.pause(600);
+
+  await cursor.select(programSelect, "structuredInterruption");
+  await cursor.pause(1600);
+
+  await cursor.click(runButton);
+  await untilStatus("finished");
+  await cursor.pause(1200);
+
+  // Ends on the fiber tree, where the interrupted children are the point of
+  // this program.
+  await cursor.moveToLocator(fiberTree, 900);
+  await cursor.pause(2500);
+}

--- a/scripts/demo/scenario.ts
+++ b/scripts/demo/scenario.ts
@@ -207,7 +207,6 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
     page.getByText(name, { exact: true }).filter({ visible: true }).first();
   const fiberTree = panelTitle("Fiber Tree");
   const executionLog = panelTitle("Execution Log");
-  const timeline = panelTitle("Timeline");
 
   /** Blocks until the playback bar reports a state, so beats never race the run. */
   const untilStatus = (state: string, timeout = 60_000) =>
@@ -229,13 +228,25 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   // --- Act 1: run it once at full speed and read the three views -----------
   await cursor.click(runButton);
 
-  // Ask the editor for a type while the program runs. The answer takes about as
-  // long as the run does, so this beat costs nothing, and it warms the language
-  // service for the edit later on.
+  // Panels are resizable, and the Basic Example needs the room: at the default
+  // split the third fiber lane is cut off by the time axis. Fifty pixels puts
+  // all three on screen. Done while the program is still running, so the lanes
+  // arrive into a panel that already fits them.
+  await cursor.drag(
+    await timelineHandlePoint(page),
+    { x: 0, y: -50 },
+    { duration: 700 },
+  );
+  await cursor.pause(250);
+
+  // Ask the editor for a type. The first answer of a session takes seconds to
+  // come back, which is why the beat is held on the content rather than on a
+  // timer; it also warms the language service for the edit in act 3.
   await hoverType(
     page,
     cursor,
     await revealText(page, cursor, "worker1", { within: "const worker1" }),
+    { hold: 700 },
   );
 
   await untilStatus("finished");
@@ -244,19 +255,7 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   await cursor.moveToLocator(fiberTree);
   await cursor.pause(520);
   await cursor.moveToLocator(executionLog);
-  await cursor.pause(520);
-  await cursor.moveToLocator(timeline);
-  await cursor.pause(430);
-
-  // Panels are resizable, and the Basic Example needs the room: at the default
-  // split the third fiber lane is cut off by the time axis. Fifty pixels puts
-  // all three on screen at once.
-  await cursor.drag(
-    await timelineHandlePoint(page),
-    { x: 0, y: -50 },
-    { duration: 700 },
-  );
-  await cursor.pause(350);
+  await cursor.pause(560);
   mark("act 1 — run and inspect");
 
   // --- Act 2: same program, slower clock, then step through it -------------

--- a/scripts/demo/scenario.ts
+++ b/scripts/demo/scenario.ts
@@ -154,6 +154,41 @@ async function revealText(
   throw new Error(`Cannot reach "${needle}" in the editor`);
 }
 
+/**
+ * Hovers an identifier and holds until Monaco has a type to show.
+ *
+ * The widget opens well before it has an answer: the first hover of a session
+ * waits on the TypeScript worker to load the program, and reads "Loading..."
+ * for about two seconds meanwhile. Waiting on the content instead of guessing a
+ * dwell keeps the beat as short as the language service allows, and stops the
+ * video moving on while the tooltip is still empty.
+ */
+async function hoverType(
+  page: Page,
+  cursor: Cursor,
+  point: Point,
+  { hold = 900, timeout = 8_000 }: { hold?: number; timeout?: number } = {},
+) {
+  await cursor.moveTo(point);
+  await page
+    .waitForFunction(
+      () => {
+        const widget = [...document.querySelectorAll(".monaco-hover")].find(
+          (el) => el.getBoundingClientRect().height > 0,
+        );
+        const text = widget?.textContent?.trim();
+        return Boolean(text) && text !== "Loading...";
+      },
+      undefined,
+      { timeout },
+    )
+    .catch(() => {
+      // A missing tooltip is not worth failing a recording over; the beat just
+      // reads as a pause over the code.
+    });
+  await cursor.pause(hold);
+}
+
 export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   const runButton = page.getByRole("button", { name: "Run", exact: true });
   const pauseButton = page.getByRole("button", { name: "Pause", exact: true });
@@ -193,8 +228,18 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
 
   // --- Act 1: run it once at full speed and read the three views -----------
   await cursor.click(runButton);
+
+  // Ask the editor for a type while the program runs. The answer takes about as
+  // long as the run does, so this beat costs nothing, and it warms the language
+  // service for the edit later on.
+  await hoverType(
+    page,
+    cursor,
+    await revealText(page, cursor, "worker1", { within: "const worker1" }),
+  );
+
   await untilStatus("finished");
-  await cursor.pause(500);
+  await cursor.pause(300);
 
   await cursor.moveToLocator(fiberTree);
   await cursor.pause(520);
@@ -236,26 +281,25 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   await cursor.pause(700);
   mark("act 2 — slow down and step");
 
-  // --- Act 3: the editor is live, and it knows the types -------------------
+  // --- Act 3: the editor is live, and the runtime says so ------------------
   await cursor.click(resetButton);
   await cursor.pause(400);
   await cursor.select(speedSelect, "1");
   await cursor.pause(300);
 
-  const worker = await revealText(page, cursor, "worker1", {
-    within: "const worker1",
-  });
-  await cursor.hover(worker, 850);
-
-  // Renaming a span keeps the run the same length, and the new name comes back
+  // Renaming a span keeps the run the same length, and the new names come back
   // out of the runtime in the execution log — which is the point being made.
+  // Double-clicking selects one `task`; selecting every occurrence puts a caret
+  // on the second worker too, so one three-letter edit renames both spans.
   const span = await revealText(page, cursor, "task", {
     within: "worker-1-task",
   });
   await cursor.doubleClick({ x: span.x + 3, y: span.y });
   await cursor.pause(250);
+  await page.keyboard.press("ControlOrMeta+Shift+L");
+  await cursor.pause(650);
   await page.keyboard.type("job", { delay: 110 });
-  await cursor.pause(600);
+  await cursor.pause(550);
 
   await cursor.click(runButton);
   await untilStatus("finished");

--- a/src/components/layout/PlaybackControls.tsx
+++ b/src/components/layout/PlaybackControls.tsx
@@ -173,6 +173,7 @@ export function PlaybackControls({
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
+                aria-label="Reset"
                 variant="ghost"
                 size="icon"
                 onClick={onReset}
@@ -188,6 +189,7 @@ export function PlaybackControls({
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
+                aria-label={isRunning ? "Pause" : "Run"}
                 data-onboarding-step="play"
                 variant="ghost"
                 size="icon"
@@ -233,6 +235,7 @@ export function PlaybackControls({
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
+                aria-label="Step"
                 variant="ghost"
                 size="icon"
                 onClick={onStep}
@@ -292,7 +295,7 @@ export function PlaybackControls({
                 }
               `}
             />
-            <span className="capitalize">
+            <span data-testid="playback-status" className="capitalize">
               {isSyncing
                 ? "Syncing..."
                 : state === "starting"

--- a/tsconfig.demo.json
+++ b/tsconfig.demo.json
@@ -4,7 +4,7 @@
     "target": "ES2023",
     /* The demo scripts run on Node, but their `page.evaluate` callbacks are
        serialised and executed in the browser, so they need the DOM lib too. */
-    "lib": ["ES2023", "DOM"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "types": ["node"],
     "skipLibCheck": true,

--- a/tsconfig.demo.json
+++ b/tsconfig.demo.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.demo.tsbuildinfo",
+    "target": "ES2023",
+    /* The demo scripts run on Node, but their `page.evaluate` callbacks are
+       serialised and executed in the browser, so they need the DOM lib too. */
+    "lib": ["ES2023", "DOM"],
+    "module": "ESNext",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    /* Matches what `node --experimental-strip-types` can actually run. */
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["scripts/demo"]
+}


### PR DESCRIPTION
## Why

The feature video in the README was screen-recorded by hand. Re-recording it after a feature lands means redoing the whole take, so in practice it never gets redone. This makes the tour a file you edit: `scripts/demo/scenario.ts` says what the video shows, and `npm run demo:record` replays it in a real browser and encodes an mp4.

The scripted tour reproduces the hand-made one act for act and adds the controls that postdate it — speed, pause, step, reset — in 58.8s.

## What is here

| File                            | Role                                                                                       |
| ------------------------------- | ------------------------------------------------------------------------------------------ |
| `scripts/demo/scenario.ts`      | The tour. The file to edit to change what the video shows.                                 |
| `scripts/demo/cursor.ts`        | The visible pointer: its glyphs, easing and gestures.                                      |
| `scripts/demo/record.ts`        | Launches Chromium, captures, trims the boot, encodes with ffmpeg. Run by `demo:record`.    |
| `scripts/demo/original-demo.md` | Frame-by-frame reconstruction of the hand-made video, the reference the scenario targets.  |
| `scripts/demo/README.md`        | How to run it, and how to write a beat that survives a slow machine.                       |

Output lands in `recordings/` (gitignored).

## The visible pointer

Playwright sends input through the DevTools Protocol, which never moves the operating system pointer, so a `recordVideo` capture shows no cursor at all — the app reacts to clicks that come from nowhere. `installCursor` in `cursor.ts` injects an SVG pointer into every document through `context.addInitScript` and slaves it to the event stream. Three things it does that matter:

- It listens to **pointer** events, not mouse events. `react-resizable-panels` calls `preventDefault()` on the pointer stream for the length of a drag, which suppresses the compatibility mouse events, so a mouse-driven overlay freezes exactly when the panel is being dragged.
- The glyph follows the computed CSS `cursor` under the point, so the recording shows an I-beam over Monaco and a resize cursor over a panel separator.
- Moves are paced at a roughly constant 0.5px/ms rather than a fixed duration. A 450px traverse given 300ms advances 60px per frame at 25fps, which the eye reads as a teleport.

## The tour

| At    | Act                    | Shows                                                                                                                                                                                                                              |
| ----- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 0.0s  | ready                  | WebContainer boot, trimmed to a glimpse.                                                                                                                                                                                           |
| 11.2s | run and inspect        | One click fills all three views. The Timeline is dragged 50px taller mid-run, because at the default split the third fiber lane sits under the time axis. A type hover answers `const worker1: Fiber.RuntimeFiber<string, never>`.   |
| 23.9s | slow down and step     | Speed to 0.5x, pause, two steps, resume.                                                                                                                                                                                           |
| 35.7s | edit and re-run        | Double-click `task`, select every occurrence, and one three-letter edit renames both worker spans — which come back out of the runtime as `worker-1-job` and `worker-2-job` in the log.                                              |
| 54.7s | break the retry policy | Switch to the retry program, cut `Schedule.recurs(5)` to `3`, and the green run goes red across all three views at once.                                                                                                            |
| 58.1s | about                  | Closes on the info modal, as the original did.                                                                                                                                                                                     |

Beats wait on app state (`untilStatus("finished")`), never on a guessed timeout, so the tour survives a slow machine. `record.ts` prints that table on every run, which is what keeps the video under a minute — trimming is measured, not guessed.

## Result

The take below is what `npm run demo:record` produced from this branch: 58.8s, 1440x810, 25fps, 4.1 MB.


https://github.com/user-attachments/assets/55d7d382-fdb4-4ad1-8948-8802f995e557



## Install and CI

`npm install` gains the `playwright` package but **not** the browser it drives. `npm run demo:prepare` downloads that, once, and is deliberately not a `postinstall`: nothing but this script needs a browser, least of all CI. `record.ts` names that script in its error if the browser is missing.

CI's `npm run typecheck` now also covers `scripts/demo` through `tsconfig.demo.json` — three files, no browser, no recording. `erasableSyntaxOnly` is on there, because the scripts run under `node --experimental-strip-types`.

## One change outside the scripts

`PlaybackControls.tsx` gains `aria-label` on Reset, Run/Pause and Step, and `data-testid="playback-status"` on the state text. Those buttons are icon-only with a tooltip, which is not an accessible name, so there was nothing stable for the scenario to target — and nothing for a screen reader to announce either. No visual change.

## Running it

```sh
npm run demo:prepare               # once per machine
npm run build && npm run preview   # in one terminal
npm run demo:record
```

The recorder targets the preview server at `http://localhost:4173`, which is why the build comes first: the WebContainer boots far faster against a build than under the dev server, and that boot is dead time at the head of the video. `--url=` overrides the target, `--headed` shows the browser, `--keep-webm` keeps the raw capture. ffmpeg has to be on the `PATH` for the mp4; without it the `.webm` is kept instead.
