### PR TITLE
feat(info): show the served origin under the QR code

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can **slow down** a program so that its sleeps stretch out, or **pause** it 
 
 This project is a learning project for me to understand the Effect runtime. My learning journey is documented in the [`workshop/`](./workshop/) folder, with each phase covering different Effect concepts (lazy evaluation, fibers, scheduling, errors, scopes). Check out the [AGENTS.md](./AGENTS.md) file for the AI approach.
 
-https://github.com/user-attachments/assets/52c76062-61e9-47fa-8b3d-6032ea8e8f90
+https://github.com/user-attachments/assets/26d25026-b17e-4725-8547-6717b7cd9bec
 
 ## Resources
 

--- a/src/components/layout/InfoModal.tsx
+++ b/src/components/layout/InfoModal.tsx
@@ -31,6 +31,25 @@ const QR_SIZE_MOBILE = 64;
 /** The mobile QR tapped to full screen, where there is room for a big one. */
 const QR_SIZE_FULLSCREEN = 200;
 
+/**
+ * Tells a dev machine host apart from a deployed one, matching `localhost`, the
+ * loopback addresses, `.local` names and the private IPv4 ranges the dev server
+ * is reached on from another device.
+ */
+function isLocalHostname(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "0.0.0.0" ||
+    hostname === "[::1]" ||
+    hostname === "::1" ||
+    hostname.endsWith(".local") ||
+    /^10\./.test(hostname) ||
+    /^192\.168\./.test(hostname) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(hostname)
+  );
+}
+
 interface InfoModalProps {
   onboardingStep?: OnboardingStepId | null;
   onOnboardingComplete?: (stepId: OnboardingStepId) => void;
@@ -46,6 +65,17 @@ export function InfoModal({
     const [url] = window.location.href.split("#");
     return url;
   });
+
+  /**
+   * The URL shown under the QR code: the origin we are served from, so a Vercel
+   * preview deployment names itself, falling back to the canonical site URL on a
+   * dev machine, whose host means nothing to a viewer.
+   */
+  const [displayUrl] = useState<string>(() =>
+    isLocalHostname(window.location.hostname)
+      ? import.meta.env.VITE_WEBSITE_URL
+      : window.location.origin,
+  );
 
   const canSupportWebContainer = useCanSupportWebContainer();
   // Safari desktop cannot run the WebContainer but still has a keyboard, so the
@@ -255,7 +285,18 @@ export function InfoModal({
                 max-w-full text-center text-sm break-all text-muted-foreground
               `}
             >
-              {currentUrl}
+              <span title={currentUrl}>
+                {
+                  /*
+                   * Displays an origin instead of `currentUrl`, so that a screen
+                   * recording shows https://effect-viz.vercel.app rather than a
+                   * localhost or share URL. The QR code above is unaffected, it
+                   * still encodes `currentUrl`, which stays reachable through
+                   * the title tooltip.
+                   */
+                  displayUrl
+                }
+              </span>
             </p>
           </div>
         </div>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,3 +2,12 @@
 
 /** The `effect` version this build resolves, injected by Vite. See vite.config.ts. */
 declare const __EFFECT_VERSION__: string;
+
+interface ImportMetaEnv {
+  /** The canonical deployed URL, from `.env`. */
+  readonly VITE_WEBSITE_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
The URL under the QR code in the info modal used to be `window.location.href`, which meant a demo recorded from the dev server showed `http://localhost:5173` (or a LAN IP, when driving the app from a phone). It now renders `window.location.origin`, so a Vercel preview deployment names itself, and falls back to `VITE_WEBSITE_URL` when `isLocalHostname` (top of `InfoModal.tsx`) recognises the host as a dev machine — `localhost`, the loopback addresses, `*.local`, and the private IPv4 ranges. Using the origin rather than the full URL also keeps a shared program's query string off camera. The QR code and the `title` tooltip are untouched: both still carry the real URL, so scanning and sharing work as before.

`src/vite-env.d.ts` gains an `ImportMetaEnv` declaration for `VITE_WEBSITE_URL`, the first env var read from app code rather than substituted into `index.html`. It merges with vite/client's interface, so the value is typed `string` instead of `any` — but that interface carries an index signature, so a misspelled key still slips through.

The README video is replaced with a new recording made from local, which this change is what makes possible.