### PR TITLE
feat(speed): change speed during a run

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -3,6 +3,8 @@
 **Quick Context**: See [`workshop/README.md`](workshop/README.md) for full documentation.
 
 ## Current Phase
+**Phase 11**: COMPLETE ✅ — speed is live during a run (`workshop/phase-11.md`). The rate travels on the control channel alongside pause, resume and step, so a running program is retuned where it stands and a paused one resumes at the rate chosen while it was frozen. `VIZ_RATE` still sets the rate a run opens at.
+
 **Phase 10**: COMPLETE ✅ — slow mode & stepper (issue #13). All steps done: VirtualClock, Effect Clock layer, Date shim, virtual timestamps, GatedScheduler + step ladder, control channel for the WebContainer, speed combo + stepper controls, origin tagging with show-internals toggle, and five new example programs.
 
 **Deferred**: Step Over — running to the end of the current span rather than stopping at every event inside it — is not implemented, and `PlaybackControls` carries no button for it.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can **slow down** a program so that its sleeps stretch out, or **pause** it 
 
 This project is a learning project for me to understand the Effect runtime. My learning journey is documented in the [`workshop/`](./workshop/) folder, with each phase covering different Effect concepts (lazy evaluation, fibers, scheduling, errors, scopes). Check out the [AGENTS.md](./AGENTS.md) file for the AI approach.
 
-https://github.com/user-attachments/assets/26d25026-b17e-4725-8547-6717b7cd9bec
+https://github.com/user-attachments/assets/45831831-afa8-4eb5-b927-fbfa10011d47
 
 ## Resources
 

--- a/scripts/demo/scenario.ts
+++ b/scripts/demo/scenario.ts
@@ -215,6 +215,21 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   const untilStatus = (state: string, timeout = 60_000) =>
     status.filter({ hasText: new RegExp(`^${state}$`) }).waitFor({ timeout });
 
+  /**
+   * Blocks until the Timeline has bars on it.
+   *
+   * `running` is reported by the playback bar as soon as the runtime starts,
+   * which is a beat before the run's first events have crossed out of the
+   * container and been drawn. A beat that changes what execution looks like has
+   * to wait for that, or it lands on an empty panel.
+   */
+  const untilTimelineDrawn = (timeout = 30_000) =>
+    page
+      .getByText("No events to display")
+      .filter({ visible: true })
+      .first()
+      .waitFor({ state: "hidden", timeout });
+
   const untilNotStatus = (state: string, timeout = 30_000) =>
     status
       .filter({ hasNotText: new RegExp(`^${state}$`) })
@@ -247,7 +262,7 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
     { timeout: 120_000 },
   );
   mark("ready");
-  await cursor.pause(900);
+  await cursor.pause(650);
 
   // --- Act 1: run it once at full speed and read the three views -----------
   await cursor.click(runButton);
@@ -274,38 +289,57 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   );
 
   await untilStatus("finished");
-  await cursor.pause(300);
+  await cursor.pause(250);
 
   await cursor.moveToLocator(fiberTree);
-  await cursor.pause(520);
+  await cursor.pause(460);
   await cursor.moveToLocator(executionLog);
-  await cursor.pause(560);
+  await cursor.pause(500);
   mark("act 1 — run and inspect");
 
-  // --- Act 2: same program, slower clock, then step through it -------------
-  // The speed change lands between two runs of the same program on purpose:
-  // the only thing that differs is how long it takes, which is the point.
-  // Picking a speed starts the run itself, so there is no Run press here.
+  // --- Act 2: slow the clock mid-run, then step through it -----------------
+  // Picking a speed on a stopped program starts the run itself, so there is no
+  // Run press here.
   await cursor.select(speedSelect, "0.5");
   await untilStatus("running");
-  await cursor.pause(600);
+  await untilTimelineDrawn();
 
+  // The second pick lands on the live program: the run does not restart, it
+  // changes slope where it stands. It follows the first with no beat between
+  // them because the whole Basic Example is only about 1.5 virtual seconds
+  // long — every beat below has to fit in what is left of it, and a change that
+  // lands near the end has nothing left to be visible in.
+  await cursor.select(speedSelect, "0.25");
+
+  // No beat between the pick and the pause: the slower slope stays on screen
+  // for the second the pointer takes to travel to Pause, and pausing early
+  // leaves enough of the program for the steps below to walk through.
   await cursor.click(pauseButton);
   await untilStatus("paused");
-  await cursor.pause(500);
+  await cursor.pause(400);
 
-  for (let i = 0; i < 2; i++) {
+  // Several presses, not one: a single step reads as a twitch, while a run of
+  // them shows the ladder — one event released per press, the log growing a
+  // line at a time. Stepping costs no wall clock, because a paused program only
+  // advances when it is told to, so this is the one beat the 1.5 virtual
+  // seconds of the Basic Example do not have to pay for.
+  for (let i = 0; i < 4; i++) {
+    // Stepping off the end of the program does not stop: from `finished`, Step
+    // starts a fresh gated run, which would blank the panels mid-act.
+    if ((await status.textContent())?.trim() !== "paused") break;
     await cursor.click(stepButton);
-    await cursor.pause(380);
+    await cursor.pause(430);
   }
 
-  await runToCompletion();
-  await cursor.pause(700);
-  mark("act 2 — slow down and step");
+  // The act ends here, paused part way through: resuming would cost five
+  // seconds of watching a quarter-speed run reach an end act 1 already showed,
+  // and act 3 opens on Reset, which clears the paused run anyway.
+  await cursor.pause(600);
+  mark("act 2 — slow down mid-run, then step");
 
   // --- Act 3: the editor is live, and the runtime says so ------------------
   await cursor.click(resetButton);
-  await cursor.pause(400);
+  await cursor.pause(300);
 
   // Renaming a span keeps the run the same length, and the new names come back
   // out of the runtime in the execution log — which is the point being made.
@@ -317,15 +351,15 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   await cursor.doubleClick({ x: span.x + 3, y: span.y });
   await cursor.pause(250);
   await page.keyboard.press("ControlOrMeta+Shift+L");
-  await cursor.pause(650);
-  await page.keyboard.type("job", { delay: 110 });
   await cursor.pause(550);
+  await page.keyboard.type("job", { delay: 110 });
+  await cursor.pause(450);
 
-  // Back to full speed, which starts the run: act 2 left the clock at 0.5, and
+  // Back to full speed, which starts the run: act 2 left the clock at 0.25, and
   // the edit is meant to be read at the same pace as act 1.
   await cursor.select(speedSelect, "1");
   await untilStatus("finished");
-  await cursor.pause(650);
+  await cursor.pause(550);
   mark("act 3 — edit and re-run");
 
   // --- Act 4: break the retry policy and watch the run go red --------------
@@ -333,10 +367,10 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
   await cursor.pause(250);
 
   await cursor.select(programSelect, "retryExponentialBackoff");
-  await cursor.pause(350);
+  await cursor.pause(300);
 
   await runToCompletion();
-  await cursor.pause(450);
+  await cursor.pause(350);
 
   // `flakyEffect` only succeeds once n >= 5, and the `if (n < 5)` guard is left
   // alone, so cutting the schedule to three retries makes failure certain.
@@ -344,19 +378,19 @@ export async function runScenario({ page, cursor, mark }: ScenarioContext) {
     within: "Schedule.recurs(5)",
   });
   await cursor.doubleClick({ x: recurs.x + 3, y: recurs.y });
-  await cursor.pause(300);
+  await cursor.pause(250);
   await page.keyboard.type("3", { delay: 110 });
-  await cursor.pause(450);
+  await cursor.pause(350);
 
   await runToCompletion();
-  await cursor.pause(700);
+  await cursor.pause(550);
 
   await cursor.moveToLocator(fiberTree);
-  await cursor.pause(950);
+  await cursor.pause(800);
   mark("act 4 — break the retry policy");
 
   // --- Close on the about box, the way the hand-made video did -------------
   await cursor.click(infoButton);
-  await cursor.pause(1500);
+  await cursor.pause(1200);
   mark("act 5 — about");
 }

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -60,6 +60,7 @@ export function MainLayout() {
     handlePause,
     handleResume,
     handleStep,
+    handleSetRate,
     handleReset,
     selectedProgram,
     setSelectedProgram,
@@ -292,16 +293,20 @@ export function MainLayout() {
   };
 
   /**
-   * Speed is read once, when a program starts, so changing it on a stopped
-   * program runs it again at the new rate rather than leaving the choice with
-   * nothing to show. A paused program keeps its session: the rate it was given
-   * holds until it is started again. The delay absorbs a keyboard user walking
-   * the options — a closed select fires a change per arrow key — instead of
-   * spawning a run for each one passed through.
+   * A live program — running or paused — is retuned where it stands, so slowing
+   * one down is possible at the moment you realise you cannot see what is
+   * happening. A stopped one has nothing to retune, so it is run again at the
+   * new rate rather than leaving the choice with nothing to show. The delay
+   * absorbs a keyboard user walking the options — a closed select fires a change
+   * per arrow key — instead of spawning a run for each one passed through.
    */
   const onSpeedChange = (next: Speed) => {
     setSpeed(next);
     cancelAutoStart();
+    if (playbackState === "running" || playbackState === "paused") {
+      handleSetRate(next);
+      return;
+    }
     if (playbackState !== "idle" && playbackState !== "finished") return;
     if (isPlayDisabled) return;
     const token = autoStartTokenRef.current;

--- a/src/components/layout/PlaybackControls.tsx
+++ b/src/components/layout/PlaybackControls.tsx
@@ -72,12 +72,14 @@ export function PlaybackControls({
     getPlaybackAvailability({ state, pauseReason, isPlayDisabled });
   const playPauseShortcut = formatShortcut("playPause");
   const stepShortcut = formatShortcut("step");
-  // Changing the speed of a stopped program runs it at the new rate. A live one,
-  // running or paused, keeps the rate it was given until it is started again.
+  // Changing the speed of a stopped program runs it at the new rate. A live one
+  // is retuned where it stands, and a paused one resumes at the new rate.
   const speedHint =
     state === "idle" || state === "finished"
       ? "Speed — slows the program's own clock, and runs it"
-      : "Speed applies on the next run";
+      : state === "paused"
+        ? "Speed — resumes at this rate"
+        : "Speed — slows the program's own clock as it runs";
   const [playMountAnimationEnded, setPlayMountAnimationEnded] = useState(false);
 
   // Skip showVisualizer step on desktop (toggle is hidden)

--- a/src/hooks/useEventHandlers.ts
+++ b/src/hooks/useEventHandlers.ts
@@ -72,13 +72,18 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
    * from a run that is no longer current are dropped.
    */
   const runIdRef = useRef(0);
+  /**
+   * The rate currently in effect. Read by the container's reply handler, which
+   * runs a round trip after the click that changed it.
+   */
+  const rateRef = useRef(1);
   const handlePlay = ({
     onFirstChunk,
     rate,
     startPaused = false,
   }: {
     onFirstChunk: () => void;
-    /** Virtual ms per wall ms. Fixed for the run: see PlaybackControls. */
+    /** Virtual ms per wall ms the run opens at; `handleSetRate` retunes it. */
     rate: number;
     /** Gate the scheduler before the program runs, so its first step is yours. */
     startPaused?: boolean;
@@ -88,6 +93,7 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
 
     clearEvents();
     clearFibers();
+    rateRef.current = rate;
     // The timeline's live cursor advances at this rate; see computeVirtualNow.
     setRate(rate);
 
@@ -110,6 +116,7 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
           // and a model resumed early would run ahead of it for good, since
           // corrections only move the cursor forward.
           if (reply.reply === "resume") mirror.resume();
+          if (reply.reply === "setRate") mirror.setRunRate(rateRef.current);
           controller?.handleReply(reply);
         },
         detach: () => controller?.detach(),
@@ -281,6 +288,21 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
     stepperRef.current?.play();
   };
 
+  /**
+   * Retune a live program. On the container path the mirrored clock follows on
+   * the reply, not here, so the page never predicts ahead of the process it is
+   * modelling.
+   */
+  const handleSetRate = (rate: number) => {
+    rateRef.current = rate;
+    setRate(rate);
+    if (webContainer?.isReady) {
+      containerRef.current?.setRate(rate);
+      return;
+    }
+    stepperRef.current?.setRate(rate);
+  };
+
   const handleStep = async (): Promise<StepOutcome | null> => {
     if (webContainer?.isReady) {
       return (await containerRef.current?.step()) ?? null;
@@ -294,6 +316,7 @@ export function useEventHandlers(webContainer?: WebContainerBridge | null) {
     handlePause,
     handleResume,
     handleStep,
+    handleSetRate,
     selectedProgram,
     setSelectedProgram,
     programs,

--- a/src/lib/containerController.test.ts
+++ b/src/lib/containerController.test.ts
@@ -20,6 +20,14 @@ describe("ContainerController", () => {
     expect(sent).toEqual([{ cmd: "pause" }, { cmd: "resume" }]);
   });
 
+  it("sends a rate change with its payload", () => {
+    const { controller, sent } = setup();
+
+    controller.setRate(0.25);
+
+    expect(sent).toEqual([{ cmd: "setRate", rate: 0.25 }]);
+  });
+
   it("resolves a step with the outcome the container reports", async () => {
     const { controller, sent } = setup();
 
@@ -92,6 +100,7 @@ describe("ContainerController", () => {
     const controller = new ContainerController();
 
     controller.pause();
+    controller.setRate(0.5);
     await expect(controller.step()).resolves.toBeNull();
   });
 });

--- a/src/lib/containerController.ts
+++ b/src/lib/containerController.ts
@@ -53,6 +53,15 @@ export class ContainerController {
     this.#send?.({ cmd: "resume" });
   }
 
+  /**
+   * Retune the running program. Nothing in the UI waits on the outcome, so
+   * unlike `step` this needs no promise; the reply still matters, because it is
+   * what tells the mirrored clock when the container actually changed slope.
+   */
+  setRate(rate: number): void {
+    this.#send?.({ cmd: "setRate", rate });
+  }
+
   step(): Promise<StepOutcome | null> {
     if (this.#send === null) return Promise.resolve(null);
     return new Promise<StepOutcome | null>((resolve) => {

--- a/src/lib/mirroredClock.test.ts
+++ b/src/lib/mirroredClock.test.ts
@@ -82,6 +82,45 @@ describe("MirroredClock", () => {
     expect(clock.now()).toBe(3000);
   });
 
+  it("changes slope without moving the cursor", () => {
+    const clock = new MirroredClock(1);
+    clock.sync(1000);
+    elapse(100);
+
+    clock.setRunRate(0.5);
+    expect(clock.now()).toBe(1100);
+
+    elapse(100);
+    expect(clock.now()).toBe(1150);
+  });
+
+  it("does not re-read the elapsed interval at the new rate", () => {
+    const clock = new MirroredClock(0.25);
+    clock.sync(1000);
+    elapse(400);
+
+    // Re-anchoring is what keeps this at 1100: without it the 400ms already
+    // elapsed would be re-read at 1x and the cursor would jump to 1400.
+    clock.setRunRate(1);
+
+    expect(clock.now()).toBe(1100);
+  });
+
+  it("holds a paused cursor still and applies the new rate on resume", () => {
+    const clock = new MirroredClock(1);
+    clock.sync(1000);
+    clock.pause();
+
+    clock.setRunRate(0.5);
+    elapse(1000);
+    expect(clock.rate).toBe(0);
+    expect(clock.now()).toBe(1000);
+
+    clock.resume();
+    elapse(200);
+    expect(clock.now()).toBe(1100);
+  });
+
   it("does not re-read the paused interval at the resumed rate", () => {
     const clock = new MirroredClock(1);
     clock.sync(1000);

--- a/src/lib/mirroredClock.ts
+++ b/src/lib/mirroredClock.ts
@@ -22,7 +22,8 @@ import { computeVirtualNow, type VirtualAnchor } from "@/lib/timelineTime";
 export class MirroredClock {
   /** The run's rate; 0 while paused. */
   #rate: number;
-  readonly #runRate: number;
+  /** The rate the run is going at when not paused; changes with the speed control. */
+  #runRate: number;
   #anchor: VirtualAnchor | null = null;
 
   constructor(rate: number) {
@@ -66,6 +67,20 @@ export class MirroredClock {
 
   resume(): void {
     this.#setRate(this.#runRate);
+  }
+
+  /**
+   * Follow a live speed change. Applied on the container's reply rather than on
+   * the click, for the same reason `resume` is: the container keeps running at
+   * the old rate for a round trip, and a model that changed slope early would
+   * predict ahead of it for good.
+   *
+   * While paused only `#runRate` moves — the cursor stays frozen and picks the
+   * new rate up on resume.
+   */
+  setRunRate(rate: number): void {
+    this.#runRate = rate;
+    if (this.#rate !== 0) this.#setRate(rate);
   }
 
   /** Re-anchor before the slope changes, or the elapsed interval is re-read at a rate that was never in effect for it. */

--- a/src/lib/playbackAvailability.test.ts
+++ b/src/lib/playbackAvailability.test.ts
@@ -64,11 +64,11 @@ describe("getPlaybackAvailability", () => {
     expect(availability("finished").canReset).toBe(true);
   });
 
-  it("fixes the rate for the life of a run", () => {
+  it("lets the rate change in every state, including mid-run", () => {
     expect(availability("idle").canChangeSpeed).toBe(true);
     expect(availability("paused").canChangeSpeed).toBe(true);
     expect(availability("finished").canChangeSpeed).toBe(true);
-    expect(availability("running").canChangeSpeed).toBe(false);
-    expect(availability("starting").canChangeSpeed).toBe(false);
+    expect(availability("running").canChangeSpeed).toBe(true);
+    expect(availability("starting").canChangeSpeed).toBe(true);
   });
 });

--- a/src/lib/playbackAvailability.ts
+++ b/src/lib/playbackAvailability.ts
@@ -53,8 +53,8 @@ export function getPlaybackAvailability({
       (state === "paused" && pauseReason === "user"),
     // Nothing to reset before the first run.
     canReset: state !== "idle",
-    // The rate is fixed when the program starts: the WebContainer receives it as
-    // a spawn environment variable and cannot be retuned until it is restarted.
-    canChangeSpeed: state !== "running" && state !== "starting",
+    // Speed is live in every state: a stopped program is re-run at the new rate,
+    // a live one is retuned in place.
+    canChangeSpeed: true,
   };
 }

--- a/src/runtime/controlChannel.test.ts
+++ b/src/runtime/controlChannel.test.ts
@@ -36,6 +36,7 @@ describe("command codec", () => {
     { cmd: "pause" },
     { cmd: "resume" },
     { cmd: "step" },
+    { cmd: "setRate", rate: 0.25 },
   ])("round-trips %o", (command) => {
     const encoded = encodeCommand(command);
     expect(encoded.endsWith("\n")).toBe(true);
@@ -50,6 +51,9 @@ describe("command codec", () => {
     ["null", "null"],
     ["object without cmd", '{"foo":1}'],
     ["unknown verb", '{"cmd":"explode"}'],
+    ["setRate without a rate", '{"cmd":"setRate"}'],
+    ["setRate with a non-numeric rate", '{"cmd":"setRate","rate":"fast"}'],
+    ["setRate with a negative rate", '{"cmd":"setRate","rate":-1}'],
   ])("returns null for %s", (_label, line) => {
     expect(decodeCommand(line)).toBeNull();
   });
@@ -120,6 +124,27 @@ describe("applyCommand", () => {
 
     expect(scheduler.mode).toBe("playing");
     expect(clock.rate).toBe(1);
+  });
+
+  it("setRate retunes a running clock and reads it back", () => {
+    const { clock, target } = setup();
+
+    const reply = applyCommand({ cmd: "setRate", rate: 0.25 }, target);
+
+    expect(reply).toMatchObject({ reply: "setRate" });
+    expect(typeof reply.virtualNow).toBe("number");
+    expect(clock.rate).toBe(0.25);
+  });
+
+  it("setRate on a paused program is what resume restores", () => {
+    const { clock, target } = setup();
+    applyCommand({ cmd: "pause" }, target);
+
+    applyCommand({ cmd: "setRate", rate: 0.5 }, target);
+    expect(clock.rate).toBe(0);
+
+    applyCommand({ cmd: "resume" }, target);
+    expect(clock.rate).toBe(0.5);
   });
 
   it("reports the outcome of a step", () => {

--- a/src/runtime/controlChannel.ts
+++ b/src/runtime/controlChannel.ts
@@ -2,9 +2,9 @@
  * The wire between the page and a program running in the WebContainer.
  *
  * The in-browser fallback holds its `Stepper` in a ref and calls it directly.
- * The container runs the program in another process, so the same three verbs —
- * pause, resume, step — have to travel as messages: commands in on the process's
- * stdin, replies out on its stdout, one JSON object per line.
+ * The container runs the program in another process, so the same four verbs —
+ * pause, resume, step, setRate — have to travel as messages: commands in on the
+ * process's stdin, replies out on its stdout, one JSON object per line.
  *
  * Replies exist for two reasons. A step returns a `StepOutcome`, which is what
  * tells the user a program is stuck rather than merely slow. And every reply
@@ -13,10 +13,8 @@
  * over a five second sleep jumps the clock by five seconds in one go, which no
  * amount of extrapolating from a rate will predict. See `workshop/phase-10.md`.
  *
- * Speed is deliberately not on the wire. It is fixed for the life of a run on
- * both paths — the container reads it once from `VIZ_RATE` at spawn — so a live
- * rate command would give the container path a capability the fallback does not
- * have.
+ * `VIZ_RATE` still gives the container the rate a run *opens* at; `setRate`
+ * is how it is retuned afterwards, so speed is live on both paths.
  */
 import type { StepOutcome, Stepper } from "@/runtime/stepper";
 import type { VirtualClock } from "@/runtime/virtualClock";
@@ -25,7 +23,9 @@ import type { VirtualClock } from "@/runtime/virtualClock";
 export type ControlCommand =
   | { readonly cmd: "pause" }
   | { readonly cmd: "resume" }
-  | { readonly cmd: "step" };
+  | { readonly cmd: "step" }
+  /** Retune the running program. `rate` is virtual ms per wall ms. */
+  | { readonly cmd: "setRate"; readonly rate: number };
 
 /**
  * Container → page. `virtualNow` is the authoritative reading of the container's
@@ -36,6 +36,7 @@ export type ControlReply =
   | { readonly reply: "ready"; readonly virtualNow: number }
   | { readonly reply: "pause"; readonly virtualNow: number }
   | { readonly reply: "resume"; readonly virtualNow: number }
+  | { readonly reply: "setRate"; readonly virtualNow: number }
   | {
       readonly reply: "step";
       readonly virtualNow: number;
@@ -48,7 +49,7 @@ export type ControlReply =
  */
 export const CONTROL_REPLY_PREFIX = "TRACE_CONTROL:";
 
-const COMMANDS = ["pause", "resume", "step"] as const;
+const COMMANDS = ["pause", "resume", "step", "setRate"] as const;
 
 export function encodeCommand(command: ControlCommand): string {
   return `${JSON.stringify(command)}\n`;
@@ -66,9 +67,17 @@ export function decodeCommand(line: string): ControlCommand | null {
   }
   if (typeof parsed !== "object" || parsed === null) return null;
   const cmd = (parsed as { cmd?: unknown }).cmd;
-  return COMMANDS.some((known) => known === cmd)
-    ? ({ cmd } as ControlCommand)
-    : null;
+  if (!COMMANDS.some((known) => known === cmd)) return null;
+  if (cmd === "setRate") {
+    // The only command with a payload, so it is the only one the codec cannot
+    // reconstruct from the verb alone.
+    const rate = (parsed as { rate?: unknown }).rate;
+    if (typeof rate !== "number" || !Number.isFinite(rate) || rate < 0) {
+      return null;
+    }
+    return { cmd, rate };
+  }
+  return { cmd } as ControlCommand;
 }
 
 export function encodeReply(reply: ControlReply): string {
@@ -93,7 +102,12 @@ export function decodeReply(line: string): ControlReply | null {
   if (typeof virtualNow !== "number" || !Number.isFinite(virtualNow)) {
     return null;
   }
-  if (reply === "ready" || reply === "pause" || reply === "resume") {
+  if (
+    reply === "ready" ||
+    reply === "pause" ||
+    reply === "resume" ||
+    reply === "setRate"
+  ) {
     return { reply, virtualNow };
   }
   if (reply === "step") {
@@ -134,6 +148,9 @@ export function applyCommand(
       const outcome = stepper.step();
       return { reply: "step", virtualNow: clock.now(), outcome };
     }
+    case "setRate":
+      stepper.setRate(command.rate);
+      return { reply: "setRate", virtualNow: clock.now() };
   }
 }
 

--- a/src/runtime/stepper.test.ts
+++ b/src/runtime/stepper.test.ts
@@ -217,6 +217,111 @@ describe("Stepper", () => {
     });
   });
 
+  describe("live speed changes", () => {
+    it("changes slope without moving virtual time", async () => {
+      const { stepper, clock, run } = setup();
+      run(Effect.sleep("10 seconds"));
+      await settle();
+      await vi.advanceTimersByTimeAsync(400);
+
+      const atChange = clock.now();
+      stepper.setRate(0.25);
+
+      expect(clock.rate).toBe(0.25);
+      expect(clock.now()).toBeCloseTo(atChange, 0);
+
+      await vi.advanceTimersByTimeAsync(400);
+      expect(clock.now()).toBeCloseTo(atChange + 100, 0);
+    });
+
+    /**
+     * Pause is rate 0, so writing the new rate straight through would restart
+     * virtual time under a scheduler that is still gated: sleeps would come due
+     * and queue work into a gate nothing is going to open.
+     */
+    it("does not start the clock when the rate is set while paused", async () => {
+      const { stepper, clock, run } = setup();
+      run(Effect.sleep("1 second"));
+      await settle();
+      stepper.pause();
+      const atPause = clock.now();
+
+      stepper.setRate(0.25);
+
+      expect(clock.rate).toBe(0);
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(clock.now()).toBe(atPause);
+    });
+
+    it("resumes at a rate chosen while paused", async () => {
+      const { stepper, clock, run } = setup();
+      run(Effect.sleep("10 seconds"));
+      await settle();
+      stepper.pause();
+
+      stepper.setRate(0.5);
+      stepper.play();
+
+      expect(clock.rate).toBe(0.5);
+      const atResume = clock.now();
+      await vi.advanceTimersByTimeAsync(400);
+      expect(clock.now()).toBeCloseTo(atResume + 200, 0);
+    });
+
+    /**
+     * The case the design rests on: a timer is already armed when the rate
+     * changes. `VirtualClock.setRate` re-arms every pending timer against the
+     * new anchor, so the sleep keeps its *virtual* deadline and only the wall
+     * time it takes to get there changes.
+     */
+    it("keeps a sleep in flight on its virtual deadline", async () => {
+      const { stepper, clock, run } = setup();
+      const done: string[] = [];
+      run(
+        Effect.gen(function* () {
+          yield* Effect.sleep("1 second");
+          done.push("woke");
+        }),
+      );
+      await settle();
+      await vi.advanceTimersByTimeAsync(400); // 400ms of the second gone
+
+      stepper.setRate(0.25); // the remaining 600 virtual ms now take 2400 wall
+
+      await vi.advanceTimersByTimeAsync(2399);
+      expect(done).toEqual([]);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(done).toEqual(["woke"]);
+      expect(clock.now()).toBeCloseTo(1000, 0);
+    });
+
+    /** The same, for the deadline `Effect.timeout` arms behind the scenes. */
+    it("keeps a timeout in flight on its virtual deadline", async () => {
+      const { stepper, run } = setup();
+      const results: string[] = [];
+      run(
+        Effect.sleep("2 seconds").pipe(
+          Effect.timeout("1 second"),
+          Effect.match({
+            onFailure: () => results.push("timed out"),
+            onSuccess: () => results.push("completed"),
+          }),
+        ),
+      );
+      await settle();
+      await vi.advanceTimersByTimeAsync(400);
+
+      stepper.setRate(0.25);
+
+      await vi.advanceTimersByTimeAsync(2399);
+      expect(results).toEqual([]);
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(results).toEqual(["timed out"]);
+    });
+  });
+
   describe("rungs in order", () => {
     it("falls through to the clock when the queue holds no visible work", () => {
       const scheduler = new GatedScheduler();

--- a/src/runtime/stepper.ts
+++ b/src/runtime/stepper.ts
@@ -108,6 +108,24 @@ export class Stepper {
     }
   }
 
+  /**
+   * Change the speed of the running program.
+   *
+   * Pause is implemented as rate 0, so a paused stepper must not touch the
+   * clock: raising the rate there would let virtual time flow while the
+   * scheduler stays gated, and sleeps coming due would queue work into a gate
+   * that nothing is going to open. The new rate is stashed instead, and `play()`
+   * restores it.
+   */
+  setRate(rate: number): void {
+    if (this.#rateBeforePause !== null) {
+      this.#rateBeforePause = rate;
+      return;
+    }
+    // Re-anchors, so virtual time keeps its value and only changes slope.
+    this.#clock.setRate(rate);
+  }
+
   /** True when a step would do something. Drives the step button. */
   canStep(): boolean {
     if (this.#isFinished()) return false;

--- a/workshop/README.md
+++ b/workshop/README.md
@@ -46,6 +46,7 @@ Refactor to use Effect's built-in observability, removing manual wrappers.
 Take over the runtime's clock and scheduler so execution can be slowed and stepped.
 
 - [Phase 10: Slow mode & stepper (issue #13)](./phase-10.md) ✅
+- [Phase 11: Changing speed during a run](./phase-11.md) ✅
 
 ### Maintenance
 

--- a/workshop/phase-10.md
+++ b/workshop/phase-10.md
@@ -517,7 +517,9 @@ editor flushes) is orthogonal and can coincide with any of them.
 Speed is locked while running because the WebContainer receives the rate as a
 spawn environment variable and cannot be retuned without restarting. That is a
 temporary limitation: pausing the container will require a host→container control
-channel anyway, and once it exists the rate can travel the same way.
+channel anyway, and once it exists the rate can travel the same way. It since
+did — see [phase 11](./phase-11.md), which makes speed live in every state and
+supersedes the Speed column above.
 
 ⏭️ is enabled at `idle` because there is otherwise no way *into* a paused run:
 Play starts a free-running program, and by the time the user pauses it, the
@@ -783,7 +785,8 @@ The protocol could carry a rate, but the fallback path fixes speed for the life
 of a run, and the container reads it once from `VIZ_RATE` at spawn. Putting a live
 rate command on the channel would give one path a capability the other does not
 have, for a control the UI presents as identical on both. It stays a spawn-time
-decision.
+decision. [Phase 11](./phase-11.md) lifts it onto the wire on both paths at once,
+which is what made it fair to do.
 
 #### Step from idle had to learn to flush
 

--- a/workshop/phase-11.md
+++ b/workshop/phase-11.md
@@ -1,0 +1,120 @@
+# Phase 11: Changing speed during a run
+
+Phase 10 gave the program a clock we own and a channel to command it, but the
+speed control stayed a spawn-time decision: the rate was read once, at startup,
+and could not be retuned without restarting the program. This phase puts the
+rate on the same wire as pause, resume and step, so it is live in both
+directions — a running program can be slowed where it stands, and a paused one
+resumes at whatever rate was chosen while it was frozen.
+
+The payoff is educational rather than cosmetic. Slowing a program down is most
+useful at the moment you realise you cannot see what is happening, which is
+necessarily mid-run; re-running at 0.25x throws away the state you were looking
+at when you noticed.
+
+`VIZ_RATE` survives, and still means what it always did: the rate a run *opens*
+at. Step-from-idle and the auto-start that follows a speed change on a stopped
+program both go through it.
+
+## Design Summary
+
+| Concern | Decision |
+|---|---|
+| Where the branch lives | `Stepper.setRate`, because pause state is private to it |
+| Container transport | A fourth `ControlCommand`, `{ cmd: "setRate", rate }` |
+| When the page's model follows | On the reply, not on the click |
+| Availability | `canChangeSpeed` is now unconditionally true |
+
+### Pause is rate 0, and that is the whole subtlety
+
+`Stepper.pause()` stashes the clock's rate, sets the clock to zero and gates the
+scheduler; `play()` restores the stashed value. Two mechanisms, one state.
+
+A naive `clock.setRate(next)` on a paused program therefore *unpauses the clock*
+while the scheduler stays gated. Virtual time would start flowing, `Effect.sleep`
+deadlines would come due, and the tasks they queue would land in a gate that
+nothing is going to open — a program that looks frozen but is quietly
+accumulating due work, and that fires all of it the moment the user resumes.
+
+So `setRate` branches on which state it is in. Paused: write the new rate into
+the stash, leave the clock at zero. Running: `clock.setRate`, which re-anchors so
+virtual time is continuous and re-arms every pending timer against the new
+anchor. The branch belongs on `Stepper` rather than on its callers because the
+stash is private to it, and because every caller would otherwise have to know
+that pause is implemented as a rate.
+
+### A timer already in flight keeps its virtual deadline
+
+The design rests on a claim `VirtualClock` made but had never been asked to
+honour: that a rate change lands cleanly on a timer that is already armed. It
+does, because `setRate` re-arms every pending timer against the new anchor. A
+sleep 400ms into its second, retuned to 0.25x, still wakes at virtual 1000 — it
+just takes 2400 more wall milliseconds to get there instead of 600.
+
+`stepper.test.ts` pins this for a bare `Effect.sleep` and for the deadline
+`Effect.timeout` arms behind the scenes, both against the in-process fallback
+where the clock is directly assertable.
+
+### The page's model changes slope on the reply
+
+`MirroredClock` is the page's predictor over the clock running in the container,
+and its run rate is what it extrapolates at between readings. A rate change is
+applied when the container's reply arrives, not when the button is clicked, for
+the same reason `resume` is: the container keeps running at the old rate for the
+length of a round trip, and corrections only ever move the cursor forward, so a
+model that changed slope early would predict ahead of the container permanently.
+
+While paused, only the run rate moves. The cursor stays frozen and picks the new
+rate up on resume.
+
+## Created/Modified Files
+
+| File | Changes |
+|---|---|
+| `src/runtime/stepper.ts` | `setRate(rate)` — the paused/running branch |
+| `src/runtime/controlChannel.ts` | `setRate` command and reply; `decodeCommand` learns to carry a payload |
+| `src/lib/containerController.ts` | `setRate(rate)` — send only, nothing waits on the outcome |
+| `src/lib/mirroredClock.ts` | `setRunRate(rate)`; `#runRate` is no longer `readonly` |
+| `src/hooks/useEventHandlers.ts` | `handleSetRate` for both paths; the reply handler follows the mirror |
+| `src/lib/playbackAvailability.ts` | `canChangeSpeed` is unconditionally true |
+| `src/components/layout/MainLayout.tsx` | `onSpeedChange` retunes a live program instead of scheduling an auto-start |
+| `src/components/layout/PlaybackControls.tsx` | A third speed hint: "applies on the next run" is no longer true |
+
+### The codec had to learn about payloads
+
+`setRate` is the first command with anything on it beyond the verb.
+`decodeCommand` reconstructed a command by validating `cmd` against a list and
+casting a bare `{ cmd }`, which would have silently dropped the rate and left the
+container applying `undefined`. It now validates the number as well, and rejects
+a `setRate` with a missing, non-numeric or negative rate rather than passing it
+to a clock that throws on negatives.
+
+## Playback availability
+
+Speed is now allowed from every state, so the phase-10 table's `–` in the Speed
+column for `starting` and `running` no longer holds. What a change *does* depends
+on the state: a stopped program is re-run at the new rate after a short debounce
+(unchanged from phase 10, and still the only way to give the choice something to
+show), and a live one — running or paused — is retuned in place.
+
+## Verification
+
+`stepper.test.ts` covers both branches of `setRate`, the pause/setRate/resume
+sequence, and the two in-flight timer cases. `controlChannel.test.ts` round-trips
+the command with its payload and checks `applyCommand` against a real `Stepper`
+and `VirtualClock` in both states. `mirroredClock.test.ts` covers the re-anchor
+and the paused case. `containerController.test.ts` and
+`playbackAvailability.test.ts` cover the send and the rule.
+
+No test spawns a container — the runner applies commands through the same
+`applyCommand` the tests drive, so the container path is covered piece by piece.
+The remaining link, that a `setRate` command actually reaches the container
+process and retunes it, was closed by hand in a real browser: the Basic and
+Timeout examples were both stepped, and both were played at 0.25x and raised to
+1x mid-run, with the timeline picking up the new slope where it stood.
+
+## Out of scope
+
+Step Over — running to the end of the current span rather than stopping at every
+event inside it — remains deferred. It touches the step ladder rather than the
+clock, and bundling it would have doubled the surface of this change.


### PR DESCRIPTION
Playback speed was a spawn-time decision: the rate was read once at startup and could only be changed by re-running. It now travels on the control channel alongside pause, resume and step, so a running program is retuned where it stands and a paused one resumes at the rate picked while it was frozen. `VIZ_RATE` still means the rate a run opens at.

`Stepper.setRate` branches on pause state, because pause is implemented as rate 0: writing the new rate straight through would start the clock under a gated scheduler, letting sleeps come due into a gate nothing will open. `decodeCommand` also had to learn about payloads — `setRate` is the first command carrying more than a verb, and the old decoder would have dropped the rate silently. The page's `MirroredClock` changes slope on the container's reply rather than on the click, so it never predicts ahead of the run.

The demo scenario now changes speed mid-run in act 2, and steps four times rather than once. Only the container round trip is unverified by tests — the runner applies commands through the same `applyCommand` the tests drive — so that link was checked by hand in a browser on the Basic and Timeout examples.

Design notes in `workshop/phase-11.md`.
