### PR TITLE
fix(timeline): make the timeline unselectable

### DIFF
--- a/src/components/visualizer/TimelineView.tsx
+++ b/src/components/visualizer/TimelineView.tsx
@@ -266,7 +266,7 @@ function TimeAxis({ duration }: { duration: number }) {
                 className={cn(
                   `
                     absolute top-2 text-xs whitespace-nowrap
-                    text-muted-foreground
+                    text-muted-foreground select-text
                   `,
                   isFirst
                     ? "left-0"
@@ -302,7 +302,7 @@ function FiberLaneRow({
       <div
         className={`
           w-12 shrink-0 truncate text-right font-mono text-xs
-          text-muted-foreground
+          text-muted-foreground select-text
           md:w-24
         `}
       >
@@ -441,7 +441,7 @@ export function TimelineView({
       </CardHeader>
       <CardContent
         className={`
-          flex min-h-0 flex-1 flex-col overflow-hidden
+          flex min-h-0 flex-1 flex-col overflow-hidden select-none
           ${!hasData ? "items-center justify-center" : ""}
         `}
       >


### PR DESCRIPTION
`select-none` on the timeline's `CardContent` (`src/components/visualizer/TimelineView.tsx`) so dragging over the lanes no longer selects anything, with `select-text` put back on the fiber labels and the axis tick labels. The panel header keeps the card's default selectable text.

Verified by reading the classes, not on a real touch device.

Closes #44