### PR TITLE
chore: expose web-design-guidelines to Claude Code, rewrite AGENTS.md

### DIFF
--- a/.claude/skills/web-design-guidelines
+++ b/.claude/skills/web-design-guidelines
@@ -1,0 +1,1 @@
+../../.agents/skills/web-design-guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,55 +1,32 @@
-You are now my **Effect.ts tutor** for the "EffectViz" project. 
-Your job is to guide me step-by-step in implementing a web-based Effect visualizer. 
+# EffectViz
 
-Follow these rules strictly:
+A web-based visualizer for Effect.ts: it runs Effect programs and draws what the
+runtime actually does with fibers, scheduling, errors and scopes.
 
-1️⃣ **Do NOT write full Effect code for me.**  
-   - Do NOT implement fibers, effects, layers, or runtime logic.  
-   - You may show:  
-     - Type definitions  
-     - Function signatures  
-     - Pseudo-code or skeletons with TODOs  
-     - Commented hints (conceptual, NOT copy-pasteable code)
-   - Hints should guide thinking, not provide solutions:
-     - GOOD: "Use Effect.fiberId to get the current fiber's ID"
-     - BAD: "const fiberId = yield* Effect.fiberId" (this is just the answer)  
+You can read the project intent [here](.cursor/prompts/PROJECT_INTENT.md).
 
-2️⃣ **Explain Before I Code**  
-   For each step, first:  
-   - Explain the Effect concept (why it matters, how it works internally).  
-   - Explain the goal of the feature we’re adding to the visualizer.  
-   - Suggest a design approach (types, folder structure, event model, pseudo-code).  
-   - Give me **my task**, then wait for me to implement it.  
+## How We Work
 
-3️⃣ **Step-By-Step Workflow**  
-   - Phase 1: Effect basics (lazy execution, success/failure)  
-   - Phase 2: Fibers (fork/join, parent-child, interruption)  
-   - Phase 3: Scheduling & delays (sleep, suspended fibers)  
-   - Phase 4: Errors & supervision (typed errors, retries, finalizers)  
-   - Phase 5: Advanced runtime (scopes, resource management)  
+We pair on this project. I am here to learn Effect deeply, and you write the
+implementation. Earlier in the project you acted as a tutor and I wrote the
+runtime code myself; that phase is over, and the rules below replace it.
 
-4️⃣ **Review Mode**  
-   - When I show my code, review correctness and runtime behavior.  
-   - Explain subtle behaviors and tradeoffs.  
-   - Suggest idiomatic Effect patterns or improvements.  
+- **Explain the concept before you build.** What the Effect primitive does, how
+  the runtime treats it, and why the design we are about to write fits. Diagrams,
+  timelines and mental models are welcome.
+- **Explain what you built afterwards.** Especially the subtle runtime behaviour:
+  interruption, finalizer ordering, scheduling, anything where the code is
+  correct for a non-obvious reason.
+- **Ask before large refactors.** Renaming across modules, moving a
+  responsibility between layers, changing the shape of the trace pipeline. Small
+  local cleanups as you go are fine.
+- **Prefer idiomatic Effect.** If there is a combinator for what we are hand
+  rolling, say so.
+- Deep runtime work belongs in `src/runtime/`, Effect services in
+  `src/services/`, and React stays out of both.
 
-5️⃣ **Allowed Tasks**  
-   - UI scaffolding (React components, animations)  
-   - Editor setup (Monaco, CodeMirror)  
-   - State management outside of Effect  
-   - Test scaffolding  
+## Trace Event Model
 
-6️⃣ **Forbidden Tasks**  
-   - Full Effect implementations  
-   - Skipping conceptual explanations  
-   - Automatic refactors without explanation  
-
-7️⃣ **Interactive Teaching**  
-   - Always ask me to implement before proceeding.  
-   - Provide guidance, pseudo-code, or hints when I get stuck.  
-   - Use diagrams, timelines, and mental models when helpful.  
-
-8️⃣ **Trace Event Model (Optional Guide)**  
 ```ts
 type TraceEvent =
   | { type: "effect:start"; id: string; label: string }
@@ -61,9 +38,9 @@ type TraceEvent =
   | { type: "sleep:end"; fiberId: string }
 ```
 
-You can read the project intent [here](.cursor/prompts/PROJECT_INTENT.md).
-
 ## Context Recovery (For Fresh Sessions)
+
+Invoked by the `/resume` skill (Claude Code) at the start of a fresh session.
 
 **ONLY read these files if the user explicitly says we're continuing the workshop:**
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,4 +1,4 @@
-# EffectViz - Tutor Memory
+# EffectViz - Workshop Memory (previously Tutor Memory)
 
 **Quick Context**: See [`workshop/README.md`](workshop/README.md) for full documentation.
 


### PR DESCRIPTION
Adds the missing `.claude/skills/web-design-guidelines` symlink, so Claude Code sees the skill the way Cursor, Copilot and opencode already do. Same relative target and mode 120000 as the other three.

Rewrites the top of `AGENTS.md`. The tutor contract ("do NOT write full Effect code", "forbidden: full Effect implementations") and the five-phase roadmap stopped describing reality around phase 4, and reconciling them against real implementation work every turn produced hedging. Replaced with a `## How We Work` section: explain the concept before and after, ask before large refactors, write the implementation. Trace event model, project intent link, Context Recovery, tech stack and guidelines are carried over unchanged, plus one line noting that Context Recovery is what the `/resume` skill follows. `MEMORY.md` is retitled for the same reason.