### PR TITLE
fix(playback): reset the playback state when switching program

### DIFF
--- a/src/components/layout/MainLayout.test.tsx
+++ b/src/components/layout/MainLayout.test.tsx
@@ -1,0 +1,134 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+import { type ProgramKey, programs } from "@/lib/programs";
+
+import { MainLayout } from "./MainLayout";
+
+/**
+ * The run in flight, if any. `handlePlay` hands back a promise the test settles
+ * itself, so a program can be held mid-run for as long as a switch takes.
+ */
+let currentRun: {
+  resolve: () => void;
+  reject: (error: unknown) => void;
+} | null = null;
+const handleReset = vi.fn();
+
+vi.mock("@/hooks/useEventHandlers", () => ({
+  useEventHandlers: () => {
+    const [selectedProgram, setSelectedProgram] = useState<ProgramKey>("basic");
+    return {
+      handlePlay: ({ onFirstChunk }: { onFirstChunk: () => void }) => {
+        onFirstChunk();
+        return new Promise<void>((resolve, reject) => {
+          currentRun = { resolve: () => resolve(), reject };
+        });
+      },
+      handlePause: vi.fn(),
+      handleResume: vi.fn(),
+      handleStep: vi.fn(),
+      handleSetRate: vi.fn(),
+      handleReset,
+      selectedProgram,
+      setSelectedProgram,
+      programs,
+    };
+  },
+}));
+
+vi.mock("@/hooks/useWebContainerBoot", () => ({
+  useWebContainerBoot: () => ({
+    status: "fallback" as const,
+    isReady: false,
+    isSyncing: false,
+    typesReady: false,
+    error: null,
+    runPlay: vi.fn(),
+    interruptPlay: vi.fn(),
+    syncToContainer: vi.fn(),
+    syncToContainerDebounced: vi.fn(),
+    flushSync: vi.fn(),
+  }),
+}));
+
+// Monaco and the visualizer bring a canvas and a worker to a test that is only
+// about state; the editor still renders the program selector it is given.
+vi.mock("@/components/editor/MultiModelEditor", () => ({
+  MultiModelEditor: ({ headerExtra }: { headerExtra: ReactNode }) => (
+    <div>{headerExtra}</div>
+  ),
+}));
+vi.mock("@/components/editor/WebContainerLogsPanel", () => ({
+  WebContainerLogsPanel: () => null,
+}));
+vi.mock("@/components/visualizer/VisualizerPanel", () => ({
+  VisualizerPanel: () => null,
+}));
+// react-resizable-panels measures a layout jsdom does not have.
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizablePanel: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: () => null,
+}));
+
+function status() {
+  return screen.getAllByTestId("playback-status")[0].textContent;
+}
+
+/** The desktop and mobile layouts each render a selector; they share state. */
+function programSelect() {
+  return screen.getAllByRole("combobox", { name: "" })[0];
+}
+
+describe("MainLayout program switching", () => {
+  beforeEach(() => {
+    currentRun = null;
+    handleReset.mockClear();
+    localStorage.clear();
+  });
+
+  it("goes back to idle when the program is switched after a run finished", async () => {
+    const user = userEvent.setup();
+    render(<MainLayout />);
+
+    await user.click(screen.getAllByRole("button", { name: "Run" })[0]);
+    expect(status()).toBe("running");
+
+    await act(async () => {
+      currentRun?.resolve();
+    });
+    expect(status()).toBe("finished");
+
+    await user.selectOptions(programSelect(), "multiStep");
+
+    expect(status()).toBe("idle");
+    expect(handleReset).toHaveBeenCalled();
+  });
+
+  it("cancels a run in flight and lands on idle when the program is switched mid-run", async () => {
+    const user = userEvent.setup();
+    render(<MainLayout />);
+
+    await user.click(screen.getAllByRole("button", { name: "Run" })[0]);
+    expect(status()).toBe("running");
+
+    await user.selectOptions(programSelect(), "multiStep");
+
+    expect(status()).toBe("idle");
+    expect(handleReset).toHaveBeenCalled();
+
+    // The cancelled run settles the way a completed one does, and must not
+    // report "finished" over the program that replaced it.
+    await act(async () => {
+      currentRun?.resolve();
+    });
+    expect(status()).toBe("idle");
+  });
+});

--- a/src/components/layout/MainLayout.test.tsx
+++ b/src/components/layout/MainLayout.test.tsx
@@ -7,10 +7,7 @@ import { type ProgramKey, programs } from "@/lib/programs";
 
 import { MainLayout } from "./MainLayout";
 
-/**
- * The run in flight, if any. `handlePlay` hands back a promise the test settles
- * itself, so a program can be held mid-run for as long as a switch takes.
- */
+/** The run in flight: `handlePlay` returns a promise the test settles itself. */
 let currentRun: {
   resolve: () => void;
   reject: (error: unknown) => void;
@@ -54,8 +51,7 @@ vi.mock("@/hooks/useWebContainerBoot", () => ({
   }),
 }));
 
-// Monaco and the visualizer bring a canvas and a worker to a test that is only
-// about state; the editor still renders the program selector it is given.
+// The editor stub still renders the program selector it is given.
 vi.mock("@/components/editor/MultiModelEditor", () => ({
   MultiModelEditor: ({ headerExtra }: { headerExtra: ReactNode }) => (
     <div>{headerExtra}</div>
@@ -67,7 +63,6 @@ vi.mock("@/components/editor/WebContainerLogsPanel", () => ({
 vi.mock("@/components/visualizer/VisualizerPanel", () => ({
   VisualizerPanel: () => null,
 }));
-// react-resizable-panels measures a layout jsdom does not have.
 vi.mock("@/components/ui/resizable", () => ({
   ResizablePanelGroup: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
@@ -82,7 +77,7 @@ function status() {
   return screen.getAllByTestId("playback-status")[0].textContent;
 }
 
-/** The desktop and mobile layouts each render a selector; they share state. */
+/** The desktop and mobile layouts each render one; they share state. */
 function programSelect() {
   return screen.getAllByRole("combobox", { name: "" })[0];
 }
@@ -112,6 +107,20 @@ describe("MainLayout program switching", () => {
     expect(handleReset).toHaveBeenCalled();
   });
 
+  it("goes back to idle when the program is switched while paused", async () => {
+    const user = userEvent.setup();
+    render(<MainLayout />);
+
+    await user.click(screen.getAllByRole("button", { name: "Run" })[0]);
+    await user.click(screen.getAllByRole("button", { name: "Pause" })[0]);
+    expect(status()).toBe("paused");
+
+    await user.selectOptions(programSelect(), "multiStep");
+
+    expect(status()).toBe("idle");
+    expect(handleReset).toHaveBeenCalled();
+  });
+
   it("cancels a run in flight and lands on idle when the program is switched mid-run", async () => {
     const user = userEvent.setup();
     render(<MainLayout />);
@@ -124,8 +133,7 @@ describe("MainLayout program switching", () => {
     expect(status()).toBe("idle");
     expect(handleReset).toHaveBeenCalled();
 
-    // The cancelled run settles the way a completed one does, and must not
-    // report "finished" over the program that replaced it.
+    // A cancelled run settles the way a completed one does.
     await act(async () => {
       currentRun?.resolve();
     });

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -138,6 +138,13 @@ export function MainLayout() {
       setSelectedProgram(programKey);
       setEditorContent(newContent);
       completeOnboardingStep("programSelect");
+      // Put the playback state back along with the panes `handleReset` clears,
+      // so the badge cannot keep the previous program's verdict. A switch
+      // mid-run cancels the run: the bumped run id stops it reporting
+      // "finished" once it settles.
+      runIdRef.current++;
+      setPlaybackState("idle");
+      setPauseReason("user");
       handleReset();
       setEditorTabId("program");
       if (webContainer.isReady) {

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -138,10 +138,8 @@ export function MainLayout() {
       setSelectedProgram(programKey);
       setEditorContent(newContent);
       completeOnboardingStep("programSelect");
-      // Put the playback state back along with the panes `handleReset` clears,
-      // so the badge cannot keep the previous program's verdict. A switch
-      // mid-run cancels the run: the bumped run id stops it reporting
-      // "finished" once it settles.
+      // Whatever the previous program reached — paused, finished, still
+      // running — the new one starts from idle.
       runIdRef.current++;
       setPlaybackState("idle");
       setPauseReason("user");


### PR DESCRIPTION
Switching program cleared the panes but left `playbackState` alone in `MainLayout`, so the badge kept the previous program's verdict — `Finished` over a freshly loaded program. `handleProgramChange` now resets the state and bumps the run id alongside `handleReset`, so a switch mid-run cancels the run and lands on `idle` too, rather than being a special case.

Covered by `src/components/layout/MainLayout.test.tsx`, which drives the real component with the editor, visualizer and container hook stubbed: one test switches from `finished`, one switches with a run still in flight and checks it does not report `finished` when it settles.

Closes #33