### PR TITLE
chore: point the tour at the stepper, and refresh the docs for v3

### DIFF
--- a/.env
+++ b/.env
@@ -4,5 +4,7 @@ VITE_DESCRIPTION=Visualize Effect.ts code execution in the browser
 VITE_TWITTER_USERNAME=@topheman
 VITE_WEBSITE_URL=https://effect-viz.vercel.app
 
-# Onboarding localStorage version (must be a number). Bump to reset all users' onboarding.
-VITE_ONBOARDING_VERSION=1
+# Onboarding localStorage version (must be a number). Bump when adding a step, and
+# give the new step that version in useOnboarding.ts: returning users are then shown
+# it alone rather than the whole tour again.
+VITE_ONBOARDING_VERSION=2

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -5,6 +5,8 @@
 ## Current Phase
 **Phase 10**: COMPLETE ✅ — slow mode & stepper (issue #13). All steps done: VirtualClock, Effect Clock layer, Date shim, virtual timestamps, GatedScheduler + step ladder, control channel for the WebContainer, speed combo + stepper controls, origin tagging with show-internals toggle, and five new example programs.
 
+**Deferred**: Step Over — running to the end of the current span rather than stopping at every event inside it — is not implemented, and `PlaybackControls` carries no button for it.
+
 **Maintenance**: [#18](https://github.com/topheman/effect-viz/issues/18) — `effect` is on 3.22.1 on both run paths, and the Effect LSP is installed. Only the Timeout example traces differently: the work that overruns the deadline now ends as `fiber:end`, since Effect runs it under `Effect.exit`. See [`workshop/effect-3.22-upgrade.md`](workshop/effect-3.22-upgrade.md).
 
 **Recent**: five new examples teach what no sleep-shaped program could — `Effect.yieldNow` interleaving, bounded concurrency, structured interruption, timeout on the shared clock, and a Deferred deadlock that reaches the stepper's `noProgress`. See [`workshop/phase-10.md`](workshop/phase-10.md).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is a visualizer for Effect runtime.
 
 It allows you to **visualize** the execution of Effect code in the browser, and **edit** the example programs.
 
+You can **slow down** a program so that its sleeps stretch out, or **pause** it and **step** through it one event at a time.
+
 This project is a learning project for me to understand the Effect runtime. My learning journey is documented in the [`workshop/`](./workshop/) folder, with each phase covering different Effect concepts (lazy evaluation, fibers, scheduling, errors, scopes). Check out the [AGENTS.md](./AGENTS.md) file for the AI approach.
 
 https://github.com/user-attachments/assets/52c76062-61e9-47fa-8b3d-6032ea8e8f90

--- a/package.json
+++ b/package.json
@@ -15,13 +15,15 @@
     "url": "https://github.com/topheman/effect-viz/issues"
   },
   "keywords": [
-    "vite",
+    "effect",
+    "effect-ts",
+    "visualizer",
+    "fibers",
+    "stepper",
+    "webcontainer",
     "react",
     "typescript",
-    "tailwindcss",
-    "testing",
-    "linting",
-    "formatting"
+    "vite"
   ],
   "scripts": {
     "dev": "npm run copy:esbuild-wasm && npm run build:runtime && vite",

--- a/scripts/demo/record.ts
+++ b/scripts/demo/record.ts
@@ -20,7 +20,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdir, readdir, rm, rename } from "node:fs/promises";
+import { mkdir, readdir, readFile, rm, rename } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -37,6 +37,17 @@ const OUT_DIR = path.join(ROOT, "recordings");
 
 /** How much of the WebContainer boot to keep at the head of the video. */
 const BOOT_LEAD_IN_SECONDS = 0.8;
+
+/**
+ * The version the app is built with, read from the same `.env` the build reads.
+ * Seeding the tour as finished under an older version would leave the steps
+ * added since it pulsing through the recording.
+ */
+async function onboardingVersion(): Promise<number> {
+  const env = await readFile(path.join(ROOT, ".env"), "utf8");
+  const match = /^VITE_ONBOARDING_VERSION=(\d+)/m.exec(env);
+  return match ? Number(match[1]) : 1;
+}
 
 function flag(name: string): string | undefined {
   const match = process.argv
@@ -75,16 +86,19 @@ async function main() {
 
   // A fresh profile would start the onboarding tour, whose pulsing highlights
   // fight with the scripted pointer for the viewer's attention.
-  await context.addInitScript(() => {
-    localStorage.setItem(
-      "effect-flow-onboarding",
-      JSON.stringify({
-        completed: "info",
-        version: 1,
-        date: new Date().toISOString(),
-      }),
-    );
-  });
+  await context.addInitScript(
+    (version: number) => {
+      localStorage.setItem(
+        "effect-flow-onboarding",
+        JSON.stringify({
+          completed: "info",
+          version,
+          date: new Date().toISOString(),
+        }),
+      );
+    },
+    await onboardingVersion(),
+  );
 
   await installCursor(context);
 

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -268,10 +268,6 @@ export function MainLayout() {
     setPauseReason(outcome._tag === "noProgress" ? "stuck" : "user");
   };
 
-  const onStepOver = () => {
-    // TODO: Step over in Effect execution
-  };
-
   const onReset = () => {
     runIdRef.current++;
     setPlaybackState("idle");
@@ -471,7 +467,6 @@ export function MainLayout() {
         onPlay={onPlay}
         onPause={onPause}
         onStep={onStep}
-        onStepOver={onStepOver}
         onReset={onReset}
         showVisualizer={showVisualizer}
         onToggleVisualizer={() => setShowVisualizer(!showVisualizer)}

--- a/src/components/layout/PlaybackControls.tsx
+++ b/src/components/layout/PlaybackControls.tsx
@@ -3,7 +3,6 @@ import {
   Pause,
   Play,
   RotateCcw,
-  SkipForward,
   StepForward,
   Workflow,
 } from "lucide-react";
@@ -22,13 +21,6 @@ import { SPEED_OPTIONS, type Speed, formatSpeed } from "@/hooks/useSpeed";
 import { cn } from "@/lib/utils";
 
 import { InfoModal } from "./InfoModal";
-
-/**
- * Step Over — run to the end of the current span rather than stopping at every
- * event inside it — is not implemented. The button is built and stays hidden
- * until `MainLayout` has a handler with something to call.
- */
-const STEP_OVER_IS_IMPLEMENTED = false;
 
 export type PlaybackState =
   | "idle"
@@ -52,7 +44,6 @@ interface PlaybackControlsProps {
   onPlay?: () => void;
   onPause?: () => void;
   onStep?: () => void;
-  onStepOver?: () => void;
   onReset?: () => void;
   showVisualizer?: boolean;
   onToggleVisualizer?: () => void;
@@ -75,7 +66,6 @@ export function PlaybackControls({
   onPlay,
   onPause,
   onStep,
-  onStepOver,
   onReset,
   showVisualizer = true,
   onToggleVisualizer,
@@ -274,23 +264,6 @@ export function PlaybackControls({
                   : "Step"}
             </TooltipContent>
           </Tooltip>
-
-          {/* Step Over */}
-          {STEP_OVER_IS_IMPLEMENTED && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={onStepOver}
-                  disabled={!canStep}
-                >
-                  <SkipForward className="h-4 w-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Step Over</TooltipContent>
-            </Tooltip>
-          )}
 
           {/* Status indicator */}
           <div

--- a/src/components/layout/PlaybackControls.tsx
+++ b/src/components/layout/PlaybackControls.tsx
@@ -23,6 +23,11 @@ import { cn } from "@/lib/utils";
 
 import { InfoModal } from "./InfoModal";
 
+/**
+ * Step Over — run to the end of the current span rather than stopping at every
+ * event inside it — is not implemented. The button is built and stays hidden
+ * until `MainLayout` has a handler with something to call.
+ */
 const STEP_OVER_IS_IMPLEMENTED = false;
 
 export type PlaybackState =
@@ -236,10 +241,27 @@ export function PlaybackControls({
             <TooltipTrigger asChild>
               <Button
                 aria-label="Step"
+                data-onboarding-step="step"
                 variant="ghost"
                 size="icon"
-                onClick={onStep}
+                onClick={() => {
+                  onStep?.();
+                  onOnboardingComplete?.("step");
+                }}
                 disabled={!canStep}
+                className={cn(
+                  onboardingStep === "step" &&
+                    canStep &&
+                    "origin-center animate-onboarding-pulse",
+                )}
+                style={
+                  {
+                    "--onboarding-pulse-x": "0",
+                    "--onboarding-pulse-y": "-30%",
+                    zIndex:
+                      onboardingStep === "step" && canStep ? "100" : "auto",
+                  } as React.CSSProperties
+                }
               >
                 <StepForward className="h-4 w-4" />
               </Button>

--- a/src/hooks/useOnboarding.test.ts
+++ b/src/hooks/useOnboarding.test.ts
@@ -29,6 +29,12 @@ describe("useOnboarding", () => {
       result.current.completeStep("play");
     });
 
+    expect(result.current.currentStep).toBe("step");
+
+    act(() => {
+      result.current.completeStep("step");
+    });
+
     expect(result.current.currentStep).toBe("showVisualizer");
 
     act(() => {
@@ -62,7 +68,7 @@ describe("useOnboarding", () => {
     expect(raw).not.toBeNull();
     const stored = JSON.parse(raw!) as { completed: string; version: number };
     expect(stored.completed).toBe("play");
-    expect(stored.version).toBe(1);
+    expect(stored.version).toBe(2);
   });
 
   it("resumes from next step after reload (simulated)", () => {
@@ -72,12 +78,12 @@ describe("useOnboarding", () => {
       result1.current.completeStep("play");
     });
 
-    expect(result1.current.currentStep).toBe("showVisualizer");
+    expect(result1.current.currentStep).toBe("step");
 
     // Simulate reload: new hook instance reads from same localStorage
     const { result: result2 } = renderHook(() => useOnboarding());
 
-    expect(result2.current.currentStep).toBe("showVisualizer");
+    expect(result2.current.currentStep).toBe("step");
   });
 
   it("returns null when all steps completed (simulated)", () => {
@@ -85,6 +91,7 @@ describe("useOnboarding", () => {
 
     act(() => {
       result1.current.completeStep("play");
+      result1.current.completeStep("step");
       result1.current.completeStep("showVisualizer");
       result1.current.completeStep("programSelect");
       result1.current.completeStep("info");
@@ -105,19 +112,46 @@ describe("useOnboarding", () => {
     expect(result.current.currentStep).toBe("play");
   });
 
-  it("starts at play when stored version does not match", () => {
+  it("shows a step added since the stored version, then ends", () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
         completed: "info",
-        version: 999,
+        version: 1,
         date: new Date().toISOString(),
       }),
     );
 
     const { result } = renderHook(() => useOnboarding());
 
-    expect(result.current.currentStep).toBe("play");
+    expect(result.current.currentStep).toBe("step");
+
+    act(() => {
+      result.current.completeStep("step");
+    });
+
+    expect(result.current.currentStep).toBe(null);
+  });
+
+  it("keeps mid-tour progress made under an older version", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        completed: "programSelect",
+        version: 1,
+        date: new Date().toISOString(),
+      }),
+    );
+
+    const { result } = renderHook(() => useOnboarding());
+
+    expect(result.current.currentStep).toBe("step");
+
+    act(() => {
+      result.current.completeStep("step");
+    });
+
+    expect(result.current.currentStep).toBe("info");
   });
 
   it("does not go back when completing an earlier step", () => {
@@ -126,12 +160,12 @@ describe("useOnboarding", () => {
     act(() => {
       result.current.completeStep("play");
     });
-    expect(result.current.currentStep).toBe("showVisualizer");
+    expect(result.current.currentStep).toBe("step");
 
     act(() => {
       result.current.completeStep("play");
     });
-    expect(result.current.currentStep).toBe("showVisualizer");
+    expect(result.current.currentStep).toBe("step");
 
     const raw = localStorage.getItem(STORAGE_KEY);
     const stored = JSON.parse(raw!) as { completed: string };
@@ -143,6 +177,7 @@ describe("useOnboarding", () => {
 
     act(() => {
       result.current.completeStep("play");
+      result.current.completeStep("step");
       result.current.completeStep("showVisualizer");
       result.current.completeStep("programSelect");
       result.current.completeStep("info");

--- a/src/hooks/useOnboarding.ts
+++ b/src/hooks/useOnboarding.ts
@@ -9,6 +9,7 @@ const OnboardingStep = Schema.Literal(
   "showVisualizer",
   "programSelect",
   "info",
+  "step",
 );
 type OnboardingStep = Schema.Schema.Type<typeof OnboardingStep>;
 
@@ -19,17 +20,33 @@ const OnboardingStored = Schema.Struct({
 });
 type OnboardingStored = Schema.Schema.Type<typeof OnboardingStored>;
 
-const STEPS_ORDER: OnboardingStep[] = [
-  "play",
-  "showVisualizer",
-  "programSelect",
-  "info",
+/**
+ * The tour, in the order it is walked. `since` is the onboarding version that
+ * introduced the step, which is how a returning visitor is shown a step added
+ * after their last visit without replaying the tour they already finished.
+ */
+const STEPS: readonly { id: OnboardingStep; since: number }[] = [
+  { id: "play", since: 1 },
+  { id: "step", since: 2 },
+  { id: "showVisualizer", since: 1 },
+  { id: "programSelect", since: 1 },
+  { id: "info", since: 1 },
 ];
 
-function getNextStep(completed: OnboardingStep): OnboardingStep | null {
-  const idx = STEPS_ORDER.indexOf(completed);
-  if (idx < 0 || idx >= STEPS_ORDER.length - 1) return null;
-  return STEPS_ORDER[idx + 1];
+const STEPS_ORDER: OnboardingStep[] = STEPS.map((step) => step.id);
+
+/**
+ * The step to show next: the first one the visitor has neither completed nor
+ * had the chance to see. A step is unseen when it comes after the last one they
+ * completed, or when it was added after the version they stored.
+ */
+function getNextStep(stored: OnboardingStored): OnboardingStep | null {
+  const completedIdx = STEPS_ORDER.indexOf(stored.completed);
+  if (completedIdx < 0) return STEPS_ORDER[0];
+  const next = STEPS.find(
+    (step, idx) => idx > completedIdx || step.since > stored.version,
+  );
+  return next?.id ?? null;
 }
 
 function readStored(): OnboardingStored | null {
@@ -37,9 +54,7 @@ function readStored(): OnboardingStored | null {
     const raw = localStorage.getItem(ONBOARDING_STORAGE_KEY);
     if (raw == null) return null;
     const parsed: unknown = JSON.parse(raw);
-    const decoded = Schema.decodeUnknownSync(OnboardingStored)(parsed);
-    if (decoded.version !== ONBOARDING_VERSION) return null;
-    return decoded;
+    return Schema.decodeUnknownSync(OnboardingStored)(parsed);
   } catch {
     return null;
   }
@@ -47,9 +62,8 @@ function readStored(): OnboardingStored | null {
 
 function getCurrentStepFromStorage(): OnboardingStep | null {
   const stored = readStored();
-  if (stored == null) return "play";
-  const next = getNextStep(stored.completed);
-  return next;
+  if (stored == null) return STEPS_ORDER[0];
+  return getNextStep(stored);
 }
 
 function getSnapshot(): OnboardingStep | null {
@@ -104,7 +118,16 @@ export function useOnboarding(): {
     const current = getCurrentStepFromStorage();
     if (current === null) return; // onboarding already completed
     if (current !== stepId) return; // only advance when completing the current step
-    writeStored(stepId);
+    // A step added behind the visitor's position is shown out of order, so keep
+    // the furthest one they have reached: writing the earlier id would walk them
+    // back through the tour they already finished.
+    const stored = readStored();
+    const reached =
+      stored != null &&
+      STEPS_ORDER.indexOf(stored.completed) > STEPS_ORDER.indexOf(stepId)
+        ? stored.completed
+        : stepId;
+    writeStored(reached);
   }, []);
 
   const restartOnboarding = useCallback(() => {

--- a/workshop/README.md
+++ b/workshop/README.md
@@ -72,4 +72,4 @@ WebContainer integration docs live in [WebContainer/](./WebContainer/):
 - [webcontainers-spec.md](./WebContainer/webcontainers-spec.md) - Specification for running edited programs in a WebContainer (boot on mount, install sequence, root vs inner project structure). This step is **necessary for v2** — the editable editor and WebContainer runtime must be in place before refactoring to runtime hooks.
 - [webcontainer-impl.md](./WebContainer/webcontainer-impl.md) - Phased implementation plan (Effect services, sync, spawn).
 - [MOBILE_FALLBACK.md](./WebContainer/MOBILE_FALLBACK.md) - Mobile fallback path (readonly editor, in-browser Effect execution) when WebContainer doesn't boot.
-- [webcontainer-perf-and-sync.md](./WebContainer/webcontainer-perf-and-sync.md) - Pre-compile optimization, sync UX (500ms debounce, flush-on-Play, Syncing...), perf instrumentation, and remaining todos (stdout→WebContainerLogsPanel).
+- [webcontainer-perf-and-sync.md](./WebContainer/webcontainer-perf-and-sync.md) - Pre-compile optimization, sync UX (500ms debounce, flush-on-Play, Syncing...), perf instrumentation, and the stdout protocol.

--- a/workshop/WebContainer/README.md
+++ b/workshop/WebContainer/README.md
@@ -8,7 +8,7 @@ This folder documents the WebContainer integration for EffectViz — running edi
 |----------|---------|
 | [webcontainers-spec.md](./webcontainers-spec.md) | Full specification: boot sequence, project structure, sync model, stdout protocol, editor behavior |
 | [webcontainer-impl.md](./webcontainer-impl.md) | Phased implementation plan (headers, tracedRunner bundle, Effect services, sync, spawn, types) |
-| [webcontainer-perf-and-sync.md](./webcontainer-perf-and-sync.md) | Pre-compile (esbuild-wasm), sync UX (500ms debounce, flush-on-Play), perf instrumentation, remaining todos |
+| [webcontainer-perf-and-sync.md](./webcontainer-perf-and-sync.md) | Pre-compile (esbuild-wasm), sync UX (500ms debounce, flush-on-Play), perf instrumentation, stdout protocol |
 | [MOBILE_FALLBACK.md](./MOBILE_FALLBACK.md) | Mobile fallback when WebContainer fails to boot (readonly editor, in-browser Effect) |
 
 ## Quick Context

--- a/workshop/WebContainer/webcontainer-perf-and-sync.md
+++ b/workshop/WebContainer/webcontainer-perf-and-sync.md
@@ -9,7 +9,7 @@
 
 - **Pre-compile**: Transpile TS→JS on the host with esbuild-wasm, run `node program.js` in the container instead of `pnpm exec tsx program.ts`. Reduces Play→first-event from ~3.5s to ~1s.
 - **Sync UX**: 500ms debounce on edit, flush-on-Play (always run latest), "Syncing..." indicator.
-- **Stdout**: Lines not matching `TRACE_EVENT:` or `PERF:` come from container stdout (errors, `console.log`). Currently logged to browser console; todo: bubble to WebContainerLogsPanel.
+- **Stdout**: Lines not matching a known prefix come from the program itself (Node errors, `console.log`) and are shown in the WebContainerLogsPanel.
 
 ---
 
@@ -176,16 +176,19 @@ before `Effect.runFork`. Logged as `[container] ready: <ms>`.
 |--------|---------|
 | `TRACE_EVENT:` | JSON trace event (effect:start, fiber:fork, etc.) |
 | `PERF:` | Performance checkpoint from container |
+| `TRACE_CONTROL:` | Reply to a pause, resume or step command (see [phase-10.md](../phase-10.md)) |
 | *(none)* | Anything else → from something writing to stdout inside the container |
 
 ### 5.2 Un-tracked Lines
 
-Any line **not** starting with `TRACE_EVENT` or `PERF` comes from:
+Any line **not** carrying one of those prefixes comes from:
 
 - Node.js errors (e.g. `ERR_MODULE_NOT_FOUND`) and stack traces
 - User's `console.log` in their program
 
-These are currently logged with `console.warn("[spawnAndParse] container output:", line)`.
+`spawnAndParse` passes them to the host through its `onStdout` callback, and they appear in the WebContainerLogsPanel with their ANSI colours intact.
+
+One kind of line is ours rather than the program's: the spawned process gets a pseudoterminal, which echoes back every command the page writes to its stdin. Those lines decode as control commands, so they are labelled `control` and stay hidden unless the user asks to see the visualizer's internals.
 
 ---
 
@@ -247,13 +250,7 @@ sequenceDiagram
   - Optional: timeout to kill runaway processes
 - **Phase 7.2**: Optional prompt when switching programs with unsaved edits
 
-### 7.2 Stdout / Console Output
-
-- **Properly bubble up `console.log`** (and any stdout from the spawned process) and format it in `WebContainerLogsPanel`:
-  - Currently: non-TRACE_EVENT/non-PERF lines are logged with `console.warn` in `spawnAndParse.ts`
-  - Target: pass a callback from the host to `spawnAndParse` (or via store) so these lines appear in `WebContainerLogsPanel` with appropriate formatting (e.g. error styling for stack traces, neutral for user `console.log`)
-
-### 7.3 Future Improvements
+### 7.2 Future Improvements
 
 - Run prewarm with `node prewarm.js` (transpile prewarm.ts) instead of tsx
 - Consider caching transpiled `program.js` when content unchanged between syncs (already skip write on unchanged content; could skip transpile too)
@@ -266,9 +263,9 @@ sequenceDiagram
 |------|------|
 | `src/lib/transpileForContainer.ts` | esbuild-wasm init + TS→ESM transform |
 | `src/lib/transformForContainer.ts` | Import path, trace emitter, program key, perf injection |
-| `src/effects/spawnAndParse.ts` | Spawn `node program.js`, parse TRACE_EVENT, log other stdout |
+| `src/effects/spawnAndParse.ts` | Spawn `node program.js`, parse TRACE_EVENT, forward other stdout to the host |
 | `src/hooks/useWebContainerBoot.ts` | syncToContainer, flushSync, isSyncing, runPlay |
 | `src/services/webcontainer.ts` | Boot, mount, INITIAL_PROGRAM + program.js, tracedRunner.js |
 | `src/components/layout/MainLayout.tsx` | onPlay with flushSync |
 | `src/components/layout/PlaybackControls.tsx` | Syncing... indicator |
-| `src/components/editor/WebContainerLogsPanel.tsx` | Boot logs (to be extended for stdout) |
+| `src/components/editor/WebContainerLogsPanel.tsx` | Boot logs, program stdout, errors |


### PR DESCRIPTION
## Why

v3's feature is the stepper and slow mode, but nothing on screen pointed at it, and the docs still described the app as it was before phase 10.

## The tour gains a fifth step

`useOnboarding.ts` now pulses the Step button second, right after Play, wired the same way as the other four. The pulse waits for `canStep`, so it appears when the button can actually be pressed rather than during the run.

Adding a step used to cost everyone the whole tour again: `readStored()` discarded any progress whose `version` didn't match. Now each entry in `STEPS` carries the `since` version that introduced it, stored progress survives a bump, and `getNextStep` returns the first step the visitor has neither completed nor could have seen. Whoever finished the old tour sees the Step pulse alone; whoever stopped halfway keeps their place. Since the new step sits ahead of where those visitors stopped, `completeStep` keeps the furthest step reached rather than the one just completed, which is what stops the tour rewinding.

`scripts/demo/record.ts` seeded the tour as finished at a hardcoded `version: 1` to keep the pulses out of the recording. It now reads `VITE_ONBOARDING_VERSION` from `.env`, so this bump can't put a pulsing button in the next video.

Checked in the browser with `{completed: "info", version: 1}` seeded: Step pulses on load, Play doesn't.

## Docs

The README now says a program can be slowed down or stepped through.

`webcontainer-perf-and-sync.md` still listed "bubble `console.log` up to the WebContainerLogsPanel" as a todo, though `spawnAndParse.ts` has been passing those lines to the host through `onStdout` for a while. §5.2 describes what actually happens, and §5.1's prefix table gains the `TRACE_CONTROL:` row phase 10 added.

## Step Over is deleted rather than hidden

It sat behind `STEP_OVER_IS_IMPLEMENTED = false`, with an empty handler in `MainLayout`. It isn't part of v3, and git history keeps the scaffold. `MEMORY.md` records that it isn't implemented.

## Also

`package.json` keywords were still the vite template's.
