### PR TITLE
fix: mobile layout and timeline axis

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -32,6 +32,7 @@ import {
   computeProgramSwitch,
   computeResetToTemplate,
 } from "@/lib/programCache";
+import { PROGRAM_TIMELINE_DURATION_MS } from "@/lib/programs";
 import type { ProgramKey } from "@/lib/programs";
 import { cn } from "@/lib/utils";
 
@@ -478,7 +479,11 @@ export function MainLayout() {
           <ResizablePanel defaultSize={60} minSize={30}>
             <div className="flex h-full flex-col">
               <div className="flex-1 overflow-hidden">
-                <VisualizerPanel />
+                <VisualizerPanel
+                  timelineDurationMs={
+                    PROGRAM_TIMELINE_DURATION_MS[selectedProgram]
+                  }
+                />
               </div>
             </div>
           </ResizablePanel>
@@ -566,7 +571,11 @@ export function MainLayout() {
         >
           <div className="flex h-full flex-col">
             <div className="flex-1 overflow-hidden">
-              <VisualizerPanel />
+              <VisualizerPanel
+                timelineDurationMs={
+                  PROGRAM_TIMELINE_DURATION_MS[selectedProgram]
+                }
+              />
             </div>
           </div>
         </div>

--- a/src/components/layout/PlaybackControls.tsx
+++ b/src/components/layout/PlaybackControls.tsx
@@ -259,8 +259,8 @@ export function PlaybackControls({
           {/* Status indicator */}
           <div
             className={`
-              ml-4 flex w-24 min-w-24 items-center gap-2 text-sm
-              text-muted-foreground
+              flex w-24 items-center gap-2 text-sm text-muted-foreground
+              md:ml-4 md:min-w-24
             `}
           >
             <div

--- a/src/components/layout/PlaybackControls.tsx
+++ b/src/components/layout/PlaybackControls.tsx
@@ -147,7 +147,12 @@ export function PlaybackControls({
         </div>
 
         {/* Center: Playback controls */}
-        <div className="flex items-center gap-1">
+        <div
+          className={`
+            flex items-center
+            md:gap-1
+          `}
+        >
           {/* Reset */}
           <Tooltip>
             <TooltipTrigger asChild>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -75,7 +75,13 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-content"
-      className={cn("px-6", className)}
+      className={cn(
+        `
+          px-3
+          md:px-6
+        `,
+        className,
+      )}
       {...props}
     />
   );

--- a/src/components/visualizer/TimelineView.tsx
+++ b/src/components/visualizer/TimelineView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
   Card,
@@ -33,7 +33,9 @@ interface FiberLane {
 // Timeline Logic
 // =============================================================================
 
-const DEFAULT_DURATION_MS = 3000; // Default 3 second view
+// Fallback axis width for a program with no entry in
+// PROGRAM_TIMELINE_DURATION_MS.
+const DEFAULT_DURATION_MS = 3000;
 
 /**
  * Build timeline segments from trace events.
@@ -198,8 +200,29 @@ function getSegmentColor(state: FiberState): string {
 // Components
 // =============================================================================
 
+/** Axis width a single tick label needs before its neighbour starts. */
+const PX_PER_TICK = 64;
+
 function TimeAxis({ duration }: { duration: number }) {
-  const tickInterval = computeTickInterval(duration);
+  // The axis is measured rather than read off a breakpoint: its width comes
+  // from a draggable panel split as much as from the viewport.
+  const [axisWidth, setAxisWidth] = useState(0);
+  const axisRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const axis = axisRef.current;
+    if (!axis) return;
+    const observer = new ResizeObserver(([entry]) => {
+      setAxisWidth(entry.contentRect.width);
+    });
+    observer.observe(axis);
+    return () => observer.disconnect();
+  }, []);
+
+  const tickInterval = computeTickInterval(
+    duration,
+    axisWidth > 0 ? Math.floor(axisWidth / PX_PER_TICK) : undefined,
+  );
   const ticks: number[] = [];
   for (let t = 0; t <= duration; t += tickInterval) {
     ticks.push(t);
@@ -216,20 +239,42 @@ function TimeAxis({ duration }: { duration: number }) {
   return (
     <div className="flex items-start gap-2 pt-1">
       {/* Spacer to align with fiber labels */}
-      <div className="w-24 shrink-0" />
+      <div
+        className={`
+          w-12 shrink-0
+          md:w-24
+        `}
+      />
 
       {/* Time axis bar */}
-      <div className="relative h-6 flex-1 border-t border-border">
-        {ticks.map((t) => {
+      <div ref={axisRef} className="relative h-6 flex-1 border-t border-border">
+        {ticks.map((t, i) => {
           const left = (t / duration) * 100;
+          // Labels are centred on their tick, except at the two ends, where a
+          // centred label would hang half its width outside the plot and widen
+          // the card. There the label is pulled inwards against the tick.
+          const isFirst = i === 0;
+          const isLast = i === ticks.length - 1;
           return (
             <div
               key={t}
-              className="absolute top-0 flex flex-col items-center"
-              style={{ left: `${left}%`, transform: "translateX(-50%)" }}
+              className="absolute top-0 w-px"
+              style={{ left: `${left}%` }}
             >
               <div className="h-2 w-px bg-border" />
-              <span className="text-xs whitespace-nowrap text-muted-foreground">
+              <span
+                className={cn(
+                  `
+                    absolute top-2 text-xs whitespace-nowrap
+                    text-muted-foreground
+                  `,
+                  isFirst
+                    ? "left-0"
+                    : isLast
+                      ? "right-0"
+                      : `left-1/2 -translate-x-1/2`,
+                )}
+              >
                 {formatTime(t)}
               </span>
             </div>
@@ -256,8 +301,9 @@ function FiberLaneRow({
       {/* Fiber label */}
       <div
         className={`
-          w-24 shrink-0 truncate text-right font-mono text-xs
+          w-12 shrink-0 truncate text-right font-mono text-xs
           text-muted-foreground
+          md:w-24
         `}
       >
         {lane.label}
@@ -313,7 +359,12 @@ function FiberLaneRow({
 // Main Component
 // =============================================================================
 
-export function TimelineView() {
+export function TimelineView({
+  defaultDurationMs,
+}: {
+  /** Starting width of the time axis, from PROGRAM_TIMELINE_DURATION_MS. */
+  defaultDurationMs?: number;
+}) {
   const { events, getVirtualNow } = useTraceStore();
   // Virtual, not wall: event timestamps are virtual, so the live cursor has to
   // be measured in the same units or the two disagree by a factor of the speed.
@@ -360,10 +411,16 @@ export function TimelineView() {
     // Auto-scale: use default duration or actual elapsed time (whichever is larger)
     // For ongoing segments, use current time instead of last event
     const currentElapsed = hasOngoingSegments ? now - startTime : elapsed;
-    const duration = Math.max(DEFAULT_DURATION_MS, currentElapsed + 500); // +500ms padding
+    // The program's own width is a floor, not a cap: an edited program that
+    // runs longer still grows the axis. +500ms keeps the last event off the
+    // right edge.
+    const duration = Math.max(
+      defaultDurationMs ?? DEFAULT_DURATION_MS,
+      currentElapsed + 500,
+    );
 
     return { startTime, duration };
-  }, [events, hasOngoingSegments, now]);
+  }, [events, hasOngoingSegments, now, defaultDurationMs]);
 
   const hasData = lanes.length > 0 && timeRange;
 
@@ -398,7 +455,7 @@ export function TimelineView() {
         ) : (
           <div className="flex h-full flex-col">
             {/* Legend */}
-            <div className="mb-2 flex gap-4 text-xs">
+            <div className={`mb-2 flex flex-wrap gap-x-4 gap-y-1 text-xs`}>
               <div className="flex items-center gap-1">
                 <div className="h-2 w-3 rounded bg-green-500" />
                 <span className="text-muted-foreground">Running</span>

--- a/src/components/visualizer/VisualizerPanel.tsx
+++ b/src/components/visualizer/VisualizerPanel.tsx
@@ -69,7 +69,12 @@ function MainContent() {
   );
 }
 
-export function VisualizerPanel() {
+export function VisualizerPanel({
+  timelineDurationMs,
+}: {
+  /** Starting width of the timeline's time axis, for the selected program. */
+  timelineDurationMs?: number;
+}) {
   return (
     <ResizablePanelGroup orientation="vertical" className="h-full">
       <ResizablePanel defaultSize={65} minSize={20}>
@@ -83,7 +88,7 @@ export function VisualizerPanel() {
 
       <ResizablePanel defaultSize={35} minSize={15}>
         <div className="h-full overflow-hidden p-2">
-          <TimelineView />
+          <TimelineView defaultDurationMs={timelineDurationMs} />
         </div>
       </ResizablePanel>
     </ResizablePanelGroup>

--- a/src/lib/programs.ts
+++ b/src/lib/programs.ts
@@ -971,3 +971,33 @@ export const requirements = [];
 } as const;
 
 export type ProgramKey = keyof typeof programs;
+
+/**
+ * Starting width of the timeline's time axis, per program, in milliseconds.
+ *
+ * Each value is the program's critical path — the longest chain of sleeps and
+ * delays, since concurrent branches overlap — rounded up for headroom. It is a
+ * floor, not a cap: `TimelineView` still grows the axis past it when an edited
+ * program runs longer. A blanket 3s default made the short programs draw their
+ * whole run inside the first sixth of the axis under a row of crowded ticks.
+ *
+ * Programs whose critical path is ~0 sit at 500ms, which the axis's own 500ms
+ * of trailing padding already covers; they are listed for completeness.
+ */
+export const PROGRAM_TIMELINE_DURATION_MS: Record<ProgramKey, number> = {
+  basic: 2000,
+  multiStep: 2000,
+  nestedForks: 1000,
+  interleaving: 500,
+  racing: 1500,
+  boundedConcurrency: 2000,
+  structuredInterruption: 500,
+  failureAndRecovery: 500,
+  retry: 500,
+  retryExponentialBackoff: 2000,
+  timeout: 2000,
+  basicFinalizers: 500,
+  acquireRelease: 500,
+  loggerWithRequirements: 500,
+  deadlock: 500,
+};

--- a/src/lib/timelineTime.test.ts
+++ b/src/lib/timelineTime.test.ts
@@ -60,6 +60,19 @@ describe("computeTickInterval", () => {
     }
   });
 
+  /**
+   * A ~505ms axis at mobile width: eight ticks put "400ms" and "500ms" hard
+   * against each other, so a narrow axis has to ask for fewer.
+   */
+  it("widens the step when the axis has room for fewer ticks", () => {
+    expect(computeTickInterval(505, 3)).toBeGreaterThan(
+      computeTickInterval(505),
+    );
+    expect(
+      Math.floor(505 / computeTickInterval(505, 3)) + 1,
+    ).toBeLessThanOrEqual(4);
+  });
+
   it("never returns a step of zero", () => {
     expect(computeTickInterval(0)).toBeGreaterThan(0);
     expect(computeTickInterval(1)).toBeGreaterThan(0);

--- a/src/lib/timelineTime.ts
+++ b/src/lib/timelineTime.ts
@@ -36,9 +36,16 @@ const TARGET_TICK_COUNT = 8;
  * readable round number at any magnitude and the label count stays bounded. A
  * fixed cap instead crams one label per unit onto a long timeline until they
  * overlap into a smear.
+ *
+ * `targetCount` is how many ticks the axis has room for. The default suits a
+ * desktop-width axis; a narrow one passes a smaller number, since eight labels
+ * that read fine across 700px run into each other across 250px.
  */
-export function computeTickInterval(duration: number): number {
-  const target = Math.max(duration, 1) / TARGET_TICK_COUNT;
+export function computeTickInterval(
+  duration: number,
+  targetCount: number = TARGET_TICK_COUNT,
+): number {
+  const target = Math.max(duration, 1) / Math.max(targetCount, 1);
   const magnitude = 10 ** Math.floor(Math.log10(target));
   for (const multiple of [1, 2, 5]) {
     const step = multiple * magnitude;


### PR DESCRIPTION
Four mobile fixes, one commit each.

`CardContent` was `px-6` while `CardHeader` is `px-3` below `md`, so every panel's body sat 12px right of its title. The playback bar's status readout carried an `ml-4` and a `min-w-24` that floored the bar's min-content width above 390px, widening the app root into an x-scrollbar; both are now `md`-only, as is the centre group's `gap-1`, which had pushed the info button against the viewport edge.

The timeline axis now starts at each program's critical path (`PROGRAM_TIMELINE_DURATION_MS` in `src/lib/programs.ts`, passed from `MainLayout` through `VisualizerPanel`) rather than a blanket 3s, and still grows when an edited program outruns it. Its first and last tick labels are pulled inside the plot instead of centred half-outside it, `TimeAxis` picks its tick count from the axis width it measures with a `ResizeObserver`, and the legend wraps.

Closes #36, closes #38, closes #37, closes #40.