### PR TITLE
chore(v3): prep the release

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -7,8 +7,6 @@
 
 **Phase 10**: COMPLETE ✅ — slow mode & stepper (issue #13). All steps done: VirtualClock, Effect Clock layer, Date shim, virtual timestamps, GatedScheduler + step ladder, control channel for the WebContainer, speed combo + stepper controls, origin tagging with show-internals toggle, and five new example programs.
 
-**Deferred**: Step Over — running to the end of the current span rather than stopping at every event inside it — is not implemented, and `PlaybackControls` carries no button for it.
-
 **Maintenance**: [#18](https://github.com/topheman/effect-viz/issues/18) — `effect` is on 3.22.1 on both run paths, and the Effect LSP is installed. Only the Timeout example traces differently: the work that overruns the deadline now ends as `fiber:end`, since Effect runs it under `Effect.exit`. See [`workshop/effect-3.22-upgrade.md`](workshop/effect-3.22-upgrade.md).
 
 **Recent**: five new examples teach what no sleep-shaped program could — `Effect.yieldNow` interleaving, bounded concurrency, structured interruption, timeout on the shared clock, and a Deferred deadlock that reaches the stepper's `noProgress`. See [`workshop/phase-10.md`](workshop/phase-10.md).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,9 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  // public/app is the runtime bundle copy-runtime.mjs lifts out of dist, so it is
+  // build output like dist itself — and only exists on a machine that has built.
+  globalIgnores(['dist', 'public/app']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/src/components/layout/InfoModal.tsx
+++ b/src/components/layout/InfoModal.tsx
@@ -181,8 +181,9 @@ export function InfoModal({
               to run the program step by step.
             </p>
             <p>
-              You can pick a speed to watch the same program run slower. On a
-              stopped program, picking one runs it.
+              You can pick a speed to watch the same program run slower, and
+              change it while it runs. On a stopped program, picking one runs
+              it.
             </p>
             {!isMobileDevice && (
               <p>

--- a/workshop/phase-11.md
+++ b/workshop/phase-11.md
@@ -112,9 +112,3 @@ The remaining link, that a `setRate` command actually reaches the container
 process and retunes it, was closed by hand in a real browser: the Basic and
 Timeout examples were both stepped, and both were played at 0.25x and raised to
 1x mid-run, with the timeline picking up the new slope where it stood.
-
-## Out of scope
-
-Step Over — running to the end of the current span rather than stopping at every
-event inside it — remains deferred. It touches the step ladder rather than the
-clock, and bundling it would have doubled the surface of this change.


### PR DESCRIPTION
Lint ignores `public/app` in `eslint.config.js` — the runtime bundle `copy-runtime.mjs` lifts out of `dist`. CI only stayed green because it lints before it builds; on a machine that has built, `npm run lint` failed on three generated `.d.ts` files.

The info modal now says the speed can be changed mid-run, which phase 11 made true but only the `PlaybackControls` tooltips reflected. Step Over is dropped from `MEMORY.md` and `workshop/phase-11.md`; its code was already removed in d859a63.