### PR TITLE
fix(ui): drop misleading chrome from the editor and visualizer

### DIFF
--- a/src/components/editor/MultiModelEditor.tsx
+++ b/src/components/editor/MultiModelEditor.tsx
@@ -98,13 +98,17 @@ export function MultiModelEditor({
           ref={tabScrollRef}
           className="min-w-0 flex-1 overflow-x-auto overflow-y-hidden"
         >
-          <TabsList variant="line" className="h-auto w-max justify-start">
-            {tabs.map((tab) => (
-              <TabsTrigger key={tab.id} value={tab.id}>
-                {tab.title}
-              </TabsTrigger>
-            ))}
-          </TabsList>
+          {/* A lone tab has nothing to switch to, so its trigger only misleads.
+              The row stays for `headerExtra`. */}
+          {tabs.length > 1 && (
+            <TabsList variant="line" className="h-auto w-max justify-start">
+              {tabs.map((tab) => (
+                <TabsTrigger key={tab.id} value={tab.id}>
+                  {tab.title}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          )}
         </div>
         {headerExtra && <div className="shrink-0">{headerExtra}</div>}
       </div>

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -477,15 +477,6 @@ export function MainLayout() {
 
           <ResizablePanel defaultSize={60} minSize={30}>
             <div className="flex h-full flex-col">
-              <div
-                className={`
-                  shrink-0 border-b border-border bg-muted/50 px-4 py-2
-                `}
-              >
-                <span className="text-sm font-medium text-muted-foreground">
-                  Visualizer
-                </span>
-              </div>
               <div className="flex-1 overflow-hidden">
                 <VisualizerPanel />
               </div>
@@ -574,13 +565,6 @@ export function MainLayout() {
           `}
         >
           <div className="flex h-full flex-col">
-            <div
-              className={`shrink-0 border-b border-border bg-muted/50 px-4 py-2`}
-            >
-              <span className="text-sm font-medium text-muted-foreground">
-                Visualizer
-              </span>
-            </div>
             <div className="flex-1 overflow-hidden">
               <VisualizerPanel />
             </div>

--- a/src/components/layout/PlaybackControls.tsx
+++ b/src/components/layout/PlaybackControls.tsx
@@ -99,7 +99,7 @@ export function PlaybackControls({
       <div
         className={`
           flex h-12 shrink-0 items-center justify-between border-t border-border
-          bg-card px-4
+          bg-card px-4 select-none
         `}
       >
         {/* Left: Mobile toggle visualizer */}


### PR DESCRIPTION
Three small UI cleanups, one commit each so any of them can be reverted alone.

- `PlaybackControls.tsx`: `select-none` on the footer bar, so dragging on mobile no longer selects the status text. Closes #32.
- `MultiModelEditor.tsx`: the `TabsList` only renders when there is more than one tab. Since v2 there is only the Program tab, so its trigger looked like a switch that does nothing. The row itself stays — it hosts the program selector and reset button via `headerExtra`. Closes #34.
- `MainLayout.tsx`: the "Visualizer" header is gone from both the desktop pane and the mobile slide-in overlay. Closes #35.

Checked at 390px and 1440px.