### PR TITLE
feat: run the program on a speed change, and tour the speed control

### DIFF
--- a/.env
+++ b/.env
@@ -7,4 +7,4 @@ VITE_WEBSITE_URL=https://effect-viz.vercel.app
 # Onboarding localStorage version (must be a number). Bump when adding a step, and
 # give the new step that version in useOnboarding.ts: returning users are then shown
 # it alone rather than the whole tour again.
-VITE_ONBOARDING_VERSION=2
+VITE_ONBOARDING_VERSION=3

--- a/scripts/demo/scenario.ts
+++ b/scripts/demo/scenario.ts
@@ -285,9 +285,8 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   // --- Act 2: same program, slower clock, then step through it -------------
   // The speed change lands between two runs of the same program on purpose:
   // the only thing that differs is how long it takes, which is the point.
+  // Picking a speed starts the run itself, so there is no Run press here.
   await cursor.select(speedSelect, "0.5");
-
-  await cursor.click(runButton);
   await untilStatus("running");
   await cursor.pause(600);
 
@@ -307,7 +306,6 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   // --- Act 3: the editor is live, and the runtime says so ------------------
   await cursor.click(resetButton);
   await cursor.pause(400);
-  await cursor.select(speedSelect, "1");
 
   // Renaming a span keeps the run the same length, and the new names come back
   // out of the runtime in the execution log — which is the point being made.
@@ -323,7 +321,10 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   await page.keyboard.type("job", { delay: 110 });
   await cursor.pause(550);
 
-  await runToCompletion();
+  // Back to full speed, which starts the run: act 2 left the clock at 0.5, and
+  // the edit is meant to be read at the same pace as act 1.
+  await cursor.select(speedSelect, "1");
+  await untilStatus("finished");
   await cursor.pause(650);
   mark("act 3 — edit and re-run");
 

--- a/src/components/layout/InfoModal.tsx
+++ b/src/components/layout/InfoModal.tsx
@@ -1,4 +1,4 @@
-import { Info, Play, StepForward, X } from "lucide-react";
+import { Info, StepForward, X } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
 import { useEffect, useState } from "react";
 
@@ -144,9 +144,8 @@ export function InfoModal({
               to run the program step by step.
             </p>
             <p>
-              You can pick a speed before pressing{" "}
-              <Play className="inline h-3.5 w-3.5 align-text-bottom" /> to watch
-              the same program run slower.
+              You can pick a speed to watch the same program run slower. On a
+              stopped program, picking one runs it.
             </p>
           </section>
 

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -19,7 +19,7 @@ import {
 import { VisualizerPanel } from "@/components/visualizer/VisualizerPanel";
 import { useEventHandlers } from "@/hooks/useEventHandlers";
 import { useOnboarding } from "@/hooks/useOnboarding";
-import { useSpeed } from "@/hooks/useSpeed";
+import { type Speed, useSpeed } from "@/hooks/useSpeed";
 import { useWebContainerBoot } from "@/hooks/useWebContainerBoot";
 import { useCanSupportWebContainer } from "@/lib/mobileDetection";
 import {
@@ -35,6 +35,12 @@ import {
   type PauseReason,
   type PlaybackState,
 } from "./PlaybackControls";
+
+/**
+ * How long a speed change waits before it starts the program, so that walking
+ * the select with the keyboard settles on one run rather than one per option.
+ */
+const SPEED_AUTO_START_DELAY_MS = 250;
 
 export function MainLayout() {
   const canSupportWebContainer = useCanSupportWebContainer();
@@ -80,12 +86,42 @@ export function MainLayout() {
    */
   const runIdRef = useRef(0);
   const [speed, setSpeed] = useSpeed();
+  /** Pending auto-start from a speed change, waiting out the debounce. */
+  const autoStartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /**
+   * Bumped whenever an auto-start is called off. A fired one is still in flight
+   * while it flushes the editor, which is long enough for a control to be
+   * pressed, so it carries the value it read and drops itself if it moved on.
+   */
+  const autoStartTokenRef = useRef(0);
+
+  const cancelAutoStart = useCallback(() => {
+    autoStartTokenRef.current++;
+    if (autoStartTimerRef.current != null) {
+      clearTimeout(autoStartTimerRef.current);
+      autoStartTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (autoStartTimerRef.current != null) {
+        clearTimeout(autoStartTimerRef.current);
+      }
+    },
+    [],
+  );
+
+  const isPlayDisabled =
+    canSupportWebContainer &&
+    (webContainer.status === "booting" || webContainer.isSyncing);
   const [showVisualizer, setShowVisualizer] = useState(false);
   const [showLogsPanel, setShowLogsPanel] = useState(true);
   const [editorTabId, setEditorTabId] = useState("program");
 
   const handleProgramChange = useCallback(
     (programKey: ProgramKey) => {
+      cancelAutoStart();
       const { newContent, updatedCache } = computeProgramSwitch(
         selectedProgram,
         programKey,
@@ -112,10 +148,12 @@ export function MainLayout() {
       completeOnboardingStep,
       handleReset,
       webContainer,
+      cancelAutoStart,
     ],
   );
 
   const handleResetToTemplate = useCallback(() => {
+    cancelAutoStart();
     const { newContent, updatedCache } = computeResetToTemplate(
       selectedProgram,
       programs,
@@ -126,7 +164,7 @@ export function MainLayout() {
     if (webContainer.isReady) {
       webContainer.syncToContainer(newContent);
     }
-  }, [selectedProgram, programs, webContainer]);
+  }, [selectedProgram, programs, webContainer, cancelAutoStart]);
 
   const handleProgramContentChange = (content: string) => {
     setEditorContent(content);
@@ -195,7 +233,13 @@ export function MainLayout() {
     </TooltipProvider>
   );
 
-  const startRun = ({ startPaused }: { startPaused: boolean }) => {
+  const startRun = ({
+    startPaused,
+    rate = speed,
+  }: {
+    startPaused: boolean;
+    rate?: Speed;
+  }) => {
     const runId = ++runIdRef.current;
     const isCurrentRun = () => runIdRef.current === runId;
 
@@ -205,7 +249,7 @@ export function MainLayout() {
       onFirstChunk: () => {
         if (!startPaused) setPlaybackState("running");
       },
-      rate: speed,
+      rate,
       startPaused,
     })
       .then(() => {
@@ -216,7 +260,23 @@ export function MainLayout() {
       });
   };
 
+  const startFromStopped = async (
+    rate: Speed,
+    isStillWanted: () => boolean = () => true,
+  ) => {
+    setShowVisualizer(true);
+    if (webContainer.isReady) {
+      await webContainer.flushSync(editorContent);
+    }
+    // Whoever pressed a control during that flush wins: starting here too would
+    // leave their run racing a second one the Reset button cannot reach.
+    if (!isStillWanted()) return;
+    setPlaybackState("starting");
+    startRun({ startPaused: false, rate });
+  };
+
   const onPlay = async () => {
+    cancelAutoStart();
     setShowVisualizer(true);
 
     // Play doubles as resume: the program is already running, just gated.
@@ -226,12 +286,27 @@ export function MainLayout() {
       return;
     }
 
-    if (webContainer.isReady) {
-      await webContainer.flushSync(editorContent);
-    }
+    await startFromStopped(speed);
+  };
 
-    setPlaybackState("starting");
-    startRun({ startPaused: false });
+  /**
+   * Speed is read once, when a program starts, so changing it on a stopped
+   * program runs it again at the new rate rather than leaving the choice with
+   * nothing to show. A paused program keeps its session: the rate it was given
+   * holds until it is started again. The delay absorbs a keyboard user walking
+   * the options — a closed select fires a change per arrow key — instead of
+   * spawning a run for each one passed through.
+   */
+  const onSpeedChange = (next: Speed) => {
+    setSpeed(next);
+    cancelAutoStart();
+    if (playbackState !== "idle" && playbackState !== "finished") return;
+    if (isPlayDisabled) return;
+    const token = autoStartTokenRef.current;
+    autoStartTimerRef.current = setTimeout(() => {
+      autoStartTimerRef.current = null;
+      void startFromStopped(next, () => autoStartTokenRef.current === token);
+    }, SPEED_AUTO_START_DELAY_MS);
   };
 
   const onPause = () => {
@@ -241,6 +316,7 @@ export function MainLayout() {
   };
 
   const onStep = async () => {
+    cancelAutoStart();
     // With nothing running, Step starts the program already gated so that its
     // first events can be stepped through; there is no other way into a paused
     // run. As with Play, a finished program starts over.
@@ -269,6 +345,7 @@ export function MainLayout() {
   };
 
   const onReset = () => {
+    cancelAutoStart();
     runIdRef.current++;
     setPlaybackState("idle");
     setPauseReason("user");
@@ -473,13 +550,10 @@ export function MainLayout() {
         onboardingStep={onboardingStep}
         onOnboardingComplete={completeOnboardingStep}
         onRestartOnboarding={restartOnboarding}
-        isPlayDisabled={
-          canSupportWebContainer &&
-          (webContainer.status === "booting" || webContainer.isSyncing)
-        }
+        isPlayDisabled={isPlayDisabled}
         isSyncing={canSupportWebContainer && webContainer.isSyncing}
         speed={speed}
-        onSpeedChange={setSpeed}
+        onSpeedChange={onSpeedChange}
         pauseReason={pauseReason}
       />
     </div>

--- a/src/components/layout/PlaybackControls.tsx
+++ b/src/components/layout/PlaybackControls.tsx
@@ -54,7 +54,7 @@ interface PlaybackControlsProps {
   isPlayDisabled?: boolean;
   /** When true, show "Syncing..." in status (e.g. flushing editor to container) */
   isSyncing?: boolean;
-  /** Playback speed applied on the next run */
+  /** Playback speed applied when a program starts */
   speed?: Speed;
   onSpeedChange?: (speed: Speed) => void;
   /** Only meaningful while paused; decides whether Step can do anything */
@@ -96,6 +96,12 @@ export function PlaybackControls({
   // The rate is fixed when the program starts: the WebContainer receives it as a
   // spawn environment variable and cannot be retuned until it is restarted.
   const canChangeSpeed = state !== "running" && state !== "starting";
+  // Changing the speed of a stopped program runs it at the new rate. A live one,
+  // running or paused, keeps the rate it was given until it is started again.
+  const speedHint =
+    state === "idle" || state === "finished"
+      ? "Speed — slows the program's own clock, and runs it"
+      : "Speed applies on the next run";
   const [playMountAnimationEnded, setPlayMountAnimationEnded] = useState(false);
 
   // Skip showVisualizer step on desktop (toggle is hidden)
@@ -304,12 +310,19 @@ export function PlaybackControls({
             <TooltipTrigger asChild>
               <Select
                 aria-label="Playback speed"
-                className="h-8 w-[4.5rem] px-2"
+                data-onboarding-step="speed"
+                className={cn(
+                  "h-8 w-[4.5rem] px-2",
+                  onboardingStep === "speed" &&
+                    canChangeSpeed &&
+                    "animate-onboarding-glow",
+                )}
                 value={speed}
                 disabled={!canChangeSpeed}
-                onChange={(e) =>
-                  onSpeedChange?.(Number(e.target.value) as Speed)
-                }
+                onChange={(e) => {
+                  onSpeedChange?.(Number(e.target.value) as Speed);
+                  onOnboardingComplete?.("speed");
+                }}
               >
                 {SPEED_OPTIONS.map((option) => (
                   <option key={option} value={option}>
@@ -318,11 +331,7 @@ export function PlaybackControls({
                 ))}
               </Select>
             </TooltipTrigger>
-            <TooltipContent>
-              {canChangeSpeed
-                ? "Speed — slows the program's own clock"
-                : "Speed applies on the next run"}
-            </TooltipContent>
+            <TooltipContent>{speedHint}</TooltipContent>
           </Tooltip>
         </div>
 

--- a/src/hooks/useOnboarding.test.ts
+++ b/src/hooks/useOnboarding.test.ts
@@ -29,16 +29,22 @@ describe("useOnboarding", () => {
       result.current.completeStep("play");
     });
 
+    expect(result.current.currentStep).toBe("showVisualizer");
+
+    act(() => {
+      result.current.completeStep("showVisualizer");
+    });
+
     expect(result.current.currentStep).toBe("step");
 
     act(() => {
       result.current.completeStep("step");
     });
 
-    expect(result.current.currentStep).toBe("showVisualizer");
+    expect(result.current.currentStep).toBe("speed");
 
     act(() => {
-      result.current.completeStep("showVisualizer");
+      result.current.completeStep("speed");
     });
 
     expect(result.current.currentStep).toBe("programSelect");
@@ -68,7 +74,7 @@ describe("useOnboarding", () => {
     expect(raw).not.toBeNull();
     const stored = JSON.parse(raw!) as { completed: string; version: number };
     expect(stored.completed).toBe("play");
-    expect(stored.version).toBe(2);
+    expect(stored.version).toBe(3);
   });
 
   it("resumes from next step after reload (simulated)", () => {
@@ -78,12 +84,12 @@ describe("useOnboarding", () => {
       result1.current.completeStep("play");
     });
 
-    expect(result1.current.currentStep).toBe("step");
+    expect(result1.current.currentStep).toBe("showVisualizer");
 
     // Simulate reload: new hook instance reads from same localStorage
     const { result: result2 } = renderHook(() => useOnboarding());
 
-    expect(result2.current.currentStep).toBe("step");
+    expect(result2.current.currentStep).toBe("showVisualizer");
   });
 
   it("returns null when all steps completed (simulated)", () => {
@@ -91,8 +97,9 @@ describe("useOnboarding", () => {
 
     act(() => {
       result1.current.completeStep("play");
-      result1.current.completeStep("step");
       result1.current.completeStep("showVisualizer");
+      result1.current.completeStep("step");
+      result1.current.completeStep("speed");
       result1.current.completeStep("programSelect");
       result1.current.completeStep("info");
     });
@@ -112,7 +119,7 @@ describe("useOnboarding", () => {
     expect(result.current.currentStep).toBe("play");
   });
 
-  it("shows a step added since the stored version, then ends", () => {
+  it("shows the steps added since the stored version, then ends", () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
@@ -128,6 +135,12 @@ describe("useOnboarding", () => {
 
     act(() => {
       result.current.completeStep("step");
+    });
+
+    expect(result.current.currentStep).toBe("speed");
+
+    act(() => {
+      result.current.completeStep("speed");
     });
 
     expect(result.current.currentStep).toBe(null);
@@ -151,6 +164,12 @@ describe("useOnboarding", () => {
       result.current.completeStep("step");
     });
 
+    expect(result.current.currentStep).toBe("speed");
+
+    act(() => {
+      result.current.completeStep("speed");
+    });
+
     expect(result.current.currentStep).toBe("info");
   });
 
@@ -160,12 +179,12 @@ describe("useOnboarding", () => {
     act(() => {
       result.current.completeStep("play");
     });
-    expect(result.current.currentStep).toBe("step");
+    expect(result.current.currentStep).toBe("showVisualizer");
 
     act(() => {
       result.current.completeStep("play");
     });
-    expect(result.current.currentStep).toBe("step");
+    expect(result.current.currentStep).toBe("showVisualizer");
 
     const raw = localStorage.getItem(STORAGE_KEY);
     const stored = JSON.parse(raw!) as { completed: string };
@@ -177,8 +196,9 @@ describe("useOnboarding", () => {
 
     act(() => {
       result.current.completeStep("play");
-      result.current.completeStep("step");
       result.current.completeStep("showVisualizer");
+      result.current.completeStep("step");
+      result.current.completeStep("speed");
       result.current.completeStep("programSelect");
       result.current.completeStep("info");
     });

--- a/src/hooks/useOnboarding.ts
+++ b/src/hooks/useOnboarding.ts
@@ -10,6 +10,7 @@ const OnboardingStep = Schema.Literal(
   "programSelect",
   "info",
   "step",
+  "speed",
 );
 type OnboardingStep = Schema.Schema.Type<typeof OnboardingStep>;
 
@@ -24,11 +25,14 @@ type OnboardingStored = Schema.Schema.Type<typeof OnboardingStored>;
  * The tour, in the order it is walked. `since` is the onboarding version that
  * introduced the step, which is how a returning visitor is shown a step added
  * after their last visit without replaying the tour they already finished.
+ * Progress is stored as a single version number, so two steps sharing a `since`
+ * cannot be told apart: give each new step a version of its own.
  */
 const STEPS: readonly { id: OnboardingStep; since: number }[] = [
   { id: "play", since: 1 },
-  { id: "step", since: 2 },
   { id: "showVisualizer", since: 1 },
+  { id: "step", since: 2 },
+  { id: "speed", since: 3 },
   { id: "programSelect", since: 1 },
   { id: "info", since: 1 },
 ];
@@ -88,10 +92,33 @@ function subscribe(cb: () => void): () => void {
   };
 }
 
-function writeStored(completed: OnboardingStep): void {
+/**
+ * The version to store once `reached` has been walked to: high enough to retire
+ * the steps the visitor has now seen, low enough to keep the ones added behind
+ * their position that they have not. Storing the current version outright would
+ * drop a second back-inserted step, since it is only ever shown while the stored
+ * version is older than the one that introduced it.
+ */
+function getStoredVersion(
+  storedVersion: number,
+  reached: OnboardingStep,
+  justCompleted: OnboardingStep,
+): number {
+  const reachedIdx = STEPS_ORDER.indexOf(reached);
+  const pending = STEPS.filter(
+    (step, idx) =>
+      idx <= reachedIdx &&
+      step.since > storedVersion &&
+      step.id !== justCompleted,
+  );
+  if (pending.length === 0) return ONBOARDING_VERSION;
+  return Math.min(...pending.map((step) => step.since)) - 1;
+}
+
+function writeStored(completed: OnboardingStep, version: number): void {
   const value: OnboardingStored = {
     completed,
-    version: ONBOARDING_VERSION,
+    version,
     date: new Date().toISOString(),
   };
   localStorage.setItem(ONBOARDING_STORAGE_KEY, JSON.stringify(value));
@@ -127,7 +154,8 @@ export function useOnboarding(): {
       STEPS_ORDER.indexOf(stored.completed) > STEPS_ORDER.indexOf(stepId)
         ? stored.completed
         : stepId;
-    writeStored(reached);
+    const storedVersion = stored?.version ?? ONBOARDING_VERSION;
+    writeStored(reached, getStoredVersion(storedVersion, reached, stepId));
   }, []);
 
   const restartOnboarding = useCallback(() => {

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -482,8 +482,11 @@ superseded run.
 
 ## Step 5a: Speed control ✅
 
-Issue #13's actual request, clickable. Selecting a speed and pressing Play runs
-the program with its clock scaled by that factor.
+Issue #13's actual request, clickable. Selecting a speed runs the program with
+its clock scaled by that factor: a stopped program is started by the choice
+itself, since the rate is only read at start and there is otherwise nothing to
+see. A paused program is left where it is, and keeps the rate it was given until
+it is started again.
 
 ### Created/Modified Files
 
@@ -491,7 +494,7 @@ the program with its clock scaled by that factor.
 |------|---------|
 | `src/hooks/useSpeed.ts` | `SPEED_OPTIONS`, `useSpeed` (localStorage-backed), `formatSpeed` |
 | `src/components/layout/PlaybackControls.tsx` | Speed `Select`, `PauseReason`, corrected enable/disable rules |
-| `src/components/layout/MainLayout.tsx` | Speed state; `finished` on completion |
+| `src/components/layout/MainLayout.tsx` | Speed state, debounced auto-start on speed change; `finished` on completion |
 | `src/hooks/useEventHandlers.ts` | `rate` through to both paths |
 | `src/hooks/useWebContainerBoot.ts`, `src/effects/spawnAndParse.ts` | `VIZ_RATE` spawn environment variable |
 
@@ -509,7 +512,7 @@ editor flushes) is orthogonal and can coincide with any of them.
 | `starting` | – | – | ✓ | – |
 | `running` | ✓ (pause) | – | ✓ | – |
 | `paused` | ✓ (resume) | ✓ | ✓ | ✓ |
-| `finished` | ✓ (re-run) | – | ✓ | ✓ |
+| `finished` | ✓ (re-run) | ✓ (starts paused) | ✓ | ✓ |
 
 Speed is locked while running because the WebContainer receives the rate as a
 spawn environment variable and cannot be retuned without restarting. That is a


### PR DESCRIPTION
## Why

The speed select did nothing until you found Play — the rate is only read when a program starts — and nothing in the tour pointed at it.

## Picking a speed starts the program

`onSpeedChange` in `MainLayout.tsx` starts the run when playback is `idle` or `finished`, handing the rate straight to `startRun`. A paused program is left alone: the rate is a spawn environment variable, so a live run keeps the one it was given.

Debounced 250ms, since a closed `<select>` fires a change per arrow key and each fire costs a `flushSync` plus a container spawn. Play, Step, Reset, a program switch, Reset to template and unmount call `cancelAutoStart`; an auto-start already flushing carries a token and drops itself if a press landed meanwhile. The tooltip and `InfoModal` follow the new behaviour.

## The tour gains a sixth step

`STEPS` in `useOnboarding.ts` now reads play → showVisualizer → step → speed → programSelect → info, with the select glowing like the program picker. `VITE_ONBOARDING_VERSION` goes to 3.

That second back-inserted step exposed a bug: `writeStored` jumped to the current version, so a visitor stored at v1 saw `step` and then silently skipped `speed`. `getStoredVersion` now stores the highest version whose steps they have actually seen, and a test walks a v1 visitor through both.

## Demo recording

`scenario.ts` assumed a speed change was inert. Act 2 drops its Run press and lets the select start the run; act 3's return to 1x moved after the Monaco edit.