### PR TITLE
Keyboard shortcuts for run/pause and step

### DIFF
--- a/src/components/editor/CodeEditor.tsx
+++ b/src/components/editor/CodeEditor.tsx
@@ -78,7 +78,52 @@ async function revalidateModels(monaco: Monaco) {
   }
 }
 
-interface CodeEditorProps {
+interface PlaybackShortcutHandlers {
+  onPlayPauseShortcut?: () => void;
+  onStepShortcut?: () => void;
+}
+
+/**
+ * Binds the playback shortcuts inside the editor. Monaco resolves keybindings
+ * on its own DOM node and stops the press from bubbling, so the window listener
+ * in `useKeyboardShortcuts` never sees one typed here — this registration is
+ * what makes the shortcuts work while editing. `KeyMod.CtrlCmd` is Cmd on
+ * macOS and Ctrl elsewhere, the same split `matchesShortcut` makes.
+ *
+ * These take over "Insert Line Below" and "Insert Line Above", which stay
+ * reachable from the editor's command palette. Registering them unconditionally
+ * means the key always belongs to the app: when a playback action is
+ * unavailable the shortcut does nothing, rather than sometimes inserting a line.
+ *
+ * `addAction` over `addCommand` so both also appear in the context menu and the
+ * command palette, which documents them for free.
+ */
+function registerPlaybackActions(
+  editor: MonacoTypes.editor.IStandaloneCodeEditor,
+  monaco: Monaco,
+  handlers: React.RefObject<PlaybackShortcutHandlers>,
+) {
+  editor.addAction({
+    id: "effect-viz.play-pause",
+    label: "Run / Pause program",
+    keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
+    contextMenuGroupId: "navigation",
+    contextMenuOrder: 0,
+    run: () => handlers.current.onPlayPauseShortcut?.(),
+  });
+  editor.addAction({
+    id: "effect-viz.step",
+    label: "Step program",
+    keybindings: [
+      monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Enter,
+    ],
+    contextMenuGroupId: "navigation",
+    contextMenuOrder: 1,
+    run: () => handlers.current.onStepShortcut?.(),
+  });
+}
+
+interface CodeEditorProps extends PlaybackShortcutHandlers {
   value?: string;
   onChange?: (value: string | undefined) => void;
   className?: string;
@@ -102,8 +147,19 @@ export function CodeEditor({
   readOnly = false,
   path,
   typesReady = false,
+  onPlayPauseShortcut,
+  onStepShortcut,
 }: CodeEditorProps) {
   const monacoRef = useRef<Monaco | null>(null);
+  // Actions are registered once, at mount, so they reach their handlers through
+  // a ref rather than capturing the ones that happened to be current then.
+  const shortcutsRef = useRef<PlaybackShortcutHandlers>({
+    onPlayPauseShortcut,
+    onStepShortcut,
+  });
+  useEffect(() => {
+    shortcutsRef.current = { onPlayPauseShortcut, onStepShortcut };
+  });
 
   useEffect(() => {
     if (typesReady && monacoRef.current) {
@@ -124,8 +180,9 @@ export function CodeEditor({
         beforeMount={(monaco) => {
           monacoRef.current = monaco;
         }}
-        onMount={(_, monaco) => {
+        onMount={(editor, monaco) => {
           monacoRef.current = monaco;
+          registerPlaybackActions(editor, monaco, shortcutsRef);
           if (typesReady) {
             revalidateModels(monaco);
           }

--- a/src/components/editor/MultiModelEditor.tsx
+++ b/src/components/editor/MultiModelEditor.tsx
@@ -32,6 +32,12 @@ interface MultiModelEditorProps {
    * Called when the Program tab content changes (only when that tab is editable).
    */
   onProgramContentChange?: (content: string) => void;
+  /**
+   * Playback shortcuts typed inside the editor. Monaco resolves them itself, so
+   * they reach the app through here rather than through the window listener.
+   */
+  onPlayPauseShortcut?: () => void;
+  onStepShortcut?: () => void;
 }
 
 /**
@@ -48,6 +54,8 @@ export function MultiModelEditor({
   onValueChange,
   onProgramContentChange,
   typesReady,
+  onPlayPauseShortcut,
+  onStepShortcut,
 }: MultiModelEditorProps) {
   const firstTabId = tabs[0]?.id ?? "";
   const [internalTabId, setInternalTabId] = useState(
@@ -106,6 +114,8 @@ export function MultiModelEditor({
           value={editorValue}
           readOnly={activeTab?.readOnly ?? true}
           typesReady={typesReady}
+          onPlayPauseShortcut={onPlayPauseShortcut}
+          onStepShortcut={onStepShortcut}
           onChange={
             activeTabId === "program" && onProgramContentChange
               ? (value) => value !== undefined && onProgramContentChange(value)

--- a/src/components/layout/InfoModal.test.tsx
+++ b/src/components/layout/InfoModal.test.tsx
@@ -86,6 +86,21 @@ describe("InfoModal", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps the links outside the scrolling body, so they stay in view", async () => {
+    const user = userEvent.setup();
+    render(<InfoModal />);
+
+    await user.click(screen.getByRole("button"));
+
+    const body = screen.getByTestId("info-modal-body");
+    expect(body).not.toContainElement(
+      screen.getByRole("link", { name: /visit github repo/i }),
+    );
+    expect(body).not.toContainElement(
+      screen.getByRole("link", { name: /visit portfolio/i }),
+    );
+  });
+
   it("closes the modal when clicking the close button", async () => {
     const user = userEvent.setup();
     render(<InfoModal />);

--- a/src/components/layout/InfoModal.tsx
+++ b/src/components/layout/InfoModal.tsx
@@ -25,8 +25,11 @@ const GITHUB_REPO_URL = "https://github.com/topheman/effect-viz";
 const PORTFOLIO_URL = "https://topheman.github.io/me/";
 
 const MOBILE_BREAKPOINT_PX = 640; // Tailwind sm
-const QR_SIZE_DESKTOP = 200;
+/** Sized so the modal body fits a laptop viewport without scrolling. */
+const QR_SIZE_DESKTOP = 160;
 const QR_SIZE_MOBILE = 64;
+/** The mobile QR tapped to full screen, where there is room for a big one. */
+const QR_SIZE_FULLSCREEN = 200;
 
 interface InfoModalProps {
   onboardingStep?: OnboardingStepId | null;
@@ -117,7 +120,7 @@ export function InfoModal({
         </DialogHeader>
 
         <div
-          className={`flex max-h-[60vh] flex-col gap-4 overflow-y-auto py-4`}
+          className={`flex max-h-[70vh] flex-col gap-4 overflow-y-auto py-4`}
           data-testid="info-modal-body"
         >
           {/* About the project */}
@@ -222,7 +225,7 @@ export function InfoModal({
                     >
                       <QRCodeSVG
                         value={currentUrl}
-                        size={QR_SIZE_DESKTOP}
+                        size={QR_SIZE_FULLSCREEN}
                         level="M"
                         fgColor="#09090b"
                         includeMargin={false}
@@ -254,38 +257,44 @@ export function InfoModal({
             >
               {currentUrl}
             </p>
-
-            <p>
-              {/* GitHub Link */}
-              <a
-                href={GITHUB_REPO_URL}
-                target="_blank"
-                title="Visit the GitHub repo"
-                rel="noopener noreferrer"
-                className={`
-                  text-sm text-primary underline-offset-4 transition-colors
-                  hover:underline
-                `}
-              >
-                Visit GitHub repo
-              </a>
-              {" - "}
-              {/* Portfolio Link */}
-              <a
-                href={PORTFOLIO_URL}
-                target="_blank"
-                title="Visit my portfolio"
-                rel="noopener noreferrer"
-                className={`
-                  text-sm text-primary underline-offset-4 transition-colors
-                  hover:underline
-                `}
-              >
-                Visit portfolio
-              </a>
-            </p>
           </div>
         </div>
+
+        {/*
+          The links sit outside the scrolling body so they stay in view however
+          far it has been scrolled. On a laptop the body is taller than its cap
+          and overlay scrollbars show nothing, so a footer left inside it reads
+          as missing rather than as further down.
+        */}
+        <p className="pt-4 text-center">
+          {/* GitHub Link */}
+          <a
+            href={GITHUB_REPO_URL}
+            target="_blank"
+            title="Visit the GitHub repo"
+            rel="noopener noreferrer"
+            className={`
+              text-sm text-primary underline-offset-4 transition-colors
+              hover:underline
+            `}
+          >
+            Visit GitHub repo
+          </a>
+          {" - "}
+          {/* Portfolio Link */}
+          <a
+            href={PORTFOLIO_URL}
+            target="_blank"
+            title="Visit my portfolio"
+            rel="noopener noreferrer"
+            className={`
+              text-sm text-primary underline-offset-4 transition-colors
+              hover:underline
+            `}
+          >
+            Visit portfolio
+          </a>
+        </p>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/layout/InfoModal.tsx
+++ b/src/components/layout/InfoModal.tsx
@@ -17,7 +17,8 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import type { OnboardingStepId } from "@/hooks/useOnboarding";
-import { useCanSupportWebContainer } from "@/lib/mobileDetection";
+import { formatShortcut } from "@/lib/keyboardShortcuts";
+import { useCanSupportWebContainer, useIsMobile } from "@/lib/mobileDetection";
 import { cn } from "@/lib/utils";
 
 const GITHUB_REPO_URL = "https://github.com/topheman/effect-viz";
@@ -44,6 +45,9 @@ export function InfoModal({
   });
 
   const canSupportWebContainer = useCanSupportWebContainer();
+  // Safari desktop cannot run the WebContainer but still has a keyboard, so the
+  // shortcuts are gated on the device rather than on that.
+  const isMobileDevice = useIsMobile();
 
   const [isMobile, setIsMobile] = useState(() => {
     if (
@@ -147,6 +151,12 @@ export function InfoModal({
               You can pick a speed to watch the same program run slower. On a
               stopped program, picking one runs it.
             </p>
+            {!isMobileDevice && (
+              <p>
+                Press {formatShortcut("playPause")} to run or pause,{" "}
+                {formatShortcut("step")} to step.
+              </p>
+            )}
           </section>
 
           <section

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -18,10 +18,16 @@ import {
 } from "@/components/ui/tooltip";
 import { VisualizerPanel } from "@/components/visualizer/VisualizerPanel";
 import { useEventHandlers } from "@/hooks/useEventHandlers";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useOnboarding } from "@/hooks/useOnboarding";
 import { type Speed, useSpeed } from "@/hooks/useSpeed";
 import { useWebContainerBoot } from "@/hooks/useWebContainerBoot";
 import { useCanSupportWebContainer } from "@/lib/mobileDetection";
+import {
+  getPlaybackAvailability,
+  type PauseReason,
+  type PlaybackState,
+} from "@/lib/playbackAvailability";
 import {
   computeProgramSwitch,
   computeResetToTemplate,
@@ -30,11 +36,7 @@ import type { ProgramKey } from "@/lib/programs";
 import { cn } from "@/lib/utils";
 
 import { Header } from "./Header";
-import {
-  PlaybackControls,
-  type PauseReason,
-  type PlaybackState,
-} from "./PlaybackControls";
+import { PlaybackControls } from "./PlaybackControls";
 
 /**
  * How long a speed change waits before it starts the program, so that walking
@@ -352,6 +354,44 @@ export function MainLayout() {
     handleReset();
   };
 
+  // The same rules the buttons are enabled by, so a shortcut cannot reach a
+  // control the UI is refusing — a run started while the container was still
+  // booting would be one the Reset button cannot see.
+  const availability = getPlaybackAvailability({
+    state: playbackState,
+    pauseReason,
+    isPlayDisabled,
+  });
+
+  /**
+   * The keyboard path to Run/Pause. It retires the onboarding step the way the
+   * button does, so a visitor who found the keyboard is not pulsed at forever.
+   */
+  const onPlayPauseShortcut = () => {
+    if (playbackState === "running") {
+      if (availability.canPause) onPause();
+      return;
+    }
+    if (!availability.canPlay) return;
+    completeOnboardingStep("play");
+    void onPlay();
+  };
+
+  /** The keyboard path to Step, retiring its onboarding step the same way. */
+  const onStepShortcut = () => {
+    if (!availability.canStep) return;
+    completeOnboardingStep("step");
+    void onStep();
+  };
+
+  useKeyboardShortcuts({
+    onPlayPause: onPlayPauseShortcut,
+    onStep: onStepShortcut,
+  });
+
+  // Monaco resolves these itself; see registerPlaybackActions in CodeEditor.
+  const editorShortcuts = { onPlayPauseShortcut, onStepShortcut };
+
   return (
     <div
       className={`
@@ -379,6 +419,7 @@ export function MainLayout() {
                       onValueChange={setEditorTabId}
                       onProgramContentChange={handleProgramContentChange}
                       typesReady={webContainer.typesReady}
+                      {...editorShortcuts}
                       headerExtra={programSelectorHeader}
                       className="flex h-full min-w-0 flex-col"
                     />
@@ -414,6 +455,7 @@ export function MainLayout() {
                   onValueChange={setEditorTabId}
                   onProgramContentChange={handleProgramContentChange}
                   typesReady={webContainer.typesReady}
+                  {...editorShortcuts}
                   headerExtra={programSelectorHeader}
                   className="flex h-full min-w-0 flex-col"
                 />
@@ -468,6 +510,7 @@ export function MainLayout() {
                   onValueChange={setEditorTabId}
                   onProgramContentChange={handleProgramContentChange}
                   typesReady={webContainer.typesReady}
+                  {...editorShortcuts}
                   headerExtra={programSelectorHeader}
                   className="flex h-full min-w-0 flex-col"
                 />
@@ -503,6 +546,7 @@ export function MainLayout() {
                   onValueChange={setEditorTabId}
                   onProgramContentChange={handleProgramContentChange}
                   typesReady={webContainer.typesReady}
+                  {...editorShortcuts}
                   headerExtra={programSelectorHeader}
                   className="flex h-full min-w-0 flex-col"
                 />

--- a/src/components/layout/PlaybackControls.tsx
+++ b/src/components/layout/PlaybackControls.tsx
@@ -18,26 +18,15 @@ import {
 } from "@/components/ui/tooltip";
 import type { OnboardingStepId } from "@/hooks/useOnboarding";
 import { SPEED_OPTIONS, type Speed, formatSpeed } from "@/hooks/useSpeed";
+import { ariaKeyShortcuts, formatShortcut } from "@/lib/keyboardShortcuts";
+import {
+  getPlaybackAvailability,
+  type PauseReason,
+  type PlaybackState,
+} from "@/lib/playbackAvailability";
 import { cn } from "@/lib/utils";
 
 import { InfoModal } from "./InfoModal";
-
-export type PlaybackState =
-  | "idle"
-  | "starting"
-  | "running"
-  | "paused"
-  | "finished";
-
-/**
- * Why execution is paused. Only a user pause can be stepped: `stuck` means
- * nothing is runnable and no deadline is pending, so a step would do nothing.
- *
- * A stuck program is either deadlocked or waiting on something outside. Telling
- * those apart needs a fiber's status, which is itself an Effect and so needs the
- * scheduler that a pause is holding.
- */
-export type PauseReason = "user" | "stuck";
 
 interface PlaybackControlsProps {
   state?: PlaybackState;
@@ -79,23 +68,10 @@ export function PlaybackControls({
   pauseReason = "user",
 }: PlaybackControlsProps) {
   const isRunning = state === "running";
-  // Play doubles as resume (from paused) and re-run (from finished).
-  const canPlay =
-    (state === "idle" || state === "paused" || state === "finished") &&
-    !isPlayDisabled;
-  // Step from a stopped program starts it already gated, so its very first
-  // events can be stepped through; like Play, that includes re-running one that
-  // has finished. Otherwise stepping needs a live, frozen program, and a stuck
-  // pause has nothing the runtime could release.
-  const canStep =
-    ((state === "idle" || state === "finished") && !isPlayDisabled) ||
-    (state === "paused" && pauseReason === "user");
-  const canPause = isRunning;
-  // Nothing to reset before the first run.
-  const canReset = state !== "idle";
-  // The rate is fixed when the program starts: the WebContainer receives it as a
-  // spawn environment variable and cannot be retuned until it is restarted.
-  const canChangeSpeed = state !== "running" && state !== "starting";
+  const { canPlay, canPause, canStep, canReset, canChangeSpeed } =
+    getPlaybackAvailability({ state, pauseReason, isPlayDisabled });
+  const playPauseShortcut = formatShortcut("playPause");
+  const stepShortcut = formatShortcut("step");
   // Changing the speed of a stopped program runs it at the new rate. A live one,
   // running or paused, keeps the rate it was given until it is started again.
   const speedHint =
@@ -190,7 +166,11 @@ export function PlaybackControls({
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
+                // The label stays free of the shortcut, which reads differently
+                // per platform: the demo recorder matches these buttons by
+                // their accessible name (scripts/demo/scenario.ts).
                 aria-label={isRunning ? "Pause" : "Run"}
+                aria-keyshortcuts={ariaKeyShortcuts("playPause")}
                 data-onboarding-step="play"
                 variant="ghost"
                 size="icon"
@@ -229,7 +209,9 @@ export function PlaybackControls({
                 )}
               </Button>
             </TooltipTrigger>
-            <TooltipContent>{isRunning ? "Pause" : "Run"}</TooltipContent>
+            <TooltipContent>
+              {isRunning ? "Pause" : "Run"} · {playPauseShortcut}
+            </TooltipContent>
           </Tooltip>
 
           {/* Step */}
@@ -237,6 +219,7 @@ export function PlaybackControls({
             <TooltipTrigger asChild>
               <Button
                 aria-label="Step"
+                aria-keyshortcuts={ariaKeyShortcuts("step")}
                 data-onboarding-step="step"
                 variant="ghost"
                 size="icon"
@@ -266,8 +249,8 @@ export function PlaybackControls({
               {state === "paused" && pauseReason === "stuck"
                 ? "Nothing can run: deadlocked, or waiting on something outside"
                 : state === "idle" || state === "finished"
-                  ? "Start paused, then step"
-                  : "Step"}
+                  ? `Start paused, then step · ${stepShortcut}`
+                  : `Step · ${stepShortcut}`}
             </TooltipContent>
           </Tooltip>
 

--- a/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/useKeyboardShortcuts.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
+
+interface HarnessProps {
+  onPlayPause: () => void;
+  onStep: () => void;
+}
+
+function Harness(props: HarnessProps) {
+  useKeyboardShortcuts(props);
+  return (
+    <>
+      {/* Monaco's own class, which is what the hook looks for. */}
+      {/* eslint-disable-next-line better-tailwindcss/no-unregistered-classes */}
+      <div className="monaco-editor">
+        <textarea data-testid="in-editor" />
+      </div>
+      <div role="dialog">
+        <button data-testid="in-dialog" type="button" />
+      </div>
+      <button data-testid="elsewhere" type="button" />
+    </>
+  );
+}
+
+describe("useKeyboardShortcuts", () => {
+  const onPlayPause = vi.fn();
+  const onStep = vi.fn();
+
+  beforeEach(() => {
+    onPlayPause.mockClear();
+    onStep.mockClear();
+    // jsdom reports no platform, and the fallback would then read a user agent
+    // that differs per machine. Pin it so the tests exercise the Ctrl branch.
+    Object.defineProperty(window.navigator, "platform", {
+      value: "Win32",
+      configurable: true,
+    });
+  });
+
+  it("runs or pauses on Ctrl+Enter", () => {
+    render(<Harness onPlayPause={onPlayPause} onStep={onStep} />);
+
+    fireEvent.keyDown(document.body, { key: "Enter", ctrlKey: true });
+
+    expect(onPlayPause).toHaveBeenCalledTimes(1);
+    expect(onStep).not.toHaveBeenCalled();
+  });
+
+  it("steps on Ctrl+Shift+Enter", () => {
+    render(<Harness onPlayPause={onPlayPause} onStep={onStep} />);
+
+    fireEvent.keyDown(document.body, {
+      key: "Enter",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(onStep).toHaveBeenCalledTimes(1);
+    expect(onPlayPause).not.toHaveBeenCalled();
+  });
+
+  it("ignores a bare Enter", () => {
+    render(<Harness onPlayPause={onPlayPause} onStep={onStep} />);
+
+    fireEvent.keyDown(document.body, { key: "Enter" });
+
+    expect(onPlayPause).not.toHaveBeenCalled();
+    expect(onStep).not.toHaveBeenCalled();
+  });
+
+  it("ignores a held chord, which would outrun a container round trip", () => {
+    render(<Harness onPlayPause={onPlayPause} onStep={onStep} />);
+
+    fireEvent.keyDown(document.body, {
+      key: "Enter",
+      ctrlKey: true,
+      repeat: true,
+    });
+
+    expect(onPlayPause).not.toHaveBeenCalled();
+  });
+
+  it("leaves presses inside the editor to Monaco", () => {
+    render(<Harness onPlayPause={onPlayPause} onStep={onStep} />);
+
+    fireEvent.keyDown(screen.getByTestId("in-editor"), {
+      key: "Enter",
+      ctrlKey: true,
+    });
+
+    expect(onPlayPause).not.toHaveBeenCalled();
+  });
+
+  it("does nothing while a modal has focus", () => {
+    render(<Harness onPlayPause={onPlayPause} onStep={onStep} />);
+
+    fireEvent.keyDown(screen.getByTestId("in-dialog"), {
+      key: "Enter",
+      ctrlKey: true,
+    });
+
+    expect(onPlayPause).not.toHaveBeenCalled();
+  });
+
+  it("calls the current handler after a re-render", () => {
+    const { rerender } = render(
+      <Harness onPlayPause={onPlayPause} onStep={onStep} />,
+    );
+    const later = vi.fn();
+    rerender(<Harness onPlayPause={later} onStep={onStep} />);
+
+    fireEvent.keyDown(document.body, { key: "Enter", ctrlKey: true });
+
+    expect(later).toHaveBeenCalledTimes(1);
+    expect(onPlayPause).not.toHaveBeenCalled();
+  });
+
+  it("stops listening once unmounted", () => {
+    const { unmount } = render(
+      <Harness onPlayPause={onPlayPause} onStep={onStep} />,
+    );
+    unmount();
+
+    fireEvent.keyDown(document.body, { key: "Enter", ctrlKey: true });
+
+    expect(onPlayPause).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from "react";
+
+import { matchesShortcut } from "@/lib/keyboardShortcuts";
+
+interface KeyboardShortcutHandlers {
+  onPlayPause: () => void;
+  onStep: () => void;
+}
+
+/**
+ * Binds the playback shortcuts everywhere on the page except inside Monaco.
+ * Monaco resolves its own keybindings on its DOM node and stops these presses
+ * from bubbling, so it registers the same two actions itself; see
+ * `registerPlaybackActions` in `CodeEditor`.
+ *
+ * Handlers are read through a ref so the listener is attached once and still
+ * calls the current closure: its caller rebuilds them every render.
+ */
+export function useKeyboardShortcuts(handlers: KeyboardShortcutHandlers): void {
+  const handlersRef = useRef(handlers);
+  useEffect(() => {
+    handlersRef.current = handlers;
+  });
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      // A held chord would queue steps faster than a WebContainer round trip
+      // can answer them.
+      if (event.repeat) return;
+      // Monaco owns these presses in the editor, and running a program behind
+      // an open modal is not what the press meant.
+      if (
+        event.target instanceof Element &&
+        event.target.closest('.monaco-editor, [role="dialog"]')
+      ) {
+        return;
+      }
+      if (matchesShortcut("playPause", event)) {
+        event.preventDefault();
+        handlersRef.current.onPlayPause();
+        return;
+      }
+      if (matchesShortcut("step", event)) {
+        event.preventDefault();
+        handlersRef.current.onStep();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+}

--- a/src/lib/keyboardShortcuts.test.ts
+++ b/src/lib/keyboardShortcuts.test.ts
@@ -1,0 +1,107 @@
+import {
+  ariaKeyShortcuts,
+  formatShortcut,
+  matchesShortcut,
+} from "./keyboardShortcuts";
+
+/** A key press with nothing held, to be narrowed per case. */
+function press(
+  overrides: Partial<
+    Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey">
+  > = {},
+) {
+  return {
+    key: "Enter",
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...overrides,
+  };
+}
+
+const apple = { apple: true };
+const other = { apple: false };
+
+describe("matchesShortcut", () => {
+  it("matches Cmd+Enter as play/pause on Apple platforms", () => {
+    expect(matchesShortcut("playPause", press({ metaKey: true }), apple)).toBe(
+      true,
+    );
+    expect(matchesShortcut("step", press({ metaKey: true }), apple)).toBe(
+      false,
+    );
+  });
+
+  it("matches Cmd+Shift+Enter as step on Apple platforms", () => {
+    expect(
+      matchesShortcut("step", press({ metaKey: true, shiftKey: true }), apple),
+    ).toBe(true);
+    expect(
+      matchesShortcut(
+        "playPause",
+        press({ metaKey: true, shiftKey: true }),
+        apple,
+      ),
+    ).toBe(false);
+  });
+
+  it("matches Ctrl+Enter and Ctrl+Shift+Enter elsewhere", () => {
+    expect(matchesShortcut("playPause", press({ ctrlKey: true }), other)).toBe(
+      true,
+    );
+    expect(
+      matchesShortcut("step", press({ ctrlKey: true, shiftKey: true }), other),
+    ).toBe(true);
+  });
+
+  it("ignores the other platform's modifier", () => {
+    expect(matchesShortcut("playPause", press({ ctrlKey: true }), apple)).toBe(
+      false,
+    );
+    expect(matchesShortcut("playPause", press({ metaKey: true }), other)).toBe(
+      false,
+    );
+  });
+
+  it("ignores a press holding both modifiers", () => {
+    const both = press({ metaKey: true, ctrlKey: true });
+    expect(matchesShortcut("playPause", both, apple)).toBe(false);
+    expect(matchesShortcut("playPause", both, other)).toBe(false);
+  });
+
+  it("ignores Alt, which belongs to some other binding", () => {
+    expect(
+      matchesShortcut(
+        "playPause",
+        press({ metaKey: true, altKey: true }),
+        apple,
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores a bare Enter and any other key", () => {
+    expect(matchesShortcut("playPause", press(), apple)).toBe(false);
+    expect(
+      matchesShortcut("playPause", press({ key: "a", metaKey: true }), apple),
+    ).toBe(false);
+  });
+});
+
+describe("formatShortcut", () => {
+  it("reads as symbols on Apple platforms and words elsewhere", () => {
+    expect(formatShortcut("playPause", apple)).toBe("⌘↵");
+    expect(formatShortcut("step", apple)).toBe("⇧⌘↵");
+    expect(formatShortcut("playPause", other)).toBe("Ctrl+Enter");
+    expect(formatShortcut("step", other)).toBe("Ctrl+Shift+Enter");
+  });
+});
+
+describe("ariaKeyShortcuts", () => {
+  it("announces only the modifier the platform uses", () => {
+    expect(ariaKeyShortcuts("playPause", apple)).toBe("Meta+Enter");
+    expect(ariaKeyShortcuts("step", apple)).toBe("Meta+Shift+Enter");
+    expect(ariaKeyShortcuts("playPause", other)).toBe("Control+Enter");
+    expect(ariaKeyShortcuts("step", other)).toBe("Control+Shift+Enter");
+  });
+});

--- a/src/lib/keyboardShortcuts.ts
+++ b/src/lib/keyboardShortcuts.ts
@@ -1,0 +1,93 @@
+/**
+ * The playback shortcuts, in one place because two very different mechanisms
+ * have to agree on them: a window listener for the page (see
+ * `useKeyboardShortcuts`) and Monaco's own keybinding service for the editor
+ * (see `CodeEditor`), which resolves presses itself and never lets them bubble.
+ *
+ * `Cmd/Ctrl+Enter` for Run is what the TypeScript Sandbox, CodeSandbox and
+ * Observable all use, so it is the nearest thing to a convention for a code
+ * sandbox. Step is the same key one modifier further out, which keeps the pair
+ * learnable and lets a step repeat by holding the modifiers and tapping Enter.
+ */
+export type ShortcutId = "playPause" | "step";
+
+interface PlatformOption {
+  /** Overrides platform detection, so both branches are testable. */
+  apple?: boolean;
+}
+
+/** Only the parts of a key press the shortcuts look at. */
+type KeyPress = Pick<
+  KeyboardEvent,
+  "key" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey"
+>;
+
+/**
+ * Whether the primary modifier is Cmd rather than Ctrl — the same split Monaco
+ * makes with `KeyMod.CtrlCmd`, so the editor and the page stay in agreement.
+ */
+export function isApplePlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  // `userAgentData` is Chromium-only and not in lib.dom, hence the local shape.
+  const { userAgentData } = navigator as Navigator & {
+    userAgentData?: { platform?: string };
+  };
+  const platform = userAgentData?.platform;
+  if (typeof platform === "string" && platform.length > 0) {
+    return /mac/i.test(platform);
+  }
+  // `navigator.platform` is deprecated but is still the only reading Safari and
+  // Firefox offer; iPadOS answers "MacIntel", which is the right answer here.
+  return /mac|iphone|ipad|ipod/i.test(
+    navigator.platform || navigator.userAgent,
+  );
+}
+
+/**
+ * Whether a press is the given shortcut. The primary modifier is matched
+ * exclusively, so a press holding both Cmd and Ctrl belongs to neither platform
+ * and fires nothing.
+ */
+export function matchesShortcut(
+  id: ShortcutId,
+  event: KeyPress,
+  options: PlatformOption = {},
+): boolean {
+  // Checked first so that ordinary typing, which this sees every keystroke of,
+  // costs one comparison.
+  if (event.key !== "Enter") return false;
+  if (event.altKey) return false;
+  const apple = options.apple ?? isApplePlatform();
+  const hasPrimary = apple
+    ? event.metaKey && !event.ctrlKey
+    : event.ctrlKey && !event.metaKey;
+  if (!hasPrimary) return false;
+  return event.shiftKey === (id === "step");
+}
+
+/** The shortcut as a reader sees it, for tooltips and help text. */
+export function formatShortcut(
+  id: ShortcutId,
+  options: PlatformOption = {},
+): string {
+  const apple = options.apple ?? isApplePlatform();
+  const withShift = id === "step";
+  if (apple) return `${withShift ? "⇧" : ""}⌘↵`;
+  return `Ctrl+${withShift ? "Shift+" : ""}Enter`;
+}
+
+/**
+ * The shortcut in the notation `aria-keyshortcuts` expects. Only the modifier
+ * the platform actually uses is announced, so a Windows user is not read a Mac
+ * binding they cannot press.
+ */
+export function ariaKeyShortcuts(
+  id: ShortcutId,
+  options: PlatformOption = {},
+): string {
+  const apple = options.apple ?? isApplePlatform();
+  const parts = [apple ? "Meta" : "Control"];
+  if (id === "step") parts.push("Shift");
+  parts.push("Enter");
+  return parts.join("+");
+}

--- a/src/lib/playbackAvailability.test.ts
+++ b/src/lib/playbackAvailability.test.ts
@@ -1,0 +1,74 @@
+import {
+  getPlaybackAvailability,
+  type PauseReason,
+  type PlaybackState,
+} from "./playbackAvailability";
+
+function availability(
+  state: PlaybackState,
+  {
+    pauseReason = "user",
+    isPlayDisabled = false,
+  }: { pauseReason?: PauseReason; isPlayDisabled?: boolean } = {},
+) {
+  return getPlaybackAvailability({ state, pauseReason, isPlayDisabled });
+}
+
+/**
+ * These rules are read by the buttons and by the keyboard shortcuts, so they are
+ * pinned here rather than left to whichever caller is being changed.
+ */
+describe("getPlaybackAvailability", () => {
+  it("offers Play from every stopped or paused state", () => {
+    expect(availability("idle").canPlay).toBe(true);
+    expect(availability("paused").canPlay).toBe(true);
+    expect(availability("finished").canPlay).toBe(true);
+    expect(availability("running").canPlay).toBe(false);
+    expect(availability("starting").canPlay).toBe(false);
+  });
+
+  it("withholds Play and Step while the container is unavailable", () => {
+    const booting = { isPlayDisabled: true };
+    expect(availability("idle", booting).canPlay).toBe(false);
+    expect(availability("idle", booting).canStep).toBe(false);
+    expect(availability("finished", booting).canStep).toBe(false);
+  });
+
+  it("steps a stopped program, which starts it gated", () => {
+    expect(availability("idle").canStep).toBe(true);
+    expect(availability("finished").canStep).toBe(true);
+  });
+
+  it("steps a paused program only while the pause is the user's", () => {
+    expect(availability("paused", { pauseReason: "user" }).canStep).toBe(true);
+    // Nothing is runnable, so a step would release nothing.
+    expect(availability("paused", { pauseReason: "stuck" }).canStep).toBe(
+      false,
+    );
+  });
+
+  it("never steps a program that is free-running or still starting", () => {
+    expect(availability("running").canStep).toBe(false);
+    expect(availability("starting").canStep).toBe(false);
+  });
+
+  it("pauses only a running program", () => {
+    expect(availability("running").canPause).toBe(true);
+    expect(availability("paused").canPause).toBe(false);
+    expect(availability("idle").canPause).toBe(false);
+  });
+
+  it("has nothing to reset before the first run", () => {
+    expect(availability("idle").canReset).toBe(false);
+    expect(availability("running").canReset).toBe(true);
+    expect(availability("finished").canReset).toBe(true);
+  });
+
+  it("fixes the rate for the life of a run", () => {
+    expect(availability("idle").canChangeSpeed).toBe(true);
+    expect(availability("paused").canChangeSpeed).toBe(true);
+    expect(availability("finished").canChangeSpeed).toBe(true);
+    expect(availability("running").canChangeSpeed).toBe(false);
+    expect(availability("starting").canChangeSpeed).toBe(false);
+  });
+});

--- a/src/lib/playbackAvailability.ts
+++ b/src/lib/playbackAvailability.ts
@@ -1,0 +1,60 @@
+export type PlaybackState =
+  | "idle"
+  | "starting"
+  | "running"
+  | "paused"
+  | "finished";
+
+/**
+ * Why execution is paused. Only a user pause can be stepped: `stuck` means
+ * nothing is runnable and no deadline is pending, so a step would do nothing.
+ *
+ * A stuck program is either deadlocked or waiting on something outside. Telling
+ * those apart needs a fiber's status, which is itself an Effect and so needs the
+ * scheduler that a pause is holding.
+ */
+export type PauseReason = "user" | "stuck";
+
+export interface PlaybackAvailability {
+  canPlay: boolean;
+  canPause: boolean;
+  canStep: boolean;
+  canReset: boolean;
+  canChangeSpeed: boolean;
+}
+
+/**
+ * Which controls the current playback state allows. It lives apart from
+ * `PlaybackControls` because the keyboard shortcuts in `MainLayout` have to obey
+ * exactly the same rules as the buttons — a shortcut that outran them could
+ * start a run the Reset button cannot reach.
+ */
+export function getPlaybackAvailability({
+  state,
+  pauseReason,
+  isPlayDisabled,
+}: {
+  state: PlaybackState;
+  pauseReason: PauseReason;
+  isPlayDisabled: boolean;
+}): PlaybackAvailability {
+  return {
+    // Play doubles as resume (from paused) and re-run (from finished).
+    canPlay:
+      (state === "idle" || state === "paused" || state === "finished") &&
+      !isPlayDisabled,
+    canPause: state === "running",
+    // Step from a stopped program starts it already gated, so its very first
+    // events can be stepped through; like Play, that includes re-running one
+    // that has finished. Otherwise stepping needs a live, frozen program, and a
+    // stuck pause has nothing the runtime could release.
+    canStep:
+      ((state === "idle" || state === "finished") && !isPlayDisabled) ||
+      (state === "paused" && pauseReason === "user"),
+    // Nothing to reset before the first run.
+    canReset: state !== "idle",
+    // The rate is fixed when the program starts: the WebContainer receives it as
+    // a spawn environment variable and cannot be retuned until it is restarted.
+    canChangeSpeed: state !== "running" && state !== "starting",
+  };
+}


### PR DESCRIPTION
`Cmd/Ctrl+Enter` runs or pauses, `Cmd/Ctrl+Shift+Enter` steps. `Cmd+Enter` for run follows the TypeScript Sandbox; step is the same key one modifier out, so the pair is learnable as one idea and repeats by holding the modifiers and tapping Enter. Neither is browser-reserved on macOS, Linux or Windows.

Two mechanisms, because Monaco resolves keybindings on its own DOM node and stops these presses from bubbling. `useKeyboardShortcuts` binds one window listener for the page, skipping presses inside `.monaco-editor` or an open dialog; `registerPlaybackActions` in `CodeEditor` registers the same two as Monaco actions, which also lists them in its context menu and command palette. They take over Monaco's *Insert Line Below* / *Insert Line Above*, which stay reachable from that palette. `getPlaybackAvailability` moved out of `PlaybackControls` into `src/lib/playbackAvailability.ts` so the shortcuts and the buttons read one set of enablement rules — pressing `Cmd+Enter` while the WebContainer boots does nothing. Shortcuts appear in the tooltips and in `aria-keyshortcuts`, never in `aria-label`, which the demo recorder matches on.

The second commit fixes a pre-existing info-modal bug: its body overflowed `max-h-[60vh]` and overlay scrollbars showed nothing, so the footer links read as missing. They now sit outside the scroll area, and a smaller desktop QR (200 → 160) lets the rest fit without scrolling at all.

Verified with unit tests for the matcher, the hook and the availability rules, plus manual checks in the browser: the `aria-keyshortcuts` values, the boot-time no-op, and the modal measurements. The Monaco-side registration is CDN-loaded and untestable in jsdom, so it was only checked by hand.